### PR TITLE
Rename "Troubleshooting" to "Debugging" in documentation

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -192,7 +192,7 @@ export default defineConfig({
           { text: "Logout", link: "/configuration/logout" },
           { text: "UI5 Versions", link: "/configuration/ui5_versions" },
           { text: "Productive Usage", link: "/configuration/productive_usage" },
-          { text: "Troubleshooting", link: "/configuration/troubleshooting" },
+          { text: "Debugging", link: "/configuration/troubleshooting" },
           {
             text: "Installation",
             link: "/configuration/installation",

--- a/docs/configuration/troubleshooting.md
+++ b/docs/configuration/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 outline: [2, 4]
 ---
-# Troubleshooting
+# Debugging
 Since all logic runs in ABAP, you can debug everything in the ABAP environment. Set an external breakpoint, because HTTP calls abap2UI5 apps externally.
 
 ### Backend


### PR DESCRIPTION
## Summary
Updated the documentation navigation and page title to use "Debugging" instead of "Troubleshooting" for better clarity and accuracy of the content.

## Changes
- Updated navigation menu text in VitePress config from "Troubleshooting" to "Debugging"
- Renamed the main heading in `docs/configuration/troubleshooting.md` from "Troubleshooting" to "Debugging"

## Details
The page content focuses on debugging techniques (setting external breakpoints, debugging in the ABAP environment) rather than troubleshooting issues, so the new title better reflects the actual purpose of the documentation.

https://claude.ai/code/session_01NyhQeESJf5mLBazQSf5kXY