### PR TITLE
Reorganize documentation sidebar navigation structure

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -209,7 +209,7 @@ export default defineConfig({
             ],
           },
           {
-            text: "Misc Topics",
+            text: "Locks, Statefulness",
             collapsed: true,
             items: [
               { text: "Locks", link: "/development/specific/locks" },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -163,14 +163,6 @@ export default defineConfig({
           { text: "Translation, i18n", link: "/development/translation" },
           { text: "Popups, Popovers", link: "/development/popups" },
           {
-            text: "Locks, Statefulness",
-            collapsed: true,
-            items: [
-              { text: "Locks", link: "/development/specific/locks" },
-              { text: "Statefulness", link: "/development/specific/statefulness" },
-            ],
-          },
-          {
             text: "Browser Features",
             collapsed: true,
             items: [
@@ -214,6 +206,14 @@ export default defineConfig({
               { text: "CDS", link: "/development/specific/cds" },
               { text: "EML", link: "/development/specific/eml" },
               { text: "Draft Handling", link: "/development/specific/draft" },
+            ],
+          },
+          {
+            text: "Misc Topics",
+            collapsed: true,
+            items: [
+              { text: "Locks", link: "/development/specific/locks" },
+              { text: "Statefulness", link: "/development/specific/statefulness" },
             ],
           },
         ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -148,7 +148,7 @@ export default defineConfig({
                 text: "Share, Bookmark",
                 link: "/development/navigation/share",
               },
-              { text: "URL", link: "/development/specific/url" },
+              { text: "URL Handling", link: "/development/specific/url" },
             ],
           },
           {

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -256,14 +256,8 @@ export default defineConfig({
           { text: "Renaming", link: "/advanced/renaming" },
           { text: "Builder", link: "/advanced/builds" },
           { text: "Local", link: "/advanced/local" },
-          {
-            text: "RFC Connector",
-            link: "/advanced/rfc",
-            collapsed: true,
-            items: [
-              { text: "HTTP Connector", link: "/advanced/http" },
-            ],
-          },
+          { text: "RFC Connector", link: "/advanced/rfc" },
+          { text: "HTTP Connector", link: "/advanced/http" },
           { text: "Fiori Elements Integration", link: "/advanced/fiori" },
           {
             text: "Extensibility",

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -148,6 +148,7 @@ export default defineConfig({
                 text: "Share, Bookmark",
                 link: "/development/navigation/share",
               },
+              { text: "URL", link: "/development/specific/url" },
             ],
           },
           {
@@ -190,7 +191,6 @@ export default defineConfig({
                   { text: "XLSX", link: "/development/specific/xlsx" },
                 ],
               },
-              { text: "URL", link: "/development/specific/url" },
               { text: "Timer", link: "/development/specific/timer" },
               { text: "Soft Keyboard", link: "/development/specific/soft_keyboard" },
             ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -214,6 +214,7 @@ export default defineConfig({
             items: [
               { text: "Locks", link: "/development/specific/locks" },
               { text: "Statefulness", link: "/development/specific/statefulness" },
+              { text: "Logout", link: "/configuration/logout" },
             ],
           },
         ],
@@ -228,7 +229,6 @@ export default defineConfig({
           { text: "Security", link: "/configuration/security" },
           { text: "Authorization", link: "/configuration/authorization" },
           { text: "Performance", link: "/configuration/performance" },
-          { text: "Logout", link: "/configuration/logout" },
           { text: "UI5 Versions", link: "/configuration/ui5_versions" },
           { text: "Productive Usage", link: "/configuration/productive_usage" },
           { text: "Debugging", link: "/configuration/troubleshooting" },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -162,12 +162,11 @@ export default defineConfig({
           { text: "Translation, i18n", link: "/development/translation" },
           { text: "Popups, Popovers", link: "/development/popups" },
           {
-            text: "RAP, EML",
+            text: "Locks, Statefulness",
             collapsed: true,
             items: [
-              { text: "CDS", link: "/development/specific/cds" },
-              { text: "EML", link: "/development/specific/eml" },
-              { text: "Draft Handling", link: "/development/specific/draft" },
+              { text: "Locks", link: "/development/specific/locks" },
+              { text: "Statefulness", link: "/development/specific/statefulness" },
             ],
           },
           {
@@ -209,11 +208,12 @@ export default defineConfig({
             ],
           },
           {
-            text: "Locks, Statefulness",
+            text: "RAP, EML",
             collapsed: true,
             items: [
-              { text: "Locks", link: "/development/specific/locks" },
-              { text: "Statefulness", link: "/development/specific/statefulness" },
+              { text: "CDS", link: "/development/specific/cds" },
+              { text: "EML", link: "/development/specific/eml" },
+              { text: "Draft Handling", link: "/development/specific/draft" },
             ],
           },
         ],

--- a/docs/development/specific/url.md
+++ b/docs/development/specific/url.md
@@ -1,7 +1,7 @@
 ---
 outline: [2, 4]
 ---
-# URL
+# URL Handling
 
 Working with URLs is common — reading parameters from the current URL, opening links in new tabs, or managing browser history.
 


### PR DESCRIPTION
## Summary
This PR reorganizes the VitePress documentation sidebar navigation to improve information architecture and user experience. The changes involve moving documentation entries to more logical groupings and updating section titles for clarity.

## Key Changes
- **Moved "URL Handling"** from the "Browser Features" section to the "Share, Bookmark" navigation group for better contextual organization
- **Reorganized "RAP, EML" section** by moving it after the "ABAP Classes" section in the development sidebar
- **Relocated "Logout" documentation** from the "Configuration" top-level menu to the "Misc Topics" subsection under development
- **Simplified "RFC Connector" structure** by converting it from a collapsible section with nested items to a flat list with "HTTP Connector" as a sibling entry
- **Updated page title** from "URL" to "URL Handling" for improved clarity and consistency

## Notable Details
- The reorganization maintains all existing documentation links and content
- Changes focus on improving the logical flow and discoverability of documentation topics
- The "Logout" entry is repositioned to be grouped with other miscellaneous development topics rather than appearing as a top-level configuration item

https://claude.ai/code/session_01EnR1HEHn8tmgxvMFHcfaXJ