### PR TITLE
Add documentation for UI5 Legacy-Free frontend variant

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -259,7 +259,7 @@ export default defineConfig({
           { text: "RFC Connector", link: "/advanced/rfc" },
           { text: "HTTP Connector", link: "/advanced/http" },
           { text: "Fiori Elements Integration", link: "/advanced/fiori" },
-          { text: "Legacy-Free Frontend", link: "/advanced/legacy_free" },
+          { text: "UI5 Legacy-Free", link: "/advanced/legacy_free" },
           {
             text: "Extensibility",
             items: [

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -259,6 +259,7 @@ export default defineConfig({
           { text: "RFC Connector", link: "/advanced/rfc" },
           { text: "HTTP Connector", link: "/advanced/http" },
           { text: "Fiori Elements Integration", link: "/advanced/fiori" },
+          { text: "Legacy-Free Frontend", link: "/advanced/legacy_free" },
           {
             text: "Extensibility",
             items: [

--- a/docs/advanced/legacy_free.md
+++ b/docs/advanced/legacy_free.md
@@ -1,0 +1,13 @@
+---
+outline: [2, 4]
+---
+# Legacy-Free Frontend
+
+abap2UI5-frontend-legacy-free is a frontend variant for abap2UI5 based on OpenUI5's legacy-free distribution. It removes deprecated features such as jQuery dependencies, synchronous APIs, and compatibility shims, providing a preview of the UI5 2.x API surface.
+
+- Future-proof: applications stay compatible with UI5 2.x
+- Leaner runtime: smaller footprint and improved performance
+- Modern async patterns: asynchronous module loading and Promise-based APIs
+- Runs in parallel to the classic abap2UI5 frontend, so both can be evaluated side by side
+
+For full details, see the repository: [abap2UI5-frontend-legacy-free](https://github.com/abap2UI5/frontend-legacy-free)

--- a/docs/advanced/legacy_free.md
+++ b/docs/advanced/legacy_free.md
@@ -1,7 +1,7 @@
 ---
 outline: [2, 4]
 ---
-# Legacy-Free Frontend
+# UI5 Legacy-Free
 
 abap2UI5-frontend-legacy-free is a frontend variant for abap2UI5 based on OpenUI5's legacy-free distribution. It removes deprecated features such as jQuery dependencies, synchronous APIs, and compatibility shims, providing a preview of the UI5 2.x API surface.
 


### PR DESCRIPTION
## Summary
This PR adds documentation for the abap2UI5 Legacy-Free frontend variant, a new distribution based on OpenUI5's legacy-free features that removes deprecated APIs and provides a preview of UI5 2.x compatibility.

## Changes
- **New documentation page**: Added `docs/advanced/legacy_free.md` explaining the UI5 Legacy-Free variant, its benefits (future-proof, leaner runtime, modern async patterns), and its parallel availability alongside the classic frontend
- **Updated navigation**: Added "UI5 Legacy-Free" link to the advanced section in the VitePress config to make the new documentation discoverable

## Details
The new documentation provides users with:
- Clear explanation of what Legacy-Free is and how it differs from the classic frontend
- Key benefits including UI5 2.x compatibility, improved performance, and modern async APIs
- Reference to the dedicated repository for full implementation details

https://claude.ai/code/session_01VHqhVwUNQpYhsYKZDZoxvu