### PR TITLE
Reorganize documentation sidebar: rename and reorder experimental features section

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -251,17 +251,6 @@ export default defineConfig({
           { text: "Fiori Elements Integration", link: "/advanced/fiori" },
           { text: "UI5 Legacy-Free", link: "/advanced/legacy_free" },
           {
-            text: "Experimental Features",
-            collapsed: true,
-            items: [
-              { text: "Drag & Drop", link: "/development/specific/drag" },
-              {
-                text: "Smart Controls",
-                link: "/development/specific/smart_controls",
-              },
-            ],
-          },
-          {
             text: "Extensibility",
             items: [
               {
@@ -273,6 +262,17 @@ export default defineConfig({
               {
                 text: "Custom Control",
                 link: "/advanced/extensibility/custom_control",
+              },
+            ],
+          },
+          {
+            text: "Experimental",
+            collapsed: true,
+            items: [
+              { text: "Drag & Drop", link: "/development/specific/drag" },
+              {
+                text: "Smart Controls",
+                link: "/development/specific/smart_controls",
               },
             ],
           },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -252,6 +252,7 @@ export default defineConfig({
           { text: "UI5 Legacy-Free", link: "/advanced/legacy_free" },
           {
             text: "Extensibility",
+            collapsed: true,
             items: [
               {
                 text: "User Exits",


### PR DESCRIPTION
## Summary
This PR reorganizes the VitePress documentation sidebar navigation by renaming the "Experimental Features" section to "Experimental" and reordering it to appear after the "Extensibility" section.

## Key Changes
- Renamed "Experimental Features" section to "Experimental" for brevity
- Moved the Experimental section to appear after Extensibility in the sidebar hierarchy
- Added `collapsed: true` property to the Extensibility section to match the collapsible state of other sections
- Maintained all existing links and content within both sections (Drag & Drop and Smart Controls remain under Experimental)

## Implementation Details
- The change is purely organizational and does not affect any documentation content or routing
- Both sections now have consistent `collapsed: true` properties for uniform sidebar behavior
- The reordering places more stable/mature features (Extensibility) before experimental ones

https://claude.ai/code/session_01JvVFraWVrJs2uxqYsskbeq