### PR TITLE
Improve sidebar navigation by adding direct links to collapsed sections

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -130,6 +130,7 @@ export default defineConfig({
           },
           {
             text: "View",
+            link: "/development/view/definition",
             collapsed: true,
             items: [
               { text: "Definition", link: "/development/view/definition" },
@@ -139,6 +140,7 @@ export default defineConfig({
           },
           {
             text: "Model",
+            link: "/development/model/binding",
             collapsed: true,
             items: [
               { text: "Binding", link: "/development/model/binding" },
@@ -173,6 +175,7 @@ export default defineConfig({
           },
           {
             text: "Message, Error",
+            link: "/development/messages/messages",
             collapsed: true,
             items: [
               { text: "Message", link: "/development/messages/messages" },
@@ -193,6 +196,7 @@ export default defineConfig({
           },
           {
             text: "Browser Feature",
+            link: "/development/specific/barcodes",
             collapsed: true,
             items: [
               {
@@ -218,6 +222,7 @@ export default defineConfig({
           },
           {
             text: "RAP, EML",
+            link: "/development/specific/cds",
             collapsed: true,
             items: [
               { text: "CDS", link: "/development/specific/cds" },
@@ -227,6 +232,7 @@ export default defineConfig({
           },
           {
             text: "Expert Topic",
+            link: "/development/specific/locks",
             collapsed: true,
             items: [
               { text: "Lock", link: "/development/specific/locks" },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -208,16 +208,15 @@ export default defineConfig({
                 text: "Geolocation, Map",
                 link: "/development/specific/geolocation",
               },
+              { text: "Timer", link: "/development/specific/timer" },
+              { text: "Soft Keyboard", link: "/development/specific/soft_keyboard" },
               {
                 text: "File Handling",
                 link: "/development/specific/files",
-                collapsed: true,
                 items: [
                   { text: "XLSX", link: "/development/specific/xlsx" },
                 ],
               },
-              { text: "Timer", link: "/development/specific/timer" },
-              { text: "Soft Keyboard", link: "/development/specific/soft_keyboard" },
             ],
           },
           {

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -237,13 +237,14 @@ export default defineConfig({
               { text: "Lock", link: "/development/specific/locks" },
               { text: "Statefulness", link: "/development/specific/statefulness" },
               { text: "Logout", link: "/configuration/logout" },
-              {
-                text: "More",
-                collapsed: true,
-                items: [
-                  { text: "Demo Output", link: "/development/specific/demo_output" },
-                ],
-              },
+            ],
+          },
+          {
+            text: "More",
+            link: "/development/specific/demo_output",
+            collapsed: true,
+            items: [
+              { text: "Demo Output", link: "/development/specific/demo_output" },
             ],
           },
         ],


### PR DESCRIPTION
## Summary
Enhanced the VitePress documentation sidebar navigation by adding direct links to the first item in each collapsed section group. This allows users to navigate to relevant content directly from the sidebar without needing to expand the section first.

## Key Changes
- Added `link` property to 6 collapsed sidebar sections, pointing to their first child item:
  - "View" section → links to `/development/view/definition`
  - "Model" section → links to `/development/model/binding`
  - "Message, Error" section → links to `/development/messages/messages`
  - "Browser Feature" section → links to `/development/specific/barcodes`
  - "RAP, EML" section → links to `/development/specific/cds`
  - "Expert Topic" section → links to `/development/specific/locks`

- Reorganized "Browser Feature" subsection items for better logical grouping:
  - Moved "Timer" and "Soft Keyboard" items before "File Handling"
  - Removed unnecessary `collapsed: true` property from "File Handling" nested section

- Restructured "Expert Topic" section:
  - Removed nested "More" collapsible group
  - Promoted "Demo Output" to a top-level "More" section with its own direct link to `/development/specific/demo_output`

## Implementation Details
These changes improve UX by making sidebar sections more interactive and reducing the need for users to expand sections to discover content. The reorganization also creates a more intuitive information hierarchy in the documentation structure.

https://claude.ai/code/session_01JSAm2THou6e8dwbbUD3gET