### PR TITLE
Add PDF, Clipboard, E-Mail, Value Help, WebSocket cookbook pages

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -236,14 +236,19 @@ export default defineConfig({
             items: [
               { text: "Lock", link: "/development/specific/locks" },
               { text: "Statefulness", link: "/development/specific/statefulness" },
+              { text: "WebSocket", link: "/development/specific/websocket" },
               { text: "Logout", link: "/configuration/logout" },
             ],
           },
           {
             text: "More",
-            link: "/development/specific/demo_output",
+            link: "/development/specific/pdf",
             collapsed: true,
             items: [
+              { text: "PDF", link: "/development/specific/pdf" },
+              { text: "Clipboard", link: "/development/specific/clipboard" },
+              { text: "E-Mail", link: "/development/specific/email" },
+              { text: "Value Help", link: "/development/specific/value_help" },
               { text: "Demo Output", link: "/development/specific/demo_output" },
             ],
           },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -195,6 +195,17 @@ export default defineConfig({
             ],
           },
           {
+            text: "UI Patterns",
+            link: "/development/patterns/form",
+            collapsed: true,
+            items: [
+              { text: "Form", link: "/development/patterns/form" },
+              { text: "Master-Detail", link: "/development/patterns/master_detail" },
+              { text: "Filter, Search, Table", link: "/development/patterns/filter_table" },
+              { text: "IconTabBar", link: "/development/patterns/icon_tab_bar" },
+            ],
+          },
+          {
             text: "Browser Feature",
             link: "/development/specific/barcodes",
             collapsed: true,

--- a/docs/development/patterns/filter_table.md
+++ b/docs/development/patterns/filter_table.md
@@ -1,0 +1,163 @@
+---
+outline: [2, 4]
+---
+# Filter, Search and Table
+
+The closest UI5 cousin of an ALV report: a table with a search field and one or two filter dropdowns above it. The user types, picks filters, the list narrows.
+
+The split of work is simple — UI5 takes the input, ABAP does the filtering. Each filter change fires a backend event, the handler re-runs the `SELECT` (or filters the in-memory table), and the table re-renders.
+
+#### Step 1 — The bare table
+
+Start with the result table. No filters yet — just bind the data and show columns. This is the [tables](../model/tables.md) pattern unchanged:
+
+```abap
+DATA(view) = z2ui5_cl_xml_view=>factory( )->page( `Sales Orders` ).
+DATA(tab)  = view->table( client->_bind( mt_orders ) growing = abap_true ).
+tab->columns( )->column( )->text( `Order` )->get_parent(
+              )->column( )->text( `Customer` )->get_parent(
+              )->column( )->text( `Value` ).
+tab->items( )->column_list_item( )->cells(
+   )->text( `{VBELN}` )->text( `{KUNNR}` )->text( `{NETWR}` ).
+```
+
+#### Step 2 — A search field in the toolbar
+
+Add a header toolbar to the table with a `search_field`. Bind its `value` two-way to a filter string and fire `SEARCH` on enter or button click. The `liveChange` event would fire on every keystroke — usually too chatty for a backend roundtrip:
+
+```abap
+DATA(tab) = view->table( client->_bind( mt_orders ) growing = abap_true ).
+tab->header_toolbar( )->overflow_toolbar(
+    )->title( `Sales Orders`
+    )->toolbar_spacer( )
+    )->search_field(
+        value  = client->_bind_edit( mv_search )
+        width  = `20rem`
+        search = client->_event( `SEARCH` ) ).
+```
+
+#### Step 3 — A filter dropdown
+
+Add a `select` next to the search field for typed filtering — sales organisation, status, type — anything with a small fixed set of values. A `change` event makes it re-filter immediately, without a separate apply button:
+
+```abap
+tab->header_toolbar( )->overflow_toolbar(
+    )->title( `Sales Orders`
+    )->toolbar_spacer( )
+    )->label( `Org:` )
+    )->select(
+        selectedkey = client->_bind_edit( mv_org )
+        change      = client->_event( `APPLY_FILTER` )
+        )->items( )->core_item( key = ``     text = `All`
+                      )->core_item( key = `1000` text = `Germany`
+                      )->core_item( key = `2000` text = `France` )->get_parent(
+    )->search_field(
+        value  = client->_bind_edit( mv_search )
+        width  = `20rem`
+        search = client->_event( `APPLY_FILTER` ) ).
+```
+
+#### Step 4 — Apply the filter in ABAP
+
+One event handler covers both filter sources. Use a clean re-`SELECT` for small datasets, or — when the source is already in memory — filter with `FILTER` / `DELETE … WHERE`:
+
+```abap
+WHEN client->check_on_event( `APPLY_FILTER` ).
+  SELECT FROM vbak
+    FIELDS vbeln, kunnr, netwr, vkorg
+    WHERE   ( @mv_org      = ''  OR vkorg = @mv_org )
+      AND   ( @mv_search   = ''  OR vbeln LIKE @( `%` && mv_search && `%` )
+                              OR  kunnr LIKE @( `%` && mv_search && `%` ) )
+    INTO TABLE @mt_orders
+    UP TO 100 ROWS.
+  client->view_model_update( ).
+```
+
+#### Full Example
+
+A complete order list with search and a sales-org filter, both wired to the same event:
+
+```abap
+CLASS z2ui5_cl_sample_filter_table DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    TYPES:
+      BEGIN OF ty_order,
+        vbeln TYPE vbak-vbeln,
+        kunnr TYPE vbak-kunnr,
+        netwr TYPE vbak-netwr,
+        vkorg TYPE vbak-vkorg,
+      END OF ty_order.
+    DATA mt_orders TYPE STANDARD TABLE OF ty_order WITH EMPTY KEY.
+    DATA mv_search TYPE string.
+    DATA mv_org    TYPE vbak-vkorg.
+
+ENDCLASS.
+
+CLASS z2ui5_cl_sample_filter_table IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    CASE abap_true.
+
+      WHEN client->check_on_init( ).
+        load_data( ).
+        render( ).
+
+      WHEN client->check_on_event( `APPLY_FILTER` ).
+        load_data( ).
+        client->view_model_update( ).
+
+    ENDCASE.
+
+  ENDMETHOD.
+
+  METHOD load_data.
+
+    SELECT FROM vbak
+      FIELDS vbeln, kunnr, netwr, vkorg
+      WHERE ( @mv_org    = ''  OR vkorg = @mv_org )
+        AND ( @mv_search = ''  OR vbeln LIKE @( `%` && mv_search && `%` )
+                              OR kunnr LIKE @( `%` && mv_search && `%` ) )
+      INTO TABLE @mt_orders
+      UP TO 100 ROWS.
+
+  ENDMETHOD.
+
+  METHOD render.
+
+    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( )->page( `Sales Orders` ).
+    DATA(tab)  = view->table( client->_bind( mt_orders ) growing = abap_true ).
+
+    tab->header_toolbar( )->overflow_toolbar(
+        )->title( `Sales Orders`
+        )->toolbar_spacer( )
+        )->label( `Org:` )
+        )->select(
+            selectedkey = client->_bind_edit( mv_org )
+            change      = client->_event( `APPLY_FILTER` )
+            )->items( )->core_item( key = ``     text = `All`
+                          )->core_item( key = `1000` text = `Germany`
+                          )->core_item( key = `2000` text = `France` )->get_parent(
+        )->search_field(
+            value  = client->_bind_edit( mv_search )
+            width  = `20rem`
+            search = client->_event( `APPLY_FILTER` ) ).
+
+    tab->columns( )->column( )->text( `Order` )->get_parent(
+                  )->column( )->text( `Customer` )->get_parent(
+                  )->column( )->text( `Value` )->get_parent(
+                  )->column( )->text( `Org` ).
+    tab->items( )->column_list_item( )->cells(
+       )->text( `{VBELN}` )->text( `{KUNNR}` )->text( `{NETWR}` )->text( `{VKORG}` ).
+
+    client->view_display( view->stringify( ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+```
+
+::: tip
+For more advanced patterns — saved filter variants, multi-range selection, fuzzy search — the [layout-variant add-on](https://github.com/abap2UI5-addons) and `Z2UI5_CL_POP_GET_RANGE` (see [Built-In Popups](../popups/built_in.md)) are worth a look.
+:::

--- a/docs/development/patterns/form.md
+++ b/docs/development/patterns/form.md
@@ -1,0 +1,136 @@
+---
+outline: [2, 4]
+---
+# Form
+
+An input mask with labels, fields and a save button — the bread-and-butter screen of every business app. UI5 builds it with `sap.ui.layout.form.SimpleForm`: a responsive grid that arranges label/field pairs and wraps automatically on small screens.
+
+The pattern is always the same — a `simple_form` with `editable = abap_true`, then `content( 'form' )` for the form body, and finally a sequence of `label( … )` + an input control. What follows builds that up step by step.
+
+#### Step 1 — Label and input
+
+The minimum: one label, one input, bound to a string field. Set `editable` so the user can type into it:
+
+```abap
+client->view_display( z2ui5_cl_xml_view=>factory(
+    )->page( `Customer`
+        )->simple_form( editable = abap_true
+            )->content( `form`
+                )->label( `Name` )->input( client->_bind_edit( ms_customer-name )
+    )->stringify( ) ).
+```
+
+#### Step 2 — More field types
+
+Real forms use more than text inputs. Mix in `select` for dropdowns, `check_box` for booleans, `date_picker` for dates and `text_area` for longer text. Bind each with `_bind_edit` against the matching ABAP field:
+
+```abap
+DATA(form) = z2ui5_cl_xml_view=>factory(
+    )->page( `Customer`
+        )->simple_form( editable = abap_true
+            )->content( `form` ).
+
+form->label( `Name`     )->input( client->_bind_edit( ms_customer-name ) ).
+form->label( `Country`  )->select( selectedkey = client->_bind_edit( ms_customer-country )
+    )->items( )->core_item( key = `DE` text = `Germany`
+                  )->core_item( key = `FR` text = `France`
+                  )->core_item( key = `IT` text = `Italy` ).
+form->label( `Active`   )->check_box( selected = client->_bind_edit( ms_customer-active ) ).
+form->label( `Birthday` )->date_picker( value = client->_bind_edit( ms_customer-birthday ) ).
+form->label( `Notes`    )->text_area(   value = client->_bind_edit( ms_customer-notes ) rows = `4` ).
+```
+
+Storing the result as `DATA(form)` and adding rows in separate statements is easier to read than one long chain — pick whichever style fits your code.
+
+#### Step 3 — Required and validation
+
+Mark a field required by setting `required = abap_true` on the `label`. UI5 then renders the red asterisk. The actual validation still runs in ABAP — check the values on save and report problems via the message API:
+
+```abap
+form->label( `Name` required = abap_true )->input( client->_bind_edit( ms_customer-name ) ).
+
+" ...later in the save handler:
+WHEN client->check_on_event( `SAVE` ).
+  IF ms_customer-name IS INITIAL.
+    client->message_box_display( `Name is required.` ).
+    RETURN.
+  ENDIF.
+  " ...persist ms_customer here...
+  client->message_toast_display( `saved` ).
+```
+
+For richer feedback — error states on individual inputs, multi-message popups — see [Messages, Errors](../messages/messages.md).
+
+#### Full Example
+
+A complete editable customer form with a save handler and basic validation:
+
+```abap
+CLASS z2ui5_cl_sample_form DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    TYPES:
+      BEGIN OF ty_customer,
+        name     TYPE string,
+        country  TYPE string,
+        active   TYPE abap_bool,
+        birthday TYPE d,
+        notes    TYPE string,
+      END OF ty_customer.
+    DATA ms_customer TYPE ty_customer.
+
+ENDCLASS.
+
+CLASS z2ui5_cl_sample_form IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    CASE abap_true.
+
+      WHEN client->check_on_init( ).
+        ms_customer = VALUE #( country = `DE` active = abap_true ).
+
+        DATA(form) = z2ui5_cl_xml_view=>factory(
+            )->page( `Customer`
+                )->simple_form( editable = abap_true
+                    )->content( `form` ).
+
+        form->title( `General` ).
+        form->label( `Name`     required = abap_true )->input( client->_bind_edit( ms_customer-name ) ).
+        form->label( `Country`  )->select( selectedkey = client->_bind_edit( ms_customer-country )
+            )->items( )->core_item( key = `DE` text = `Germany`
+                          )->core_item( key = `FR` text = `France`
+                          )->core_item( key = `IT` text = `Italy` ).
+        form->label( `Active`   )->check_box( selected = client->_bind_edit( ms_customer-active ) ).
+        form->label( `Birthday` )->date_picker( value = client->_bind_edit( ms_customer-birthday ) ).
+
+        form->title( `Notes` ).
+        form->label( `Comment` )->text_area( value = client->_bind_edit( ms_customer-notes ) rows = `4` ).
+
+        form->toolbar( )->toolbar_spacer(
+            )->button( text = `Save` type = `Emphasized` press = client->_event( `SAVE` )
+            )->button( text = `Cancel` press = client->_event( `CANCEL` ) ).
+
+        client->view_display( form->stringify( ) ).
+
+      WHEN client->check_on_event( `SAVE` ).
+        IF ms_customer-name IS INITIAL.
+          client->message_box_display( `Name is required.` ).
+          RETURN.
+        ENDIF.
+        " ...persist ms_customer here...
+        client->message_toast_display( `saved` ).
+
+      WHEN client->check_on_event( `CANCEL` ).
+        CLEAR ms_customer.
+        client->view_model_update( ).
+
+    ENDCASE.
+
+  ENDMETHOD.
+ENDCLASS.
+```
+
+::: tip
+For a responsive layout that places labels next to fields on desktop and stacks them on mobile, pass `layout = 'ResponsiveGridLayout'` to `simple_form` and tune `labelspanxl`, `columnsxl` etc. — see the `Z2UI5_CL_APP_STARTUP` source for a fine-tuned reference.
+:::

--- a/docs/development/patterns/icon_tab_bar.md
+++ b/docs/development/patterns/icon_tab_bar.md
@@ -1,0 +1,142 @@
+---
+outline: [2, 4]
+---
+# IconTabBar
+
+A page split into tabs — *General*, *Items*, *Status*, *Notes* — each one a small section instead of a long scroll. Standard on every Fiori detail screen.
+
+In abap2UI5 it's a three-level chain: `icon_tab_bar` → `items` → one `icon_tab_filter` per tab. Each filter holds its own `content` block, and only one tab is rendered at a time on the frontend.
+
+#### Step 1 — Two tabs
+
+The smallest version — two tabs, each with a piece of text. Note the three nested calls: the *bar*, then *items*, then a *filter* per tab:
+
+```abap
+client->view_display( z2ui5_cl_xml_view=>factory(
+    )->page( `Order 4711`
+        )->icon_tab_bar(
+            )->items(
+                )->icon_tab_filter( text = `General`
+                    )->content( )->text( `header data here` )->get_parent( )->get_parent(
+                )->icon_tab_filter( text = `Items`
+                    )->content( )->text( `line items here` )
+    )->stringify( ) ).
+```
+
+`get_parent( )->get_parent( )` walks back up out of the first tab's `content` so the next `icon_tab_filter` is added as a sibling, not as a child.
+
+#### Step 2 — Counters and icons
+
+Tabs become much more useful with a count (*Items (12)*) or a status icon. Both are properties on `icon_tab_filter` — `count`, `icon`, `iconcolor` for the dot:
+
+```abap
+DATA(bar) = view->icon_tab_bar( )->items( ).
+
+bar->icon_tab_filter(
+    text  = `General`
+    icon  = `sap-icon://hint`
+    )->content( )->text( `header data here` ).
+
+bar->icon_tab_filter(
+    text  = `Items`
+    count = |{ lines( mt_items ) }|
+    icon  = `sap-icon://list`
+    )->content( )->text( `line items here` ).
+
+bar->icon_tab_filter(
+    text       = `Status`
+    icon       = `sap-icon://message-warning`
+    iconcolor  = COND #( WHEN mv_has_errors = abap_true THEN `Negative` ELSE `Positive` )
+    )->content( )->text( `status info here` ).
+```
+
+Cheap to read at a glance — the user sees the warning colour and the item count without opening the tab.
+
+#### Step 3 — Real content per tab
+
+Replace the placeholder `text` with whatever each tab needs — a form, a table, a tree. The tab is just a container, anything that works in a `page` works inside `content`:
+
+```abap
+DATA(tab_items) = bar->icon_tab_filter( text = `Items` count = |{ lines( mt_items ) }| )->content( ).
+DATA(items_tab) = tab_items->table( client->_bind( mt_items ) ).
+items_tab->columns( )->column( )->text( `Pos` )->get_parent(
+                    )->column( )->text( `Material` ).
+items_tab->items( )->column_list_item( )->cells(
+   )->text( `{POSNR}` )->text( `{MATNR}` ).
+```
+
+#### Full Example
+
+A sales-order detail page with three tabs — header form, item table, status overview:
+
+```abap
+CLASS z2ui5_cl_sample_icon_tab_bar DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    TYPES:
+      BEGIN OF ty_item,
+        posnr TYPE posnr,
+        matnr TYPE matnr,
+        kwmeng TYPE kwmeng,
+      END OF ty_item.
+    DATA ms_header TYPE vbak.
+    DATA mt_items  TYPE STANDARD TABLE OF ty_item WITH EMPTY KEY.
+
+ENDCLASS.
+
+CLASS z2ui5_cl_sample_icon_tab_bar IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    IF client->check_on_init( ).
+
+      ms_header = VALUE #( vbeln = `0000004711` auart = `OR` vkorg = `1000` ).
+      mt_items  = VALUE #(
+        ( posnr = `0010` matnr = `M-01` kwmeng = `10`  )
+        ( posnr = `0020` matnr = `M-02` kwmeng = `5`   )
+        ( posnr = `0030` matnr = `M-03` kwmeng = `15`  ) ).
+
+      DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title = |Order { ms_header-vbeln }| ).
+      DATA(bar)  = view->icon_tab_bar( )->items( ).
+
+      " --- Tab 1: header form ---
+      DATA(form) = bar->icon_tab_filter(
+          text = `General`
+          icon = `sap-icon://hint`
+          )->content( )->simple_form( editable = abap_false )->content( `form` ).
+      form->label( `Order`    )->text( ms_header-vbeln ).
+      form->label( `Type`     )->text( ms_header-auart ).
+      form->label( `Sales Org`)->text( ms_header-vkorg ).
+
+      " --- Tab 2: item table ---
+      DATA(tab_items) = bar->icon_tab_filter(
+          text  = `Items`
+          count = |{ lines( mt_items ) }|
+          icon  = `sap-icon://list`
+          )->content( ).
+      DATA(items_tab) = tab_items->table( client->_bind( mt_items ) ).
+      items_tab->columns( )->column( )->text( `Pos`      )->get_parent(
+                          )->column( )->text( `Material` )->get_parent(
+                          )->column( )->text( `Qty`      ).
+      items_tab->items( )->column_list_item( )->cells(
+         )->text( `{POSNR}` )->text( `{MATNR}` )->text( `{KWMENG}` ).
+
+      " --- Tab 3: status ---
+      bar->icon_tab_filter(
+          text      = `Status`
+          icon      = `sap-icon://message-success`
+          iconcolor = `Positive`
+          )->content(
+              )->message_strip( text = `Order is released and ready for delivery.` type = `Success` ).
+
+      client->view_display( view->stringify( ) ).
+
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.
+```
+
+::: tip
+Pre-select a tab with `selectedkey` on `icon_tab_bar` plus a matching `key` on each filter — handy when navigating into the page already expecting a specific tab (e.g. *Status* after an error).
+:::

--- a/docs/development/patterns/master_detail.md
+++ b/docs/development/patterns/master_detail.md
@@ -1,0 +1,143 @@
+---
+outline: [2, 4]
+---
+# Master-Detail
+
+The most familiar Fiori floorplan: a list on the left, the picked item's details on the right. Selecting a row updates only the right pane — no full page reload, no app navigation.
+
+The recipe in abap2UI5 is straightforward. Lay out an `hbox` with two children — a list and a detail panel. Both panels read from the same backend data; an `mv_selected` field decides which row the detail panel shows. Selection events update that field, the framework re-renders, the detail panel reflects the new row.
+
+#### Step 1 — The list
+
+Start with the left pane: a basic table bound to your data. Add a `press` event on the row template so a click fires a backend event. Pass the row's key in `t_arg`, otherwise the handler has no way to know which row the user clicked:
+
+```abap
+DATA(view) = z2ui5_cl_xml_view=>factory( )->page( `Airlines` ).
+DATA(tab) = view->table( client->_bind( mt_carriers ) growing = abap_true ).
+tab->columns( )->column( )->text( `Carrier` )->get_parent(
+              )->column( )->text( `Name` ).
+tab->items( )->column_list_item(
+    type  = `Active`
+    press = client->_event(
+        val   = `SELECT`
+        t_arg = VALUE #( ( `${CARRID}` ) ) )
+    )->cells( )->text( `{CARRID}` )->text( `{CARRNAME}` ).
+```
+
+`type = 'Active'` is what makes a row clickable in `sap.m.Table` — without it `press` fires nothing.
+
+#### Step 2 — Capture the selection
+
+In the event handler, store the picked key. `client->get_event_arg( )` returns the first `t_arg` entry — here the carrier id:
+
+```abap
+WHEN client->check_on_event( `SELECT` ).
+  mv_selected = client->get_event_arg( ).
+  READ TABLE mt_carriers WITH KEY carrid = mv_selected INTO ms_detail.
+  client->view_model_update( ).
+```
+
+The `view_model_update( )` call refreshes the bound model — the detail panel (built in the next step) picks up the new row automatically.
+
+#### Step 3 — Side-by-side layout
+
+Wrap the list and the detail in an `hbox`. The list gets a fixed width, the detail panel takes the rest. Conditional rendering shows a placeholder when nothing is selected yet:
+
+```abap
+DATA(view) = z2ui5_cl_xml_view=>factory( )->page( `Airlines` ).
+DATA(hbox) = view->hbox( ).
+
+" left pane — list
+DATA(left) = hbox->vbox( width = `30%` ).
+" ...build the table from Step 1 inside `left`...
+
+" right pane — detail
+DATA(right) = hbox->vbox( width = `70%` ).
+IF mv_selected IS INITIAL.
+  right->text( `Select an airline on the left.` ).
+ELSE.
+  right->object_header( title = ms_detail-carrname
+                        number = ms_detail-carrid ).
+  right->simple_form( editable = abap_false
+      )->content( `form`
+          )->label( `URL` )->link( text = ms_detail-url href = ms_detail-url ).
+ENDIF.
+```
+
+#### Full Example
+
+Sales-organisation list on the left, a small detail form on the right — selecting a row updates the detail panel without a full re-render:
+
+```abap
+CLASS z2ui5_cl_sample_master_detail DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    DATA mt_carriers TYPE STANDARD TABLE OF scarr WITH EMPTY KEY.
+    DATA ms_detail   TYPE scarr.
+    DATA mv_selected TYPE scarr-carrid.
+
+ENDCLASS.
+
+CLASS z2ui5_cl_sample_master_detail IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    CASE abap_true.
+
+      WHEN client->check_on_init( ).
+        SELECT FROM scarr FIELDS carrid, carrname, currcode, url
+          INTO TABLE @mt_carriers UP TO 50 ROWS.
+        render( ).
+
+      WHEN client->check_on_event( `SELECT` ).
+        mv_selected = client->get_event_arg( ).
+        READ TABLE mt_carriers WITH KEY carrid = mv_selected INTO ms_detail.
+        render( ).
+
+    ENDCASE.
+
+  ENDMETHOD.
+
+  METHOD render.
+
+    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( )->page( `Airlines` ).
+    DATA(hbox) = view->hbox( ).
+
+    " ---- left pane (list) ----
+    DATA(left) = hbox->vbox( width = `30%` ).
+    DATA(tab)  = left->table( client->_bind( mt_carriers ) growing = abap_true ).
+    tab->columns( )->column( )->text( `Carrier` )->get_parent(
+                  )->column( )->text( `Name` ).
+    tab->items( )->column_list_item(
+        type  = `Active`
+        press = client->_event(
+            val   = `SELECT`
+            t_arg = VALUE #( ( `${CARRID}` ) ) )
+        )->cells( )->text( `{CARRID}` )->text( `{CARRNAME}` ).
+
+    " ---- right pane (detail) ----
+    DATA(right) = hbox->vbox( width = `70%` ).
+    IF mv_selected IS INITIAL.
+      right->message_page(
+          text         = `No airline selected`
+          description  = `Pick one from the list on the left.`
+          icon         = `sap-icon://flight`
+          showheader   = abap_false ).
+    ELSE.
+      right->object_header( title = ms_detail-carrname number = ms_detail-carrid ).
+      DATA(form) = right->simple_form( editable = abap_false )->content( `form` ).
+      form->label( `Carrier ID` )->text( ms_detail-carrid ).
+      form->label( `Currency`   )->text( ms_detail-currcode ).
+      form->label( `Website`    )->link( text = ms_detail-url href = ms_detail-url target = `_blank` ).
+    ENDIF.
+
+    client->view_display( view->stringify( ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+```
+
+::: tip
+On a phone the side-by-side layout becomes cramped. Detect the form factor with the [Device Model](../model/device.md) and either stack the panes vertically or navigate to a separate detail app when `device>/system/phone` is true.
+:::

--- a/docs/development/specific/clipboard.md
+++ b/docs/development/specific/clipboard.md
@@ -1,0 +1,51 @@
+---
+outline: [2, 4]
+---
+# Clipboard
+
+Copy arbitrary text to the user's clipboard with the frontend event `client->cs_event-clipboard_copy`. The text travels as the first `t_arg` entry and is passed to the browser's `navigator.clipboard.writeText` API — no backend roundtrip on paste.
+
+```abap
+CLASS z2ui5_cl_sample_clipboard DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    DATA mv_text TYPE string.
+
+ENDCLASS.
+
+CLASS z2ui5_cl_sample_clipboard IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    CASE abap_true.
+
+      WHEN client->check_on_init( ).
+        mv_text = `Hello from abap2UI5`.
+
+        client->view_display( z2ui5_cl_xml_view=>factory(
+            )->page(
+                )->input( client->_bind_edit( mv_text )
+                )->button(
+                    text  = `copy to clipboard`
+                    press = client->_event( `COPY` )
+            )->stringify( ) ).
+
+      WHEN client->check_on_event( `COPY` ).
+        client->follow_up_action( client->_event_client(
+            val   = client->cs_event-clipboard_copy
+            t_arg = VALUE #( ( mv_text ) ) ) ).
+        client->message_toast_display( `copied` ).
+
+    ENDCASE.
+
+  ENDMETHOD.
+ENDCLASS.
+```
+
+#### Copy the App State URL
+
+To share the current app state instead of a custom string, use `clipboard_app_state` — see [Share, Bookmark](../navigation/share.md).
+
+::: warning
+The browser's Clipboard API requires HTTPS (or `localhost`). On plain HTTP the call is silently ignored.
+:::

--- a/docs/development/specific/email.md
+++ b/docs/development/specific/email.md
@@ -1,0 +1,77 @@
+---
+outline: [2, 4]
+---
+# E-Mail
+
+abap2UI5 has no e-mail control of its own — sending mail is plain ABAP via `cl_bcs_message` (or `cl_bcs` on older releases). The UI part is a normal event handler that gathers the form fields and calls the BCS API.
+
+#### Plain Text Mail
+
+```abap
+CLASS z2ui5_cl_sample_email DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    DATA mv_to      TYPE string.
+    DATA mv_subject TYPE string.
+    DATA mv_body    TYPE string.
+
+ENDCLASS.
+
+CLASS z2ui5_cl_sample_email IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    CASE abap_true.
+
+      WHEN client->check_on_init( ).
+        client->view_display( z2ui5_cl_xml_view=>factory(
+            )->page( `Send E-Mail`
+                )->simple_form( editable = abap_true
+                    )->content( `form`
+                        )->label( `To`      )->input( client->_bind_edit( mv_to )
+                        )->label( `Subject` )->input( client->_bind_edit( mv_subject )
+                        )->label( `Body`    )->text_area( client->_bind_edit( mv_body )
+                        )->button(
+                            text  = `send`
+                            press = client->_event( `SEND` )
+            )->stringify( ) ).
+
+      WHEN client->check_on_event( `SEND` ).
+        TRY.
+            DATA(lo_mail) = cl_bcs_message=>create_persistent( ).
+            lo_mail->set_subject( CONV #( mv_subject ) ).
+            lo_mail->set_main( cl_bcs_convert=>string_to_soli( mv_body ) ).
+            lo_mail->add_recipient( i_address = CONV #( mv_to ) i_address_type = `INT` ).
+            lo_mail->send( i_with_error_screen = abap_false ).
+            COMMIT WORK.
+            client->message_toast_display( `mail queued` ).
+          CATCH cx_root INTO DATA(lx).
+            client->message_box_display( lx->get_text( ) ).
+        ENDTRY.
+
+    ENDCASE.
+
+  ENDMETHOD.
+ENDCLASS.
+```
+
+#### Attachment
+
+Reuse the [file upload](./files.md) flow to capture an attachment as base64, then hand it to `cl_bcs_message`:
+
+```abap
+DATA(lv_xstring) = cl_web_http_utility=>decode_x_base64( mv_attachment_base64 ).
+lo_mail->add_attachment(
+    iv_attachment_type    = `PDF`
+    iv_attachment_subject = mv_attachment_name
+    iv_attachment_size    = CONV #( xstrlen( lv_xstring ) )
+    i_attachment_content_hex = cl_bcs_convert=>xstring_to_solix( lv_xstring ) ).
+```
+
+::: tip
+SAPconnect (`SCOT`) must be configured for the mail to actually leave the system. If you do not see anything in `SOST`, that is where to look first.
+:::
+
+#### Compatibility
+
+`cl_bcs_message` is the modern API. On older releases or in ABAP Cloud check what is released for your platform — the structure of the example stays the same, only the API class changes.

--- a/docs/development/specific/pdf.md
+++ b/docs/development/specific/pdf.md
@@ -1,0 +1,52 @@
+---
+outline: [2, 4]
+---
+# PDF
+
+Render a PDF directly in your app — for printouts from Adobe Forms, SmartForms, archived documents from the Content Server, or anything else that produces an `xstring`.
+
+#### Built-In Popup
+
+The simplest path is the built-in popup `Z2UI5_CL_POP_PDF`. It expects the PDF as a `data:application/pdf;base64,...` URI and embeds it in an iframe:
+
+```abap
+METHOD z2ui5_if_app~main.
+
+  CASE abap_true.
+
+    WHEN client->check_on_init( ).
+      client->view_display( z2ui5_cl_xml_view=>factory(
+          )->page(
+              )->button(
+                  text  = `show PDF`
+                  press = client->_event( `SHOW_PDF` )
+          )->stringify( ) ).
+
+    WHEN client->check_on_event( `SHOW_PDF` ).
+      "lv_xstring contains the binary PDF — e.g. from cl_fp_function_module=>get_pdf, SmartForm OTF
+      "conversion, or SELECT FROM the SOFFCONT1 archive
+      DATA(lv_base64) = cl_web_http_utility=>encode_x_base64( lv_xstring ).
+      DATA(lo_popup)  = z2ui5_cl_pop_pdf=>factory(
+          i_title = `Invoice 4711`
+          i_pdf   = `data:application/pdf;base64,` && lv_base64 ).
+      client->nav_app_call( lo_popup ).
+
+  ENDCASE.
+
+ENDMETHOD.
+```
+
+#### Download Instead of Display
+
+To let the user save the PDF rather than view it inline, use the [file download](./files.md) pattern:
+
+```abap
+client->follow_up_action( client->_event_client(
+    val   = client->cs_event-download_b64_file
+    t_arg = VALUE #( ( `data:application/pdf;base64,` && lv_base64 )
+                     ( `invoice_4711.pdf` ) ) ).
+```
+
+::: tip
+On older ABAP releases without `cl_web_http_utility`, use `cl_http_utility=>if_http_utility~encode_x_base64( lv_xstring )` instead.
+:::

--- a/docs/development/specific/value_help.md
+++ b/docs/development/specific/value_help.md
@@ -1,0 +1,92 @@
+---
+outline: [2, 4]
+---
+# Value Help
+
+A field that asks *"which one?"* is the F4 moment of ABAP. abap2UI5 covers the basics with two built-in popups and lets you build anything custom on top.
+
+#### Suggestions on the Input
+
+The lightest variant — type-ahead from a bound list, no popup, no roundtrip after the initial render. Bind `suggestionitems` to an internal table and pick the columns via the `suggestion_item` template:
+
+```abap
+TYPES: BEGIN OF ty_country,
+         code TYPE c LENGTH 3,
+         name TYPE string,
+       END OF ty_country.
+DATA mt_countries TYPE STANDARD TABLE OF ty_country.
+DATA mv_country   TYPE string.
+
+mt_countries = VALUE #( ( code = `DE` name = `Germany` )
+                        ( code = `FR` name = `France`  )
+                        ( code = `IT` name = `Italy`   ) ).
+
+client->view_display( z2ui5_cl_xml_view=>factory(
+    )->page(
+        )->input(
+            value             = client->_bind_edit( mv_country )
+            showsuggestion    = abap_true
+            suggestionitems   = client->_bind( mt_countries )
+            )->suggestion_items(
+                )->list_item( text = `{CODE}` additionaltext = `{NAME}`
+    )->stringify( ) ).
+```
+
+#### Selection Popup
+
+For a *"pick from this list"* dialog use the built-in `Z2UI5_CL_POP_TO_SELECT`. Pass any internal table, navigate to it as a sub-app, and read the result on return:
+
+```abap
+CLASS z2ui5_cl_sample_f4 DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    DATA mv_carrid TYPE string.
+
+ENDCLASS.
+
+CLASS z2ui5_cl_sample_f4 IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    CASE abap_true.
+
+      WHEN client->check_on_init( ).
+        client->view_display( z2ui5_cl_xml_view=>factory(
+            )->page(
+                )->input(
+                    value            = client->_bind_edit( mv_carrid )
+                    showvaluehelp    = abap_true
+                    valuehelprequest = client->_event( `F4` )
+            )->stringify( ) ).
+
+      WHEN client->check_on_event( `F4` ).
+        SELECT carrid, carrname, url FROM scarr INTO TABLE @DATA(lt_carriers).
+        client->nav_app_call( z2ui5_cl_pop_to_select=>factory(
+            i_tab   = lt_carriers
+            i_title = `Choose airline` ) ).
+
+      WHEN client->check_on_navigated( ).
+        DATA(lo_prev) = CAST z2ui5_cl_pop_to_select( client->get_app_prev( ) ).
+        DATA(ls_res)  = lo_prev->result( ).
+        IF ls_res-check_confirmed = abap_true.
+          FIELD-SYMBOLS <row> TYPE any.
+          ASSIGN ls_res-row->* TO <row>.
+          ASSIGN COMPONENT `CARRID` OF STRUCTURE <row> TO FIELD-SYMBOL(<carrid>).
+          mv_carrid = <carrid>.
+        ENDIF.
+
+    ENDCASE.
+
+  ENDMETHOD.
+ENDCLASS.
+```
+
+Pass `i_multiselect = abap_true` for multi-pick; the result table is then in `ls_res-table`.
+
+#### DDIC Search Help
+
+For value helps that exist as DDIC search help objects (`SE11` → search help), the [generic search help builder](https://github.com/axelmohnen/a2UI5-generic_search_hlp) wraps the F4 framework so you can fire any standard search help by name and get the picked row back. Install it like any other [add-on](../../resources/addons.md).
+
+#### Custom Dialog
+
+When neither popup fits — e.g. a filter bar with multiple columns, ranges, fuzzy search — build the F4 as a separate app with its own view and call it via `nav_app_call`. See [Popup → Separated App](../popups/popup.md#separated-app) for the pattern.

--- a/docs/development/specific/websocket.md
+++ b/docs/development/specific/websocket.md
@@ -1,0 +1,54 @@
+---
+outline: [2, 4]
+---
+# WebSocket
+
+Stateless roundtrips are fine for click-driven UIs, but some scenarios need the server to *push* — a news feed, a job-status indicator, a chat. abap2UI5 has no special API for this; you use SAP's standard WebSocket stack and feed the messages into the rendered view via custom JavaScript.
+
+The building blocks:
+
+| Layer | Purpose |
+|---|---|
+| **APC** (Application Push Channel, `SAPC`) | Exposes the WebSocket endpoint over HTTP/S |
+| **AMC** (Application Messaging Channel, `SAMC`) | In-system pub/sub — any ABAP code can broadcast into a channel |
+| **Custom JS** in the view | Opens the socket, dispatches incoming messages |
+
+Once both channels are configured, any `COMMIT WORK` that fires an AMC publish reaches every connected browser within milliseconds — no polling, no timer.
+
+#### Server Side
+
+An APC class extending `cl_apc_wsp_ext_stateless_base` binds an AMC consumer when a client connects, so AMC messages are forwarded to that socket. Broadcasting is then a one-liner from anywhere in the system:
+
+```abap
+DATA(lo_producer) = cl_amc_channel_manager=>create_message_producer(
+    i_application_id = `Z2UI5_SAMPLE`
+    i_channel_id     = `/news_feed` ).
+lo_producer->send( i_message = `New order arrived` ).
+```
+
+A full reference implementation lives in the samples repo — `Z2UI5_CL_DEMO_APP_S_05_WS` for the APC handler and `Z2UI5_CL_DEMO_APP_S_05` for the consuming app.
+
+#### Client Side
+
+The browser opens the socket via [Custom JavaScript](../../advanced/extensibility/custom_js.md) embedded in the view. The connection stays open across normal abap2UI5 roundtrips — incoming messages can update a model, trigger a toast, or fire an abap2UI5 event to pull fresh data from the backend:
+
+```js
+const ws = new WebSocket("wss://" + window.location.host + "/sap/bc/apc/sap/z2ui5_sample");
+ws.onmessage = (e) => {
+  sap.m.MessageToast.show(e.data);
+};
+```
+
+#### When to Reach For It
+
+WebSockets cost a permanent connection per user — comparable to a stateful session in resource terms. Use them when push really matters:
+
+- live dashboards, monitoring screens
+- multi-user collaboration (chat, shared editing)
+- long-running background jobs reporting status
+
+For *"refresh every few seconds"* the [Timer](./timer.md) is cheaper and simpler.
+
+::: warning
+APC/AMC are not available on every ABAP platform — check release notes for your system (ABAP Cloud, S/4 Public Cloud, BTP ABAP Environment) before designing around them.
+:::


### PR DESCRIPTION
Closes coverage gaps for common ABAP-developer scenarios: built-in PDF
popup, frontend clipboard copy, BCS-based mail sending, F4-style value
help with the selection popup, and WebSocket push via APC/AMC.

PDF, Clipboard, E-Mail and Value Help land under "More"; WebSocket joins
"Expert Topic" next to Statefulness.