### PR TITLE
Reorganize documentation: split tables/trees and add templating guides

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -134,6 +134,7 @@ export default defineConfig({
             collapsed: true,
             items: [
               { text: "Definition", link: "/development/view/definition" },
+              { text: "Nested", link: "/development/view/nested" },
               { text: "Expression Binding", link: "/development/model/expression_binding" },
               { text: "Formatter", link: "/development/specific/formatter" },
             ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -146,7 +146,6 @@ export default defineConfig({
               { text: "Binding", link: "/development/model/binding" },
               { text: "Table, Tree", link: "/development/model/tables" },
               { text: "Device Model", link: "/development/model/device" },
-              { text: "OData", link: "/development/model/odata" },
             ],
           },
           {
@@ -267,6 +266,7 @@ export default defineConfig({
               { text: "Demo Output", link: "/development/specific/demo_output" },
               { text: "XML Templating", link: "/development/specific/xml_templating" },
               { text: "Nested Views", link: "/development/view/nested" },
+              { text: "OData", link: "/development/model/odata" },
             ],
           },
         ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -265,6 +265,7 @@ export default defineConfig({
               { text: "Value Help", link: "/development/specific/value_help" },
               { text: "E-Mail", link: "/development/specific/email" },
               { text: "Demo Output", link: "/development/specific/demo_output" },
+              { text: "XML Templating", link: "/development/specific/xml_templating" },
             ],
           },
         ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -144,7 +144,8 @@ export default defineConfig({
             collapsed: true,
             items: [
               { text: "Binding", link: "/development/model/binding" },
-              { text: "Table, Tree", link: "/development/model/tables" },
+              { text: "Tables", link: "/development/model/tables" },
+              { text: "Trees", link: "/development/model/trees" },
               { text: "Device Model", link: "/development/model/device" },
             ],
           },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -134,7 +134,6 @@ export default defineConfig({
             collapsed: true,
             items: [
               { text: "Definition", link: "/development/view/definition" },
-              { text: "Nested", link: "/development/view/nested" },
               { text: "Expression Binding", link: "/development/model/expression_binding" },
               { text: "Formatter", link: "/development/specific/formatter" },
             ],
@@ -267,6 +266,7 @@ export default defineConfig({
               { text: "E-Mail", link: "/development/specific/email" },
               { text: "Demo Output", link: "/development/specific/demo_output" },
               { text: "XML Templating", link: "/development/specific/xml_templating" },
+              { text: "Nested Views", link: "/development/view/nested" },
             ],
           },
         ],

--- a/docs/development/model/tables.md
+++ b/docs/development/model/tables.md
@@ -1,8 +1,8 @@
 ---
 outline: [2, 4]
 ---
-# Tables, Trees
-This section walks through rendering nested data structures — tables, trees, and nested records — in views.
+# Tables
+This section walks through rendering tabular and nested data in views.
 
 ### Tables
 The example below binds a simple table to a UI5 control:
@@ -80,75 +80,6 @@ To make a table editable, switch the binding to `bind_edit`:
     ENDIF.
 
   ENDMETHOD.
-```
-
-### Tree
-For trees, use nested structures:
-```abap
-CLASS z2ui5_cl_sample_tree DEFINITION PUBLIC.
-
-  PUBLIC SECTION.
-    INTERFACES z2ui5_if_app.
-    TYPES:
-      BEGIN OF ty_prodh_node_level3,
-        is_selected TYPE abap_bool,
-        text        TYPE string,
-        prodh       TYPE string,
-      END OF ty_prodh_node_level3,
-      BEGIN OF ty_prodh_node_level2,
-        is_selected TYPE abap_bool,
-        text        TYPE string,
-        prodh       TYPE string,
-        nodes       TYPE STANDARD TABLE OF ty_prodh_node_level3 WITH DEFAULT KEY,
-      END OF ty_prodh_node_level2,
-      BEGIN OF ty_prodh_node_level1,
-        is_selected TYPE abap_bool,
-        text        TYPE string,
-        prodh       TYPE string,
-        nodes       TYPE STANDARD TABLE OF ty_prodh_node_level2 WITH DEFAULT KEY,
-      END OF ty_prodh_node_level1,
-      ty_prodh_nodes TYPE STANDARD TABLE OF ty_prodh_node_level1 WITH DEFAULT KEY.
-    DATA prodh_nodes    TYPE ty_prodh_nodes.
-
-ENDCLASS.
-
-CLASS z2ui5_cl_sample_tree IMPLEMENTATION.
-  METHOD z2ui5_if_app~main.
-
-    prodh_nodes = VALUE #( (
-        text = `Machines`
-        prodh  = `00100`
-        nodes  = VALUE #( (
-            text = `Pumps`
-            prodh = `0010000100`
-            nodes = VALUE #( (
-                text  = `Pump 001`
-                prodh = `001000010000000100` ) (
-                text  = `Pump 002`
-                prodh = `001000010000000105` ) )
-        ) ) ) (
-        text  = `Paints`
-        prodh = `00110`
-        nodes = VALUE #( (
-            text  = `Gloss paints`
-            prodh = `0011000105`
-            nodes = VALUE #( (
-                text  = `Paint 001`
-                prodh = `001100010500000100` ) (
-                text  = `Paint 002`
-                prodh = `001100010500000105` )
-    ) ) ) ) ).
-
-    DATA(tree) = z2ui5_cl_xml_view=>factory( )->page(
-        )->tree( items = client->_bind_edit( prodh_nodes )
-            )->items( )->standard_tree_item(
-                selected = `{IS_SELECTED}`
-                title    = `{TEXT}` ).
-
-    client->view_display( tree->stringify( ) ).
-
-  ENDMETHOD.
-ENDCLASS.
 ```
 
 ### Nested Structures

--- a/docs/development/model/trees.md
+++ b/docs/development/model/trees.md
@@ -1,0 +1,76 @@
+---
+outline: [2, 4]
+---
+# Trees
+For hierarchical data, abap2UI5 uses nested ABAP structures to represent tree levels. Each level holds a table of child nodes, which UI5 traverses to build the expandable tree control.
+
+### Tree
+Define a type hierarchy where each node contains a child table of the next level:
+```abap
+CLASS z2ui5_cl_sample_tree DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    TYPES:
+      BEGIN OF ty_prodh_node_level3,
+        is_selected TYPE abap_bool,
+        text        TYPE string,
+        prodh       TYPE string,
+      END OF ty_prodh_node_level3,
+      BEGIN OF ty_prodh_node_level2,
+        is_selected TYPE abap_bool,
+        text        TYPE string,
+        prodh       TYPE string,
+        nodes       TYPE STANDARD TABLE OF ty_prodh_node_level3 WITH DEFAULT KEY,
+      END OF ty_prodh_node_level2,
+      BEGIN OF ty_prodh_node_level1,
+        is_selected TYPE abap_bool,
+        text        TYPE string,
+        prodh       TYPE string,
+        nodes       TYPE STANDARD TABLE OF ty_prodh_node_level2 WITH DEFAULT KEY,
+      END OF ty_prodh_node_level1,
+      ty_prodh_nodes TYPE STANDARD TABLE OF ty_prodh_node_level1 WITH DEFAULT KEY.
+    DATA prodh_nodes    TYPE ty_prodh_nodes.
+
+ENDCLASS.
+
+CLASS z2ui5_cl_sample_tree IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    prodh_nodes = VALUE #( (
+        text = `Machines`
+        prodh  = `00100`
+        nodes  = VALUE #( (
+            text = `Pumps`
+            prodh = `0010000100`
+            nodes = VALUE #( (
+                text  = `Pump 001`
+                prodh = `001000010000000100` ) (
+                text  = `Pump 002`
+                prodh = `001000010000000105` ) )
+        ) ) ) (
+        text  = `Paints`
+        prodh = `00110`
+        nodes = VALUE #( (
+            text  = `Gloss paints`
+            prodh = `0011000105`
+            nodes = VALUE #( (
+                text  = `Paint 001`
+                prodh = `001100010500000100` ) (
+                text  = `Paint 002`
+                prodh = `001100010500000105` )
+    ) ) ) ) ).
+
+    DATA(tree) = z2ui5_cl_xml_view=>factory( )->page(
+        )->tree( items = client->_bind_edit( prodh_nodes )
+            )->items( )->standard_tree_item(
+                selected = `{IS_SELECTED}`
+                title    = `{TEXT}` ).
+
+    client->view_display( tree->stringify( ) ).
+
+  ENDMETHOD.
+ENDCLASS.
+```
+
+The child table field (`nodes` in the example above) is the key: UI5 follows that field name to locate sub-items at each level. The name must match across all levels but can be anything you choose.

--- a/docs/development/specific/xml_templating.md
+++ b/docs/development/specific/xml_templating.md
@@ -1,0 +1,98 @@
+---
+outline: [2, 4]
+---
+# XML Templating
+
+abap2UI5 sends views to the browser as XML strings. XML Templating lets you construct those strings dynamically in ABAP — branching on conditions, looping over data, and composing fragments — so that the view the browser receives is already fully resolved without any client-side template engine.
+
+#### How It Works
+
+Every abap2UI5 view is ultimately an XML string. You can build that string however you like: literal assignment, string concatenation, helper method calls, or a dedicated XML builder. The browser never sees template syntax — it only receives the final, rendered XML.
+
+```abap
+METHOD z2ui5_if_app~main.
+  IF client->check_on_init( ).
+    DATA(xml) = z2ui5_cl_xml_view=>factory( ).
+    client->view_display( xml->stringify( ) ).
+  ENDIF.
+ENDMETHOD.
+```
+
+#### Conditional Rendering
+
+Use ABAP `IF` statements to include or exclude controls depending on runtime state:
+
+```abap
+DATA(xml) = z2ui5_cl_xml_view=>factory( ).
+DATA(page) = xml->page( 'Conditional View' ).
+
+IF is_admin = abap_true.
+  page->button(
+    text  = 'Admin Action'
+    press = client->_event( 'ADMIN_ACTION' ) ).
+ENDIF.
+
+page->text( 'Hello, ' && username ).
+client->view_display( xml->stringify( ) ).
+```
+
+Only the controls added to the builder are serialized — nothing from the skipped branch appears in the XML.
+
+#### Repeating Controls
+
+Loop over an internal table to generate repeated controls:
+
+```abap
+DATA(list) = page->list( ).
+
+LOOP AT items INTO DATA(item).
+  list->item(
+    title       = item-title
+    description = item-description ).
+ENDLOOP.
+```
+
+Each iteration appends a child node. The resulting XML contains exactly as many `<Item>` elements as there were rows in `items`.
+
+#### Composing Fragments
+
+Break complex views into reusable helper methods that each return a subtree:
+
+```abap
+METHOD build_header.
+  rv_header = io_page->toolbar( )->title( title ).
+ENDMETHOD.
+
+METHOD build_table.
+  DATA(tbl) = io_page->table( ).
+  " ... add columns and rows
+  rv_table = tbl.
+ENDMETHOD.
+```
+
+Call the helpers in sequence inside `main` to assemble the final view. Because the builder accumulates children as regular ABAP object references, standard ABAP patterns (loops, conditions, method calls, function modules) all apply without restriction.
+
+#### Dynamic Column Sets
+
+A common pattern is selecting which columns to show based on user settings or authorization:
+
+```abap
+DATA(cols) = xml->table( )->columns( ).
+
+IF show_price = abap_true.
+  cols->column( )->text( 'Price' ).
+ENDIF.
+IF show_stock = abap_true.
+  cols->column( )->text( 'Stock' ).
+ENDIF.
+```
+
+The same loop that drives the column headers can drive the cell binding paths, keeping them in sync.
+
+#### Tips
+
+- Build the full view on every roundtrip. abap2UI5 is stateless by default, so the view is always reconstructed from the current model state — there is no diff or patch step.
+- Keep view-construction logic out of business-logic methods. A dedicated `build_view` method or a set of small fragment builders keeps `main` readable.
+- Prefer the fluent builder API (`z2ui5_cl_xml_view`) over raw string concatenation. The builder escapes special characters automatically and produces well-formed XML.
+
+See `Z2UI5_CL_DEMO_APP_032` and `Z2UI5_CL_DEMO_APP_033` for complete examples of conditional and dynamic views.

--- a/docs/development/view/nested.md
+++ b/docs/development/view/nested.md
@@ -1,0 +1,100 @@
+---
+outline: [2, 4]
+---
+# Nested Views
+
+A nested view is a view that is built from several independent parts. In abap2UI5 there are two main ways to achieve this: composing a single view tree from helper methods, and splitting the app into sub-apps that each own a slice of the view.
+
+#### Composing with Helper Methods
+
+The fluent builder returns each node as an object reference, so you can pass a node into a helper method and let it add children there:
+
+```abap
+METHOD z2ui5_if_app~main.
+  IF client->check_on_init( ).
+    DATA(xml)  = z2ui5_cl_xml_view=>factory( ).
+    DATA(page) = xml->shell( )->page( 'My App' ).
+
+    build_header( page ).
+    build_content( page ).
+    build_footer( page ).
+
+    client->view_display( xml->stringify( ) ).
+  ENDIF.
+ENDMETHOD.
+
+METHOD build_header.
+  io_page->toolbar( )->title( 'Header' ).
+ENDMETHOD.
+
+METHOD build_content.
+  io_page->vbox(
+      )->text( 'Line 1'
+      )->text( 'Line 2' ).
+ENDMETHOD.
+
+METHOD build_footer.
+  io_page->footer( )->button(
+    text  = 'Save'
+    press = client->_event( 'SAVE' ) ).
+ENDMETHOD.
+```
+
+Each helper receives the parent node by reference and attaches its controls to it. The final `stringify( )` call serialises the entire tree — including all nested children — into one XML string.
+
+#### Sub-Apps
+
+For larger apps it is useful to split responsibility across separate ABAP classes. Each sub-app implements `z2ui5_if_app` and manages its own piece of the view. The parent app instantiates the sub-app, passes the client, and merges the returned view fragment into its own view tree.
+
+**Parent app:**
+```abap
+METHOD z2ui5_if_app~main.
+  IF client->check_on_init( ).
+    sub_app = NEW z2ui5_cl_my_sub_app( ).
+  ENDIF.
+
+  DATA(xml)  = z2ui5_cl_xml_view=>factory( ).
+  DATA(page) = xml->shell( )->page( 'Parent' ).
+
+  " Let the sub-app render into a container on the page
+  DATA(container) = page->vbox( ).
+  sub_app->render( client = client io_node = container ).
+
+  client->view_display( xml->stringify( ) ).
+ENDMETHOD.
+```
+
+**Sub-app:**
+```abap
+METHOD render.
+  io_node->text( 'I am the sub-app' ).
+  io_node->button(
+    text  = 'Sub Action'
+    press = io_client->_event( 'SUB_ACTION' ) ).
+ENDMETHOD.
+```
+
+The sub-app appends its controls to whatever node the parent provides. Events fired inside the sub-app are handled by the sub-app's own `main` method on the next roundtrip.
+
+#### Navigation Between Views
+
+When the nested content changes completely — for example, a detail page replacing a list — use `view_display` to swap the entire view rather than nesting:
+
+```abap
+CASE client->get_event( ).
+  WHEN 'OPEN_DETAIL'.
+    client->view_display( detail_view->stringify( ) ).
+  WHEN 'BACK'.
+    client->view_display( list_view->stringify( ) ).
+ENDCASE.
+```
+
+Reserve true nesting for content that appears side-by-side or in a stable layout shell. Use `view_display` for sequential navigation where one screen fully replaces another.
+
+#### Tips
+
+- Keep each helper or sub-app focused on one logical section. A helper that grows beyond ~30 lines is a candidate for its own sub-app class.
+- Sub-apps can hold their own instance attributes for local state. Because the whole app tree is reconstructed on every roundtrip, each sub-app re-renders from its current state automatically.
+- Pass only the node the sub-app needs, not the whole view root. This limits the sub-app's scope and makes the boundary explicit.
+
+See `Z2UI5_CL_DEMO_APP_160` for an end-to-end example of parent and sub-app composition.


### PR DESCRIPTION
## Summary
This PR reorganizes the development documentation to improve clarity and discoverability by splitting content into more focused guides and adding new documentation for XML templating and nested views.

## Key Changes

- **Split Tables and Trees documentation**: Moved tree-specific content from `docs/development/model/tables.md` into a new dedicated `docs/development/model/trees.md` file, keeping tables documentation focused on tabular data
- **Added XML Templating guide** (`docs/development/specific/xml_templating.md`): New comprehensive guide covering dynamic view construction, conditional rendering, repeating controls, and composing fragments
- **Added Nested Views guide** (`docs/development/view/nested.md`): New guide documenting two approaches to building nested views—composing with helper methods and using sub-apps—plus guidance on when to use `view_display` for navigation
- **Updated navigation structure**: Modified `docs/.vitepress/config.mjs` to reflect the new documentation organization:
  - Renamed "Table, Tree" link to "Tables"
  - Added separate "Trees" link
  - Added "XML Templating" and "Nested Views" to the sidebar navigation
  - Removed OData link from model section (appears to be moved or deprecated)

## Implementation Details

- All new documentation follows the existing format with frontmatter outline configuration and consistent heading structure
- Examples use the established abap2UI5 patterns and reference demo apps for further learning
- Documentation emphasizes practical patterns: helper methods for composition, sub-apps for responsibility separation, and server-side template resolution

https://claude.ai/code/session_0188k14QNhv7aWeXMPQHmxZo