### PR TITLE
Add RAP documentation and reorganize data access layer docs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -235,19 +235,12 @@ export default defineConfig({
             ],
           },
           {
-            text: "RAP, EML",
+            text: "EML, CDS, SQL",
             link: "/development/specific/eml",
             collapsed: true,
             items: [
               { text: "EML", link: "/development/specific/eml" },
               { text: "Draft Handling", link: "/development/specific/draft" },
-            ],
-          },
-          {
-            text: "CDS, SQL",
-            link: "/development/specific/cds",
-            collapsed: true,
-            items: [
               { text: "CDS", link: "/development/specific/cds" },
               { text: "ABAP SQL", link: "/development/specific/abap_sql" },
               { text: "Fuzzy Search", link: "/development/specific/fuzzy_search" },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -218,7 +218,7 @@ export default defineConfig({
                 link: "/development/specific/files",
                 items: [
                   { text: "PDF", link: "/development/specific/pdf" },
-                  { text: "XLSX", link: "/development/specific/xlsx" },
+                  { text: "Spreadsheet", link: "/development/specific/xlsx" },
                 ],
               },
             ],
@@ -236,9 +236,10 @@ export default defineConfig({
           },
           {
             text: "EML, CDS, SQL",
-            link: "/development/specific/eml",
+            link: "/development/specific/rap",
             collapsed: true,
             items: [
+              { text: "RAP", link: "/development/specific/rap" },
               { text: "EML", link: "/development/specific/eml" },
               { text: "Draft Handling", link: "/development/specific/draft" },
               { text: "CDS", link: "/development/specific/cds" },

--- a/docs/development/specific/rap.md
+++ b/docs/development/specific/rap.md
@@ -1,0 +1,62 @@
+---
+outline: [2, 4]
+---
+# RAP
+
+### RAP is a Programming Model — abap2UI5 is Not
+
+**RAP (RESTful Application Programming Model)** is a full-stack programming model. It prescribes how you design, expose, and consume business objects: you define entities with CDS views, declare their behavior in Behavior Definitions (BDEFs), implement handlers in Behavior Implementation classes, and expose everything as an OData V4 service consumed by a Fiori Elements frontend. Every layer is part of the model.
+
+**abap2UI5 is not a programming model.** It is a UI rendering library — a single ABAP interface your class implements. It has no opinion on how you structure your data, which access layer you use, or how your business logic is organized. There is no CDS requirement, no BDEF, no OData service. abap2UI5 simply calls your `main` method on each user interaction and renders whatever view you return.
+
+This distinction matters: RAP defines the architecture *around* your application. abap2UI5 only defines how the UI is built *inside* your ABAP class.
+
+### abap2UI5 is Agnostic
+
+Because abap2UI5 imposes no access layer, you pick whatever fits:
+
+| Access Layer | Works in abap2UI5? |
+|---|---|
+| ABAP SQL (`SELECT`, `INSERT`, …) | ✅ |
+| CDS Views (VDM, custom) | ✅ |
+| EML (`READ ENTITIES`, `MODIFY ENTITIES`) | ✅ |
+| Function modules, BAPIs | ✅ |
+| RAP actions called via EML | ✅ |
+| Direct table access | ✅ |
+
+Nothing is excluded. The abap2UI5 controller is a plain ABAP class — any statement that is valid in ABAP is valid there.
+
+### Using RAP Functionality from Outside
+
+When you call EML from inside the RAP framework (e.g., from a Behavior Implementation), the framework enforces its own rules: no explicit `COMMIT WORK`, no direct database modifications, controlled side effects.
+
+abap2UI5 runs **outside** the RAP framework. This means all RAP restrictions that apply inside the framework do not apply here. You call EML freely:
+
+```abap
+READ ENTITIES OF i_salesordertp
+  ENTITY salesorder
+  ALL FIELDS WITH VALUE #( ( SalesOrder = `0000000001` ) )
+  RESULT DATA(lt_result).
+```
+
+```abap
+MODIFY ENTITIES OF i_salesordertp
+  ENTITY salesorder
+  CREATE FIELDS ( salesordertype salesorganization soldtoparty )
+  WITH VALUE #( ( %cid = `001` %data = VALUE #( ... ) ) )
+  MAPPED DATA(ls_mapped)
+  FAILED DATA(ls_failed)
+  REPORTED DATA(ls_reported).
+
+COMMIT ENTITIES BEGIN
+  RESPONSE OF i_salesordertp
+  FAILED DATA(ls_save_failed)
+  REPORTED DATA(ls_save_reported).
+COMMIT ENTITIES END.
+```
+
+The explicit `COMMIT ENTITIES` is required — and fully permitted — because you are not inside a RAP handler. The same applies to reading CDS views, calling RAP actions, or accessing draft tables directly.
+
+::: tip
+Running outside the RAP framework gives you more control: you decide when to commit, how to handle errors, and how to combine multiple business object operations in one user interaction.
+:::

--- a/docs/development/specific/xlsx.md
+++ b/docs/development/specific/xlsx.md
@@ -1,7 +1,7 @@
 ---
 outline: [2, 4]
 ---
-# XLSX
+# Spreadsheet
 
 abap2UI5 works with the XLSX APIs on your ABAP system to upload and download spreadsheets, converting between XLSX files and internal tables as needed.
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation about RAP (RESTful Application Programming Model) and its relationship with abap2UI5, while reorganizing the data access layer documentation structure for better clarity.

## Key Changes
- **New RAP documentation** (`docs/development/specific/rap.md`): Explains that RAP is a full-stack programming model while abap2UI5 is a UI rendering library, clarifies the distinction between the two, documents supported access layers (ABAP SQL, CDS Views, EML, Function modules, etc.), and explains how RAP functionality can be called from outside the RAP framework with full control over commits and error handling
- **Reorganized sidebar navigation**: Consolidated "RAP, EML" and "CDS, SQL" sections into a single "EML, CDS, SQL" section with RAP as the primary link, improving information architecture
- **Updated section labels**: Changed "XLSX" to "Spreadsheet" for better clarity in the documentation sidebar

## Notable Details
- The RAP documentation emphasizes that abap2UI5 runs **outside** the RAP framework, meaning RAP restrictions (like no explicit `COMMIT WORK`) do not apply, giving developers more control
- Includes practical code examples showing EML usage patterns within abap2UI5 controllers
- Clarifies that abap2UI5 is access-layer agnostic and works with any valid ABAP statement

https://claude.ai/code/session_0133KCCdNqKq8PpZRFR3jvfX