### PR TITLE
Reorganize documentation sidebar navigation structure

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -157,6 +157,7 @@ export default defineConfig({
               { text: "Frontend", link: "/development/events/frontend" },
               { text: "Follow-up", link: "/development/events/follow_up" },
               { text: "Navigation", link: "/development/navigation/inner_cross_app" },
+              { text: "Error", link: "/development/messages/errors" },
             ],
           },
           {
@@ -209,12 +210,11 @@ export default defineConfig({
             ],
           },
           {
-            text: "Message, Error",
+            text: "Message",
             link: "/development/messages/messages",
             collapsed: true,
             items: [
               { text: "Message", link: "/development/messages/messages" },
-              { text: "Error", link: "/development/messages/errors" },
               { text: "Logging", link: "/development/messages/logging" },
               { text: "Translation, i18n", link: "/development/translation" },
             ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -175,16 +175,16 @@ export default defineConfig({
             collapsed: true,
             items: [
               { text: "Info", link: "/development/specific/info" },
-              {
-                text: "Barcode Scanning",
-                link: "/development/specific/barcodes",
-              },
               { text: "Camera", link: "/development/specific/camera" },
               {
                 text: "Geolocation",
                 link: "/development/specific/geolocation",
               },
               { text: "Soft Keyboard", link: "/development/specific/soft_keyboard" },
+              {
+                text: "Barcode Scanning",
+                link: "/development/specific/barcodes",
+              },
               {
                 text: "Upload, Download",
                 link: "/development/specific/files",

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -153,8 +153,14 @@ export default defineConfig({
             collapsed: true,
             items: [
               { text: "Life Cycle", link: "/development/controller/life_cycle" },
-              { text: "Backend", link: "/development/events/backend" },
-              { text: "Frontend", link: "/development/events/frontend" },
+              {
+                text: "Event",
+                link: "/development/events/backend",
+                items: [
+                  { text: "Backend", link: "/development/events/backend" },
+                  { text: "Frontend", link: "/development/events/frontend" },
+                ],
+              },
               { text: "Action", link: "/development/events/follow_up" },
               { text: "App Navigation", link: "/development/navigation/inner_cross_app" },
               { text: "Error", link: "/development/messages/errors" },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -171,9 +171,10 @@ export default defineConfig({
           },
           {
             text: "Device Capabilities",
-            link: "/development/specific/barcodes",
+            link: "/development/specific/info",
             collapsed: true,
             items: [
+              { text: "Info", link: "/development/specific/info" },
               {
                 text: "Barcode Scanning",
                 link: "/development/specific/barcodes",
@@ -184,7 +185,6 @@ export default defineConfig({
                 link: "/development/specific/geolocation",
               },
               { text: "Soft Keyboard", link: "/development/specific/soft_keyboard" },
-              { text: "Frontend Info", link: "/development/specific/frontend_info" },
               {
                 text: "Upload, Download",
                 link: "/development/specific/files",

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -242,7 +242,7 @@ export default defineConfig({
               { text: "WebSocket", link: "/development/specific/websocket" },
               { text: "Logout", link: "/configuration/logout" },
               { text: "OData", link: "/development/model/odata" },
-              { text: "App State, Share, Bookmark", link: "/development/navigation/app_state" },
+              { text: "App State, Share", link: "/development/navigation/app_state" },
               {
                 text: "Utilities",
                 collapsed: false,

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -197,14 +197,14 @@ export default defineConfig({
           },
           {
             text: "Browser Interaction",
-            link: "/development/specific/focus",
+            link: "/development/specific/title",
             collapsed: true,
             items: [
+              { text: "Title", link: "/development/specific/title" },
               { text: "Focus", link: "/development/specific/focus" },
               { text: "Scrolling", link: "/development/specific/scrolling" },
-              { text: "Clipboard", link: "/development/specific/clipboard" },
-              { text: "Title", link: "/development/specific/title" },
               { text: "Timer", link: "/development/specific/timer" },
+              { text: "Clipboard", link: "/development/specific/clipboard" },
               { text: "URL Handling", link: "/development/specific/url" },
             ],
           },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -156,7 +156,7 @@ export default defineConfig({
               { text: "Backend", link: "/development/events/backend" },
               { text: "Frontend", link: "/development/events/frontend" },
               { text: "Action", link: "/development/events/follow_up" },
-              { text: "Navigation", link: "/development/navigation/inner_cross_app" },
+              { text: "App Navigation", link: "/development/navigation/inner_cross_app" },
               { text: "Error", link: "/development/messages/errors" },
             ],
           },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -216,7 +216,7 @@ export default defineConfig({
             ],
           },
           {
-            text: "Message",
+            text: "Translation, Messages",
             link: "/development/messages/messages",
             collapsed: true,
             items: [

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -155,7 +155,7 @@ export default defineConfig({
               { text: "Life Cycle", link: "/development/controller/life_cycle" },
               { text: "Backend", link: "/development/events/backend" },
               { text: "Frontend", link: "/development/events/frontend" },
-              { text: "Follow-up", link: "/development/events/follow_up" },
+              { text: "Action", link: "/development/events/follow_up" },
               { text: "Navigation", link: "/development/navigation/inner_cross_app" },
               { text: "Error", link: "/development/messages/errors" },
             ],

--- a/docs/development/specific/info.md
+++ b/docs/development/specific/info.md
@@ -1,7 +1,7 @@
 ---
 outline: [2, 4]
 ---
-# Frontend Info
+# Info
 
 abap2UI5 offers a custom control for reading all frontend information from the user's device — UI5 version and theme, browser, operating system, system type, screen dimensions, and device class (phone, tablet, desktop). This is handy whenever your ABAP logic needs to adapt to the runtime environment.
 


### PR DESCRIPTION
## Summary
Restructured the VitePress documentation sidebar configuration to improve information architecture and navigation hierarchy. This includes reorganizing development topics into more logical groupings, renaming sections for clarity, and reordering menu items.

## Key Changes
- **Controller section**: Reorganized event-related items under a new "Event" parent menu with Backend and Frontend as sub-items; renamed "Follow-up" to "Action" and "Navigation" to "App Navigation"
- **Device Capabilities section**: 
  - Changed primary link from "Barcode Scanning" to "Info"
  - Renamed "Barcode Scanning" item to "Frontend Info" → "Info"
  - Reordered items to place "Info" first, moved "Barcode Scanning" to the end
- **Browser Interaction section**: 
  - Changed primary link from "Focus" to "Title"
  - Reordered items to place "Title" first
  - Reorganized remaining items (Focus, Scrolling, Timer, Clipboard, URL Handling)
- **Messages section**: 
  - Renamed from "Message, Error" to "Translation, Messages"
  - Moved "Error" link to Controller section
  - Removed "Error" from this section's items
- **Navigation section**: Updated "App State, Share, Bookmark" label to "App State, Share"
- **Documentation file**: Renamed `frontend_info.md` to `info.md` and updated the page title from "Frontend Info" to "Info"

## Notable Details
- The reorganization maintains all existing documentation links while improving the logical grouping of related topics
- Error handling documentation is now grouped with core controller concepts rather than general messages
- Device capabilities now emphasizes general device info as the primary entry point

https://claude.ai/code/session_017TBpABD8x6dGxm2RDNMKpS