### PR TITLE
Update documentation sidebar navigation labels

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -162,8 +162,8 @@ export default defineConfig({
                 ],
               },
               { text: "Action", link: "/development/events/follow_up" },
-              { text: "App Navigation", link: "/development/navigation/inner_cross_app" },
-              { text: "Error", link: "/development/messages/errors" },
+              { text: "Navigation", link: "/development/navigation/inner_cross_app" },
+              { text: "Exception", link: "/development/messages/errors" },
             ],
           },
           {


### PR DESCRIPTION
## Summary
Updated the sidebar navigation labels in the VitePress documentation configuration to use more concise and consistent terminology.

## Changes
- Renamed "App Navigation" to "Navigation" for the inner cross-app navigation section
- Renamed "Error" to "Exception" for the error messages documentation section

These changes improve clarity and consistency in the documentation navigation structure.

https://claude.ai/code/session_015j2vwkno9FHYdbVrALztrQ