### PR TITLE
Reorganize cookbook sidebar navigation structure

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -177,32 +177,6 @@ export default defineConfig({
             ],
           },
           {
-            text: "Device Capabilities",
-            link: "/cookbook/device_capabilities/info",
-            collapsed: true,
-            items: [
-              { text: "Info", link: "/cookbook/device_capabilities/info" },
-              { text: "Camera", link: "/cookbook/device_capabilities/camera" },
-              {
-                text: "Geolocation",
-                link: "/cookbook/device_capabilities/geolocation",
-              },
-              { text: "Soft Keyboard", link: "/cookbook/device_capabilities/soft_keyboard" },
-              {
-                text: "Barcode Scanning",
-                link: "/cookbook/device_capabilities/barcode_scanning",
-              },
-              {
-                text: "Upload, Download",
-                link: "/cookbook/device_capabilities/upload_download",
-                items: [
-                  { text: "PDF", link: "/cookbook/device_capabilities/pdf" },
-                  { text: "Spreadsheet", link: "/cookbook/device_capabilities/spreadsheet" },
-                ],
-              },
-            ],
-          },
-          {
             text: "Browser Interaction",
             link: "/cookbook/browser_interaction/title",
             collapsed: true,
@@ -236,6 +210,32 @@ export default defineConfig({
               { text: "CDS", link: "/cookbook/eml_cds_sql/cds" },
               { text: "ABAP SQL", link: "/cookbook/eml_cds_sql/abap_sql" },
               { text: "Fuzzy Search", link: "/cookbook/eml_cds_sql/fuzzy_search" },
+            ],
+          },
+          {
+            text: "Device Capabilities",
+            link: "/cookbook/device_capabilities/info",
+            collapsed: true,
+            items: [
+              { text: "Info", link: "/cookbook/device_capabilities/info" },
+              { text: "Camera", link: "/cookbook/device_capabilities/camera" },
+              {
+                text: "Geolocation",
+                link: "/cookbook/device_capabilities/geolocation",
+              },
+              { text: "Soft Keyboard", link: "/cookbook/device_capabilities/soft_keyboard" },
+              {
+                text: "Barcode Scanning",
+                link: "/cookbook/device_capabilities/barcode_scanning",
+              },
+              {
+                text: "Upload, Download",
+                link: "/cookbook/device_capabilities/upload_download",
+                items: [
+                  { text: "PDF", link: "/cookbook/device_capabilities/pdf" },
+                  { text: "Spreadsheet", link: "/cookbook/device_capabilities/spreadsheet" },
+                ],
+              },
             ],
           },
           {

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -251,7 +251,6 @@ export default defineConfig({
               { text: "App State, Share", link: "/cookbook/expert_more/app_state_share" },
               {
                 text: "Utilities",
-                collapsed: false,
                 items: [
                   { text: "Value Help", link: "/cookbook/expert_more/value_help" },
                   { text: "Demo Output", link: "/cookbook/expert_more/demo_output" },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -200,18 +200,6 @@ export default defineConfig({
             ],
           },
           {
-            text: "EML, CDS, SQL",
-            link: "/cookbook/eml_cds_sql/rap",
-            collapsed: true,
-            items: [
-              { text: "RAP", link: "/cookbook/eml_cds_sql/rap" },
-              { text: "EML", link: "/cookbook/eml_cds_sql/eml" },
-              { text: "Draft Handling", link: "/cookbook/eml_cds_sql/draft_handling" },
-              { text: "CDS", link: "/cookbook/eml_cds_sql/cds" },
-              { text: "ABAP SQL", link: "/cookbook/eml_cds_sql/abap_sql" },
-            ],
-          },
-          {
             text: "Device Capabilities",
             link: "/cookbook/device_capabilities/info",
             collapsed: true,
@@ -248,6 +236,17 @@ export default defineConfig({
               { text: "Logout", link: "/configuration/logout" },
               { text: "OData", link: "/cookbook/expert_more/odata" },
               { text: "App State, Share", link: "/cookbook/expert_more/app_state_share" },
+              {
+                text: "EML, CDS, SQL",
+                link: "/cookbook/eml_cds_sql/rap",
+                items: [
+                  { text: "RAP", link: "/cookbook/eml_cds_sql/rap" },
+                  { text: "EML", link: "/cookbook/eml_cds_sql/eml" },
+                  { text: "Draft Handling", link: "/cookbook/eml_cds_sql/draft_handling" },
+                  { text: "CDS", link: "/cookbook/eml_cds_sql/cds" },
+                  { text: "ABAP SQL", link: "/cookbook/eml_cds_sql/abap_sql" },
+                ],
+              },
               {
                 text: "Utilities",
                 items: [

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -209,7 +209,6 @@ export default defineConfig({
               { text: "Draft Handling", link: "/cookbook/eml_cds_sql/draft_handling" },
               { text: "CDS", link: "/cookbook/eml_cds_sql/cds" },
               { text: "ABAP SQL", link: "/cookbook/eml_cds_sql/abap_sql" },
-              { text: "Fuzzy Search", link: "/cookbook/eml_cds_sql/fuzzy_search" },
             ],
           },
           {
@@ -255,6 +254,7 @@ export default defineConfig({
                   { text: "Value Help", link: "/cookbook/expert_more/value_help" },
                   { text: "Demo Output", link: "/cookbook/expert_more/demo_output" },
                   { text: "E-Mail", link: "/cookbook/expert_more/email" },
+                  { text: "Fuzzy Search", link: "/cookbook/eml_cds_sql/fuzzy_search" },
                 ],
               },
             ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -177,6 +177,16 @@ export default defineConfig({
             ],
           },
           {
+            text: "Translation, Messages",
+            link: "/cookbook/translation_messages/message",
+            collapsed: true,
+            items: [
+              { text: "Message", link: "/cookbook/translation_messages/message" },
+              { text: "Logging", link: "/cookbook/translation_messages/logging" },
+              { text: "Translation, i18n", link: "/cookbook/translation_messages/translation_i18n" },
+            ],
+          },
+          {
             text: "Browser Interaction",
             link: "/cookbook/browser_interaction/title",
             collapsed: true,
@@ -187,16 +197,6 @@ export default defineConfig({
               { text: "Timer", link: "/cookbook/browser_interaction/timer" },
               { text: "Clipboard", link: "/cookbook/browser_interaction/clipboard" },
               { text: "URL Handling", link: "/cookbook/browser_interaction/url_handling" },
-            ],
-          },
-          {
-            text: "Translation, Messages",
-            link: "/cookbook/translation_messages/message",
-            collapsed: true,
-            items: [
-              { text: "Message", link: "/cookbook/translation_messages/message" },
-              { text: "Logging", link: "/cookbook/translation_messages/logging" },
-              { text: "Translation, i18n", link: "/cookbook/translation_messages/translation_i18n" },
             ],
           },
           {


### PR DESCRIPTION
## Summary
Reorganized the documentation sidebar navigation to improve the logical grouping and hierarchy of cookbook sections.

## Key Changes
- Added new top-level "Translation, Messages" section with Message, Logging, and Translation/i18n subsections
- Moved "Browser Interaction" section up in the navigation order (before "Device Capabilities")
- Moved "EML, CDS, SQL" section from top-level to a nested subsection under "Expert, More"
- Reorganized "Expert, More" section to include the nested "EML, CDS, SQL" subsection
- Moved "Fuzzy Search" from the "EML, CDS, SQL" section to the "Utilities" subsection
- Removed `collapsed: false` property from "Utilities" section (using default behavior)

## Implementation Details
- The navigation hierarchy now groups related topics more intuitively with "Translation, Messages" and "Browser Interaction" appearing earlier in the cookbook
- Advanced topics like "EML, CDS, SQL" are now nested under "Expert, More" to better reflect their complexity level
- All links and paths remain unchanged; this is purely a structural reorganization

https://claude.ai/code/session_01FNaYLEvNCQsx7CGn4AhCSZ