### PR TITLE
Add Cookbook overview page and update navigation links

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -60,7 +60,7 @@ export default defineConfig({
         text: "Guide",
         items: [
           { text: "Introduction", link: "/get_started/about" },
-          { text: "Cookbook", link: "/cookbook/event_navigation/life_cycle" },
+          { text: "Cookbook", link: "/cookbook/overview" },
           { text: "Configuration", link: "/configuration/setup" },
           { text: "Advanced Topic", link: "/advanced/downporting" },
           { text: "Technical Insight", link: "/technical/concept" },
@@ -119,9 +119,10 @@ export default defineConfig({
       },
       {
         text: "Cookbook",
-        link: "/cookbook/event_navigation/life_cycle",
+        link: "/cookbook/overview",
         collapsed: true,
         items: [
+          { text: "Overview", link: "/cookbook/overview" },
           {
             text: "View",
             link: "/cookbook/view/definition",

--- a/docs/cookbook/overview.md
+++ b/docs/cookbook/overview.md
@@ -1,0 +1,41 @@
+---
+outline: [2, 4]
+---
+# Overview
+
+The Cookbook collects task-oriented recipes for everyday abap2UI5 development. Each section focuses on one area of the framework and shows the patterns you reach for most often. Use this page as a map — pick the topic that matches the problem in front of you and jump straight in.
+
+### Sections
+
+#### [View](/cookbook/view/definition)
+Build the XML view your app sends to the browser. Covers the basic view definition, nesting views inside other views, and XML templating for repeating structures.
+
+#### [Model](/cookbook/model/binding)
+Share data between ABAP and the frontend. Explains one-way and two-way binding, expressions and formatters, tables and trees, the device model, and how to deal with the model size limit.
+
+#### [Event, Navigation](/cookbook/event_navigation/life_cycle)
+Understand how a request flows through your app. Covers the lifecycle, backend and frontend events, actions, navigation between apps, and exception handling.
+
+#### [Popup, Popover](/cookbook/popup_popover/popup)
+Overlay parts of the view with dialogs and popovers — custom popups, popovers anchored to a control, and the built-in dialogs the framework ships out of the box.
+
+#### [Translation, Messages](/cookbook/translation_messages/message)
+Communicate with the user. Show message toasts and message boxes, write to the application log, and translate text with `i18n`.
+
+#### [Browser Interaction](/cookbook/browser_interaction/title)
+Reach into the browser from ABAP — set the tab title, control focus and scrolling, run timers, access the clipboard, work with the URL, and handle the soft keyboard on mobile.
+
+#### [Device Capabilities](/cookbook/device_capabilities/info)
+Read device info and use native hardware: camera, geolocation, barcode scanning, audio, and file upload/download including PDF and spreadsheet generation.
+
+#### [Beyond Basics](/cookbook/expert_more/lock)
+Advanced topics for production apps — sessions and communication (locking, statefulness, WebSocket, OData, app state), EML/CDS/SQL integration with RAP, recurring patterns and helpers, troubleshooting, and a list of obsolete features kept for reference.
+
+### How to Use This Cookbook
+
+- Each recipe stands on its own — read only the section you need.
+- Code snippets are copy-paste ready. Drop them into a class that implements `z2ui5_if_app`.
+- For full sample apps, browse the 250+ examples in the [samples repository](https://github.com/abap2UI5/samples).
+- For the API surface (`z2ui5_if_client`, `z2ui5_cl_xml_view`, …), read the source in the [main repository](https://github.com/abap2UI5/abap2UI5).
+
+→ New to abap2UI5? Start with the [Getting Started Guide](/get_started/quickstart).


### PR DESCRIPTION
## Summary
Added a new Cookbook overview page that serves as a landing point for the cookbook section, providing users with a map of all available topics and guidance on how to use the cookbook effectively.

## Key Changes
- **New file**: `docs/cookbook/overview.md` - A comprehensive overview page that:
  - Introduces the purpose of the Cookbook as a collection of task-oriented recipes
  - Lists all 8 major sections (View, Model, Event/Navigation, Popup/Popover, Translation/Messages, Browser Interaction, Device Capabilities, Beyond Basics)
  - Provides brief descriptions of what each section covers
  - Includes usage instructions and links to related resources (samples repository, main repository, Getting Started Guide)

- **Updated navigation**: Modified `docs/.vitepress/config.mjs` to:
  - Change the main "Cookbook" link in the top navigation from `/cookbook/event_navigation/life_cycle` to `/cookbook/overview`
  - Update the sidebar navigation to point to `/cookbook/overview` as the primary link
  - Add the new Overview page as the first item in the Cookbook sidebar items list

## Implementation Details
The overview page uses Vitepress frontmatter (`outline: [2, 4]`) to control the table of contents display, showing only level 2-4 headings. The page is structured to be a clear entry point that helps users navigate to the specific cookbook sections they need.

https://claude.ai/code/session_01Gx1LBQnXnsjCjX1kDhRSFZ