### PR TITLE
Rewrite nested views and XML templating documentation

### DIFF
--- a/docs/cookbook/view/nested_views.md
+++ b/docs/cookbook/view/nested_views.md
@@ -3,98 +3,200 @@ outline: [2, 4]
 ---
 # Nested Views
 
-A nested view is a view that is built from several independent parts. In abap2UI5 there are two main ways to achieve this: composing a single view tree from helper methods, and splitting the app into sub-apps that each own a slice of the view.
+A **nested view** in abap2UI5 is a separate XML view fragment that you inject into a *placeholder* inside another view. The main view stays on screen; only the nested fragment is rendered (and later re-rendered or refreshed) independently. This is the standard pattern for master-detail screens, side panels, tab content, and anywhere you want one part of the UI to update without rebuilding the whole page.
 
-#### Composing with Helper Methods
+If you know SAPUI5's [nested views](https://sapui5.hana.ondemand.com/sdk/#/topic/df8c9c3d6f2a4d728ba7d6f4cb6c6d35) (`<mvc:XMLView viewName="..."/>`), the goal is the same — split the UI into independently managed pieces. In abap2UI5 the wiring is done from ABAP at runtime: instead of referencing a static view file, you build the nested view's XML in ABAP and tell the client to plug it into a named slot.
 
-The fluent builder returns each node as an object reference, so you can pass a node into a helper method and let it add children there:
+#### The Basic Pattern
 
-```abap
-METHOD z2ui5_if_app~main.
-  IF client->check_on_init( ).
-    DATA(xml)  = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = xml->shell( )->page( 'My App' ).
+Two ingredients are needed:
 
-    build_header( page ).
-    build_content( page ).
-    build_footer( page ).
-
-    client->view_display( xml->stringify( ) ).
-  ENDIF.
-ENDMETHOD.
-
-METHOD build_header.
-  io_page->toolbar( )->title( 'Header' ).
-ENDMETHOD.
-
-METHOD build_content.
-  io_page->vbox(
-      )->text( 'Line 1'
-      )->text( 'Line 2' ).
-ENDMETHOD.
-
-METHOD build_footer.
-  io_page->footer( )->button(
-    text  = 'Save'
-    press = client->_event( 'SAVE' ) ).
-ENDMETHOD.
-```
-
-Each helper receives the parent node by reference and attaches its controls to it. The final `stringify( )` call serialises the entire tree — including all nested children — into one XML string.
-
-#### Sub-Apps
-
-For larger apps it is useful to split responsibility across separate ABAP classes. Each sub-app implements `z2ui5_if_app` and manages its own piece of the view. The parent app instantiates the sub-app, passes the client, and merges the returned view fragment into its own view tree.
-
-**Parent app:**
-```abap
-METHOD z2ui5_if_app~main.
-  IF client->check_on_init( ).
-    sub_app = NEW z2ui5_cl_my_sub_app( ).
-  ENDIF.
-
-  DATA(xml)  = z2ui5_cl_xml_view=>factory( ).
-  DATA(page) = xml->shell( )->page( 'Parent' ).
-
-  " Let the sub-app render into a container on the page
-  DATA(container) = page->vbox( ).
-  sub_app->render( client = client io_node = container ).
-
-  client->view_display( xml->stringify( ) ).
-ENDMETHOD.
-```
-
-**Sub-app:**
-```abap
-METHOD render.
-  io_node->text( 'I am the sub-app' ).
-  io_node->button(
-    text  = 'Sub Action'
-    press = io_client->_event( 'SUB_ACTION' ) ).
-ENDMETHOD.
-```
-
-The sub-app appends its controls to whatever node the parent provides. Events fired inside the sub-app are handled by the sub-app's own `main` method on the next roundtrip.
-
-#### Navigation Between Views
-
-When the nested content changes completely — for example, a detail page replacing a list — use `view_display` to swap the entire view rather than nesting:
+1. **An anchor in the main view** — any control with an `id`. The nested view will be inserted *into* this control.
+2. **A nested view + a `nest_view_display` call** — builds the fragment and ships it to the named anchor.
 
 ```abap
-CASE client->get_event( ).
-  WHEN 'OPEN_DETAIL'.
-    client->view_display( detail_view->stringify( ) ).
-  WHEN 'BACK'.
-    client->view_display( list_view->stringify( ) ).
+" 1) Main view with an anchor
+DATA(lo_view) = z2ui5_cl_xml_view=>factory( ).
+DATA(page)    = lo_view->shell(
+    )->page( title = `Main View`
+             id    = `test` ).        " <-- the anchor id
+
+page->content(
+  )->button( text  = `Re-render only the nested view`
+             press = client->_event( `NEST` ) ).
+
+" 2) Nested view, built like any other view
+DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory(
+  )->page( `Nested View`
+    )->input( client->_bind_edit( mv_input_nest )
+    )->button( text  = `event`
+               press = client->_event( `TEST` ) ).
+
+IF client->check_on_init( ).
+  client->view_display( lo_view->stringify( ) ).
+ENDIF.
+
+CASE client->get( )-event.
+  WHEN `NEST`.
+    client->nest_view_display(
+        val           = lo_view_nested->stringify( )
+        id            = `test`               " target the anchor
+        method_insert = `addContent` ).      " UI5 mutator on that control
 ENDCASE.
 ```
 
-Reserve true nesting for content that appears side-by-side or in a stable layout shell. Use `view_display` for sequential navigation where one screen fully replaces another.
+What happens at runtime: `view_display` paints the main view; the page with `id="test"` sits on screen. When the user clicks the button, `nest_view_display` ships the nested XML to the client, which calls `addContent( ... )` on the control with that id. The nested fragment appears inside the page — without re-rendering the page itself.
+
+The full pattern (re-render everything vs. main only vs. nested only) is in `Z2UI5_CL_DEMO_APP_065`.
+
+#### `nest_view_display` Parameters
+
+| Parameter        | Meaning                                                                                            |
+| ---------------- | -------------------------------------------------------------------------------------------------- |
+| `val`            | The nested view's XML, produced by `stringify( )`.                                                 |
+| `id`             | The id of the anchor control in the main view.                                                     |
+| `method_insert`  | UI5 mutator method called on the anchor to add the nested view (e.g. `addContent`).                |
+| `method_destroy` | Optional. UI5 mutator method that removes the previous nested content before inserting the new one. |
+
+`method_insert` and `method_destroy` are plain UI5 control methods — pick whichever the anchor exposes. The choice depends on the anchor's aggregation:
+
+| Anchor control          | Typical `method_insert`     | Typical `method_destroy`        |
+| ----------------------- | --------------------------- | ------------------------------- |
+| `Page`, `VBox`, generic | `addContent`                | `removeAllContent`              |
+| `FlexibleColumnLayout`  | `addMidColumnPage`          | `removeAllMidColumnPages`       |
+| `FlexibleColumnLayout`  | `addEndColumnPage`          | `removeAllEndColumnPages`       |
+| `FlexibleColumnLayout`  | `addBeginColumnPage`        | `removeAllBeginColumnPages`     |
+
+Always pass `method_destroy` when the nested view is going to be replaced over the lifetime of the app; otherwise consecutive calls stack new fragments on top of the old ones.
+
+#### Independent Re-rendering
+
+The whole point of nested views is to re-render only what changed. Three calls cover the common needs:
+
+| Call                              | What it does                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------------------- |
+| `client->view_display( ... )`     | Replaces the main view's XML. The anchor is recreated, so any nested content is lost too.    |
+| `client->nest_view_display( ... )`| Replaces only the nested view. The main view stays on screen.                                |
+| `client->nest_view_model_update( )` | Pushes current ABAP data values into the **already-rendered** nested view. No re-render.   |
+
+The matching call for the main view is `client->view_model_update( )` — push data changes into the rendered main view without re-rendering it.
+
+A rule of thumb:
+
+- **Layout changed** (different controls, new columns, new sections) → `view_display` / `nest_view_display`.
+- **Only the data changed** (a flag flipped, a row added to a bound table) → `view_model_update` / `nest_view_model_update`.
+
+`Z2UI5_CL_DEMO_APP_065` shows the difference between the three options in a single screen with one button per call.
+
+#### Master-Detail with `FlexibleColumnLayout`
+
+The most common real-world use: a master list on the left, detail content on the right. `sap.f.FlexibleColumnLayout` is the standard container; abap2UI5 nests the detail view into its middle column.
+
+```abap
+" Master view — built once
+DATA(page) = z2ui5_cl_xml_view=>factory(
+  )->page( title = `abap2UI5 - Master Detail` ).
+
+DATA(lr_master) = page->flexible_column_layout(
+                       layout = client->_bind_edit( mv_layout )
+                       id     = `test`                            " anchor
+                     )->begin_column_pages( ).
+
+lr_master->list( items = client->_bind_edit( val  = t_tab
+                                             view = client->cs_view-main )
+                 selectionchange = client->_event( `SELCHANGE` )
+  )->standard_list_item( title    = `{TITLE}`
+                         selected = `{SELECTED}` ).
+
+client->view_display( page->stringify( ) ).
+```
+
+When the user picks a row, a detail view is rendered into the middle column:
+
+```abap
+METHOD view_display_detail.
+  DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
+  DATA(page) = lo_view_nested->page( `Nested View` ).
+
+  page->ui_table( rows = client->_bind_edit( val  = t_tab2
+                                             view = client->cs_view-nested ) ).
+  " ...columns, toolbar, row actions...
+
+  client->nest_view_display(
+    val            = lo_view_nested->stringify( )
+    id             = `test`
+    method_insert  = `addMidColumnPage`
+    method_destroy = `removeAllMidColumnPages` ).
+ENDMETHOD.
+```
+
+The layout is bound editable (`mv_layout`), so events like *full-screen mode* or *close detail* simply update `mv_layout` and call `view_model_update` / `nest_view_model_update`. The FCL transitions itself; no view is rebuilt.
+
+End-to-end samples:
+
+- `Z2UI5_CL_DEMO_APP_069` — tree master, two interchangeable detail apps (`addMidColumnPage`).
+- `Z2UI5_CL_DEMO_APP_097` — list master, `sap.ui.table.Table` in the detail with sort/filter/row actions.
+- `Z2UI5_CL_DEMO_APP_085` — full master-detail with an `ObjectPageLayout` as the nested detail, including search, sort, and the FCL fullscreen toggle.
+
+#### Routing Bindings to the Right View
+
+Each view (main, nested) has its own client-side model. When you build a binding with `client->_bind( ... )` you can declare which view's model the binding belongs to via the `view` parameter:
+
+```abap
+" In the main view
+items = client->_bind_edit( val = t_tab  view = client->cs_view-main )
+
+" In the nested view
+rows  = client->_bind_edit( val = t_tab2 view = client->cs_view-nested )
+```
+
+The constants `client->cs_view-main` and `client->cs_view-nested` are abap2UI5's view identifiers. Declaring them lets `nest_view_model_update( )` know which model to refresh:
+
+```abap
+DELETE t_tab2 WHERE title = ls_arg-title.
+client->nest_view_model_update( ).   " only the nested view's data is pushed
+```
+
+If you omit `view`, the binding defaults to the main view, which still works for many cases but is less explicit. Get into the habit of passing the right `cs_view-...` value whenever a fragment is built — it makes the data flow obvious to anyone reading the code.
+
+#### Two Levels of Nesting
+
+The middle column can itself host another nested view in the end column — useful for master / detail / detail-of-detail flows. abap2UI5 exposes a second method for this level:
+
+```abap
+METHOD view_display_detail_detail.
+  DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
+  lo_view_nested->page( `Nested View`
+    )->text( client->_bind( mv_title ) ).
+
+  client->nest2_view_display(
+    val            = lo_view_nested->stringify( )
+    id             = `test`
+    method_insert  = `addEndColumnPage`
+    method_destroy = `removeAllEndColumnPages` ).
+ENDMETHOD.
+```
+
+`nest2_view_display` works exactly like `nest_view_display` but targets the second level — typically the FCL's *end* column. `Z2UI5_CL_DEMO_APP_098` walks through all three columns: a list selects a row, a row-action navigates to the end column, the layout switches to `ThreeColumnsEndExpanded`.
+
+#### When to Use Nested Views (and When Not To)
+
+| Situation                                                       | Approach                                                                              |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Different visual sections that update at different rates        | Nested views — re-render each piece on its own                                       |
+| Master-detail, FCL columns, drill-down navigation               | Nested views — the canonical use case                                                |
+| A side panel that toggles open/closed but keeps the page intact | Nested views                                                                          |
+| Building one view from helper methods (still rendered as one)   | Plain ABAP composition — pass nodes between methods, no `nest_view_display` needed   |
+| One full screen replacing another                               | `view_display` with the new view (or `nav_app_call` for a separate app)              |
+
+Plain composition is the right starting point: keep helper methods that take a parent node and add children to it. Reach for nested views once the UI has clear sub-areas that need to update independently — otherwise you pay for ceremony you don't use.
 
 #### Tips
 
-- Keep each helper or sub-app focused on one logical section. A helper that grows beyond ~30 lines is a candidate for its own sub-app class.
-- Sub-apps can hold their own instance attributes for local state. Because the whole app tree is reconstructed on every roundtrip, each sub-app re-renders from its current state automatically.
-- Pass only the node the sub-app needs, not the whole view root. This limits the sub-app's scope and makes the boundary explicit.
+- The anchor id must be unique in the main view. The framework calls `byId` on the rendered view to find it; duplicate ids break the lookup.
+- Always provide `method_destroy` when a nested slot will be replaced more than once. Forgetting it causes nested fragments to accumulate.
+- Build the nested view in its own method (e.g. `view_display_detail`) and call it both from the initial render and from event handlers. Two call sites, one definition.
+- If a nested view does not pick up a data change, you probably need `nest_view_model_update( )`; if a control simply isn't there, you need `nest_view_display( )` again.
+- For very large apps, look at `Z2UI5_CL_DEMO_APP_104`, which loads each detail screen from a separate `z2ui5_if_app` class and renders it into the nested slot. It is an advanced pattern — start with the simpler form first.
 
-See `Z2UI5_CL_DEMO_APP_160` for an end-to-end example of parent and sub-app composition.
+See `Z2UI5_CL_DEMO_APP_065`, `Z2UI5_CL_DEMO_APP_069`, `Z2UI5_CL_DEMO_APP_085`, `Z2UI5_CL_DEMO_APP_097`, `Z2UI5_CL_DEMO_APP_098`, and `Z2UI5_CL_DEMO_APP_104` for runnable examples covering every variation above.

--- a/docs/cookbook/view/xml_templating.md
+++ b/docs/cookbook/view/xml_templating.md
@@ -3,96 +3,142 @@ outline: [2, 4]
 ---
 # XML Templating
 
-abap2UI5 sends views to the browser as XML strings. XML Templating lets you construct those strings dynamically in ABAP — branching on conditions, looping over data, and composing fragments — so that the view the browser receives is already fully resolved without any client-side template engine.
+XML Templating is a **UI5 preprocessor feature**, not an abap2UI5 invention. The UI5 runtime understands a small set of instructions in the `template` XML namespace — `template:repeat`, `template:if`, `template:then`, `template:else`, `template:with` — and expands them into plain XML *before* the control tree is created. abap2UI5 exposes these instructions through the fluent builder so you can drive the expansion from ABAP data.
+
+See the official UI5 references for the underlying mechanics:
+[XML Templating](https://sapui5.hana.ondemand.com/sdk/#/topic/5ee619fc1370463ea674ee04b65ed83b),
+[`template:repeat`](https://sapui5.hana.ondemand.com/sdk/#/topic/512e545ba66f4214ba0de1eb56f319e1),
+[`template:if`](https://sapui5.hana.ondemand.com/sdk/#/topic/fc185952184c48618ef46306a1517f8c).
 
 #### How It Works
 
-Every abap2UI5 view is ultimately an XML string. You can build that string however you like: literal assignment, string concatenation, helper method calls, or a dedicated XML builder. The browser never sees template syntax — it only receives the final, rendered XML.
+Templating happens **once**, at view instantiation, against a JSON model. The preprocessor walks the XML, evaluates each `template:` instruction against that model, and replaces the instruction with the resulting XML. After that the control tree is built from the expanded XML and normal data binding takes over.
+
+This timing has two consequences:
+
+- **Expansion is build-time.** A `template:repeat` over an internal table produces a fixed number of controls; the expanded XML is what UI5 renders.
+- **Data changes do not re-template.** If the data driving the template changes, the existing expansion stays as is. To pick up the change you must rebuild the view (`view_display`) or the templated fragment (`nest_view_display`) — see [Re-rendering](#re-rendering) below.
+
+abap2UI5 wires up the templating model for you. Every variable you bind with `client->_bind( ... )` or `client->_bind_edit( ... )` is reachable inside templates via the `template>` model prefix:
+
+| ABAP binding                       | Path inside templates       |
+| ---------------------------------- | --------------------------- |
+| `client->_bind( mt_layout )`       | `{template>/MT_LAYOUT}`     |
+| `client->_bind_edit( mv_flag )`    | `{template>/XX/MV_FLAG}`    |
+
+The `template>` model is the templating engine's view of the data — distinct from the default model used by runtime bindings like `{MT_DATA}`.
+
+#### `template:repeat` — Loops
+
+`template:repeat` clones its children once per row of the bound list. Use it when the **structure** of the view (e.g. which columns a table has) depends on data:
 
 ```abap
-METHOD z2ui5_if_app~main.
-  IF client->check_on_init( ).
-    DATA(xml) = z2ui5_cl_xml_view=>factory( ).
-    client->view_display( xml->stringify( ) ).
-  ENDIF.
-ENDMETHOD.
+mt_layout = VALUE #( ( fname = `NAME` merge = `false` visible = `true`  )
+                     ( fname = `DATE` merge = `false` visible = `true`  )
+                     ( fname = `AGE`  merge = `false` visible = `false` ) ).
+client->_bind( mt_layout ).
+
+view->table( client->_bind( mt_data )
+  )->columns(
+    )->template_repeat( list = `{template>/MT_LAYOUT}`
+                        var  = `L0`
+      )->column( mergeduplicates = `{L0>MERGE}`
+                 visible         = `{L0>VISIBLE}`
+        )->text( `{L0>FNAME}` )->get_parent(
+    )->get_parent( )->get_parent(
+    )->items(
+      )->column_list_item(
+        )->cells(
+          )->template_repeat( list = `{template>/MT_LAYOUT}`
+                              var  = `L1`
+            )->object_identifier( text = `{= '{' + ${L1>FNAME} + '}' }` ).
 ```
 
-#### Conditional Rendering
+Notes on the snippet:
 
-Use ABAP `IF` statements to include or exclude controls depending on runtime state:
+- `list` is the binding path that drives the loop; `var` is the alias used inside the loop body (here `L0` for the column headers, `L1` for the cells).
+- Inside the loop, `{L0>FNAME}` is a templating-time read — it ends up as the literal string `NAME`/`DATE`/`AGE` in the expanded XML.
+- `{= '{' + ${L1>FNAME} + '}' }` is an [expression binding](https://sapui5.hana.ondemand.com/sdk/#/topic/daf6852a04b44d118963968a1239d2c0) that **constructs another binding string at templating time**. With `L1>FNAME = NAME` it expands to `text="{NAME}"`, which becomes a normal runtime binding against the row of `mt_data`. This is the standard pattern for templated tables: outer loop builds the columns, inner loop builds the cells, expression binding wires each cell to the right field of the row.
+- `template_repeat` accepts the same optional attributes as the UI5 instruction (`startIndex`, `length`) plus list-binding extras like sorters and filters.
+
+The full sample is `Z2UI5_CL_DEMO_APP_173`.
+
+#### `template:if` / `template:then` / `template:else` — Conditionals
+
+`template:if` evaluates an expression against the templating model and keeps or drops its children accordingly. With a `template:then` / `template:else` pair you get a two-branch switch:
 
 ```abap
-DATA(xml) = z2ui5_cl_xml_view=>factory( ).
-DATA(page) = xml->page( 'Conditional View' ).
+client->_bind_edit( mv_flag ).
 
-IF is_admin = abap_true.
-  page->button(
-    text  = 'Admin Action'
-    press = client->_event( 'ADMIN_ACTION' ) ).
-ENDIF.
-
-page->text( 'Hello, ' && username ).
-client->view_display( xml->stringify( ) ).
+view->template_if( `{template>/XX/MV_FLAG}`
+  )->template_then(
+    )->icon( src   = `sap-icon://accept`
+             color = `green` )->get_parent(
+  )->template_else(
+    )->icon( src   = `sap-icon://decline`
+             color = `red` ).
 ```
 
-Only the controls added to the builder are serialized — nothing from the skipped branch appears in the XML.
+The test argument follows the same rules as in UI5: any binding expression is fine, and the string `"false"` is treated as boolean `false` (a UI5 convenience). For richer conditions use expression binding, e.g. `` `{= ${template>/XX/MV_COUNT} > 0 }` ``.
 
-#### Repeating Controls
+`template:elseif` is also supported by UI5; check `Z2UI5_CL_XML_VIEW` for the corresponding fluent method or fall back to the generic builder (see [Definition](/cookbook/view/definition#the-fully-generic-builder)).
 
-Loop over an internal table to generate repeated controls:
+#### Re-rendering
+
+Because templating runs once, the view must be rebuilt for changes in the templating model to take effect. There are two strategies:
+
+**Rebuild the whole view** — simplest, works for most apps. After the user toggles a flag, render the view again:
 
 ```abap
-DATA(list) = page->list( ).
-
-LOOP AT items INTO DATA(item).
-  list->item(
-    title       = item-title
-    description = item-description ).
-ENDLOOP.
+CASE client->get( )-event.
+  WHEN `CHANGE_FLAG`.
+    view_display( ).   " builds and ships the view again
+ENDCASE.
 ```
 
-Each iteration appends a child node. The resulting XML contains exactly as many `<Item>` elements as there were rows in `items`.
+This is the pattern used in `Z2UI5_CL_DEMO_APP_173`: the switch fires `CHANGE_FLAG`, `view_display` runs, the new value of `mv_flag` flows through `template:if`, and the icon swaps.
 
-#### Composing Fragments
-
-Break complex views into reusable helper methods that each return a subtree:
+**Rebuild only the templated fragment** — keeps a stable shell on screen and replaces a nested piece. `Z2UI5_CL_DEMO_APP_176` separates the main view from the templated table:
 
 ```abap
-METHOD build_header.
-  rv_header = io_page->toolbar( )->title( title ).
-ENDMETHOD.
+" Main view: built once, stays on screen
+DATA(lo_view) = z2ui5_cl_xml_view=>factory( ).
+lo_view->shell( )->page( title = `Main View` id = `test` ... ).
+client->view_display( lo_view->stringify( ) ).
 
-METHOD build_table.
-  DATA(tbl) = io_page->table( ).
-  " ... add columns and rows
-  rv_table = tbl.
-ENDMETHOD.
+" Nested templated view: inserted into the main view by id
+DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
+lo_view_nested->shell( )->page( `Nested View`
+  )->table( client->_bind( mt_data )
+  )->columns(
+    )->template_repeat( list = `{template>/MT_LAYOUT}` var = `LO`
+      )->column( ... ) " ...
+
+client->nest_view_display( val           = lo_view_nested->stringify( )
+                           id            = `test`
+                           method_insert = `addContent` ).
 ```
 
-Call the helpers in sequence inside `main` to assemble the final view. Because the builder accumulates children as regular ABAP object references, standard ABAP patterns (loops, conditions, method calls, function modules) all apply without restriction.
+`nest_view_display` targets a control in the existing view by id (`test`) and appends/replaces the nested view there. To refresh the templated piece on a data change, call `nest_view_display` again from the event handler — the main view is left untouched.
 
-#### Dynamic Column Sets
+#### Templating vs ABAP-side Composition
 
-A common pattern is selecting which columns to show based on user settings or authorization:
+The two demo apps both build *dynamic* views, but with different mechanics. Pick based on what the dynamic part actually is:
 
-```abap
-DATA(cols) = xml->table( )->columns( ).
+| Situation                                                            | Approach                                                                             |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Whether a control exists at all, decided once per render             | ABAP `IF` around the builder call — simpler, no `template:` namespace involved       |
+| Number of controls comes from an internal table, computed once       | ABAP `LOOP` over the table, calling the builder for each row                         |
+| Reusable XML fragment that UI5 itself should expand against metadata | `template:repeat` / `template:if` — keeps the templating logic in the view layer     |
+| Cells of a table where the column set itself is data-driven          | `template:repeat` — UI5 expands columns and cell bindings in one pass, as in app 173 |
 
-IF show_price = abap_true.
-  cols->column( )->text( 'Price' ).
-ENDIF.
-IF show_stock = abap_true.
-  cols->column( )->text( 'Stock' ).
-ENDIF.
-```
-
-The same loop that drives the column headers can drive the cell binding paths, keeping them in sync.
+Plain ABAP control flow covers most cases and is easier to debug. Reach for `template:` when you want the expansion to live in the view (closer to standard UI5 patterns) or when you are mapping a metadata-style structure onto controls.
 
 #### Tips
 
-- Build the full view on every roundtrip. abap2UI5 is stateless by default, so the view is always reconstructed from the current model state — there is no diff or patch step.
-- Keep view-construction logic out of business-logic methods. A dedicated `build_view` method or a set of small fragment builders keeps `main` readable.
-- Prefer the fluent builder API (`z2ui5_cl_xml_view`) over raw string concatenation. The builder escapes special characters automatically and produces well-formed XML.
+- Always bind the data that drives a template (`client->_bind` / `client->_bind_edit`) **before** the builder call that references it. The binding registers the path that `{template>/...}` resolves against.
+- Inside `template:repeat`, prefer `{var>FIELD}` over deeper paths — it keeps the body readable and lets you nest repeats with distinct `var` names (`L0`, `L1`, ...) without collisions.
+- Use expression binding (`{= ... }`) when the value you need is a binding string itself. Templating-time expressions can read `${var>...}` and concatenate strings, which is how dynamic cell bindings are assembled.
+- If a templated control does not update after a data change, you forgot to rebuild — call `view_display` or `nest_view_display` again.
 
-See `Z2UI5_CL_DEMO_APP_032` and `Z2UI5_CL_DEMO_APP_033` for complete examples of conditional and dynamic views.
+See `Z2UI5_CL_DEMO_APP_173` for `template:repeat` + `template:if` in a single view and `Z2UI5_CL_DEMO_APP_176` for the stable-shell / templated-nested-view pattern.


### PR DESCRIPTION
## Summary

Completely rewrote the documentation for nested views and XML templating to provide clearer, more practical guidance with real-world examples and decision trees.

## Key Changes

### Nested Views (`docs/cookbook/view/nested_views.md`)
- **Replaced conceptual overview with concrete pattern**: Changed from abstract discussion of "helper methods" and "sub-apps" to a clear two-ingredient pattern (anchor + `nest_view_display` call) with working code examples
- **Added comprehensive API reference**: Documented `nest_view_display` parameters, method signatures for different anchor controls (Page, VBox, FlexibleColumnLayout), and the three re-rendering strategies (`view_display`, `nest_view_display`, `nest_view_model_update`)
- **Introduced master-detail as primary use case**: Replaced generic sub-app pattern with `FlexibleColumnLayout` as the canonical example, showing how to build a list master and detail view
- **Added two-level nesting support**: Documented `nest2_view_display` for end-column navigation in three-column layouts
- **Included decision table**: Added "When to Use Nested Views" table to help developers choose between nested views, plain composition, and full view replacement
- **Expanded tips and examples**: Replaced generic advice with specific gotchas (duplicate ids, missing `method_destroy`, data binding routing) and references to 6 demo apps covering different patterns

### XML Templating (`docs/cookbook/view/xml_templating.md`)
- **Clarified templating as UI5 preprocessor feature**: Opened with explicit statement that this is a UI5 feature, not abap2UI5-specific, with links to official UI5 documentation
- **Explained timing and consequences**: Added section on how templating runs once at view instantiation and why data changes require rebuilding
- **Documented the templating model**: Explained how `client->_bind()` variables become accessible via `{template>/...}` paths, distinct from runtime bindings
- **Replaced generic examples with realistic patterns**: 
  - `template:repeat` now shows the standard pattern for dynamic table columns (outer loop for columns, inner loop for cells, expression binding to wire cells to row fields)
  - `template:if/then/else` shows icon-swapping example with proper expression binding syntax
- **Added re-rendering strategies**: Documented two approaches (rebuild whole view vs. rebuild templated fragment in nested slot) with code examples and demo app references
- **Introduced decision table**: Added "Templating vs ABAP-side Composition" table to help developers choose between ABAP control flow and `template:` instructions
- **Updated tips**: Replaced generic advice with specific guidance on binding order, variable naming in nested repeats, expression binding for dynamic cell bindings, and debugging strategies

## Notable Implementation Details

- Both documents now follow a consistent structure: brief intro → core pattern with code → API/parameter reference → real-world examples → decision guidance → tips
- Replaced abstract "sub-app" pattern with concrete `FlexibleColumnLayout` master-detail, which is the actual common use case
- Added explicit references to 8 demo apps (`Z2UI5_CL_DEMO_APP_065`, `069`, `085`, `097`, `098`, `104`, `173`, `176`) that readers can run to see each pattern in action
- Clarified the distinction between templating-time expansion (`{template>/...}`) and runtime binding (`{FIELD}`) to reduce confusion
- Emphasized that both features require rebuilding the view for data changes to take effect, with clear guidance on which rebuild method to use

https://claude.ai/code/session_01G4ekN8QsSQDhsXN8Hdjkbk