### PR TITLE
Add set_title_launchpad event for SAP Fiori Launchpad shell

### DIFF
--- a/docs/cookbook/browser_interaction/title.md
+++ b/docs/cookbook/browser_interaction/title.md
@@ -34,4 +34,12 @@ METHOD z2ui5_if_app~main.
 
 #### Launchpad
 
-Inside an SAP Fiori Launchpad shell the title is forwarded to the `ShellUIService`; standalone the framework falls back to `document.title`.
+When the app runs inside an SAP Fiori Launchpad shell, use the dedicated `set_title_launchpad` event instead. It forwards the title to the shell's `ShellUIService` rather than setting `document.title`:
+
+```abap
+client->action(
+    val   = client->cs_event-set_title_launchpad
+    t_arg = VALUE #( ( `Invoice 4711` ) ) ).
+```
+
+Use `set_title` for the browser tab/window title (standalone) and `set_title_launchpad` for the launchpad shell title.

--- a/docs/cookbook/event_navigation/frontend.md
+++ b/docs/cookbook/event_navigation/frontend.md
@@ -27,6 +27,7 @@ The following frontend events are available:
       download_b64_file         TYPE string VALUE `DOWNLOAD_B64_FILE`,
       set_size_limit            TYPE string VALUE `SET_SIZE_LIMIT`,
       set_title                 TYPE string VALUE `SET_TITLE`,
+      set_title_launchpad       TYPE string VALUE `SET_TITLE_LAUNCHPAD`,
       set_focus                 TYPE string VALUE `SET_FOCUS`,
       scroll_to                 TYPE string VALUE `SCROLL_TO`,
       scroll_into_view          TYPE string VALUE `SCROLL_INTO_VIEW`,

--- a/docs/cookbook/expert_more/custom_controls.md
+++ b/docs/cookbook/expert_more/custom_controls.md
@@ -15,6 +15,7 @@ The table below lists custom controls that are no longer necessary and the built
 | Old Custom Control Purpose | New Built-in Action          | Documentation                                                              |
 | -------------------------- | ---------------------------- | -------------------------------------------------------------------------- |
 | Set the browser tab title  | `cs_event-set_title`         | [Title](/cookbook/browser_interaction/title)                               |
+| Set the launchpad title    | `cs_event-set_title_launchpad` | [Title](/cookbook/browser_interaction/title)                             |
 | Move input focus           | `cs_event-set_focus`         | [Focus](/cookbook/browser_interaction/focus)                               |
 | Scroll to a position       | `cs_event-scroll_to`         | [Scrolling](/cookbook/browser_interaction/scrolling)                       |
 | Scroll an element into view| `cs_event-scroll_into_view`  | [Scrolling](/cookbook/browser_interaction/scrolling)                       |


### PR DESCRIPTION
## Summary
This PR introduces a new `set_title_launchpad` frontend event that allows apps running inside an SAP Fiori Launchpad shell to set the launchpad title separately from the browser tab title.

## Key Changes
- Added `set_title_launchpad` event to the frontend events list in the event navigation documentation
- Updated the title cookbook documentation with:
  - Clear guidance on when to use `set_title` vs `set_title_launchpad`
  - Code example showing how to invoke `set_title_launchpad` with the `ShellUIService`
  - Explanation that `set_title_launchpad` forwards to the shell's `ShellUIService` instead of `document.title`
- Updated the custom controls deprecation table to reference the new `set_title_launchpad` event

## Implementation Details
- The new event provides a dedicated mechanism for launchpad-aware title management, replacing the need for custom controls
- `set_title` continues to handle browser tab/window titles in standalone mode
- `set_title_launchpad` is specifically for apps running within an SAP Fiori Launchpad shell environment

https://claude.ai/code/session_01B32aq8HwaTFjzeQMomHsHg