### PR TITLE
Add documentation for detecting OpenUI5 vs SAPUI5 distribution

### DIFF
--- a/docs/cookbook/device_capabilities/info.md
+++ b/docs/cookbook/device_capabilities/info.md
@@ -22,6 +22,29 @@ DATA(gav)             = ui5-gav.               " group, artifact, version
 DATA(theme)           = ui5-theme.             " e.g. `sap_horizon`
 ```
 
+##### OpenUI5 or SAPUI5
+
+The `gav` (group–artifact–version) field tells you which UI5 [distribution](../../configuration/ui5_versions.md) is loaded: SAPUI5 ships the `com.sap.ui5` modules, OpenUI5 does not. Checking whether `gav` contains `com.sap.ui5` is the same logic the framework itself uses internally to detect the distribution. No custom control and no extra roundtrip are needed — the info is part of every request, so it already works in `check_on_init( )`:
+
+```abap
+IF client->check_on_init( ).
+
+  DATA(ui5) = client->get( )-s_ui5.
+
+  DATA(text) = COND string(
+    WHEN ui5-gav IS INITIAL          THEN |UI5 distribution unknown ({ ui5-version })|
+    WHEN ui5-gav CS `com.sap.ui5`    THEN |SAPUI5 is running ({ ui5-version })|
+    ELSE                                  |OpenUI5 is running ({ ui5-version })| ).
+
+  client->message_box_display( text ).
+
+ENDIF.
+```
+
+::: tip
+`VersionInfo.load()` can fail on the frontend, leaving `gav` empty. Treat an initial `gav` as *unknown* rather than assuming OpenUI5 — hence the explicit `IS INITIAL` check above.
+:::
+
 #### Focus
 
 For reading the current focus via `client->get( )-s_focus`, see [Focus](../browser_interaction/focus.md).


### PR DESCRIPTION
## Summary
Added comprehensive documentation explaining how to detect whether OpenUI5 or SAPUI5 is running in a UI5 device capabilities context.

## Key Changes
- Added new "OpenUI5 or SAPUI5" subsection under device capabilities documentation
- Documented the `gav` (group–artifact–version) field as the reliable indicator for distribution detection
- Provided a practical code example showing how to check the distribution using `com.sap.ui5` module presence
- Included a tip warning about handling cases where `VersionInfo.load()` fails on the frontend, resulting in an empty `gav` field
- Clarified that this detection method works without custom controls or extra roundtrips, and is available during `check_on_init()`

## Implementation Details
The documentation explains that:
- SAPUI5 ships `com.sap.ui5` modules while OpenUI5 does not
- The framework uses the same `gav` field internally for distribution detection
- The `gav` information is available in every request, making it suitable for early initialization checks
- An initial/empty `gav` should be treated as "unknown" rather than assuming OpenUI5

https://claude.ai/code/session_01EKqL1FyyG9P1uepj7ijwpm