### PR TITLE
Document check_on_navigated lifecycle behavior for sub-app returns

### DIFF
--- a/docs/cookbook/event_navigation/life_cycle.md
+++ b/docs/cookbook/event_navigation/life_cycle.md
@@ -62,6 +62,35 @@ abap2UI5 does not re-render the view automatically. After an event, if you do **
 
 Call `view_display( )` again only when the **structure** of the view needs to change: different controls, different bindings, a new dialog, navigation to a different screen. Rebuilding and re-sending the view on every event is wasteful and can cause visible flicker, lost scroll position, and lost focus.
 
+### Returning From a Sub-App Hits `check_on_navigated`, Not `check_on_init`
+`check_on_init( )` is `abap_true` **exactly once** — on the very first call of an app instance. It does *not* fire again when control comes back to the app after a `nav_app_call( )` (a popup or a fullscreen sub-app) is closed with `nav_app_leave( )`. That return is signalled by `check_on_navigated( )`.
+
+This trips up apps that build their view only under `check_on_init`:
+
+```abap
+" WRONG — screen is blank after returning from the sub-app
+CASE abap_true.
+  WHEN client->check_on_init( ).
+    render_main( ).                 " runs only the first time
+  WHEN client->check_on_event( `OPEN_POPUP` ).
+    client->nav_app_call( ... ).
+ENDCASE.
+```
+
+When the sub-app is left, `main` runs again, but neither `check_on_init` nor any event matches, so `view_display( )` is never called and the user is left looking at a stale or empty screen. Render from the navigation-return branch as well — `check_on_navigated( )` fires both on the first display *and* on every return, so reacting to it alone is usually enough:
+
+```abap
+" CORRECT — the view is rebuilt on first display and on every return
+CASE abap_true.
+  WHEN client->check_on_navigated( ).
+    render_main( ).
+  WHEN client->check_on_event( `OPEN_POPUP` ).
+    client->nav_app_call( ... ).
+ENDCASE.
+```
+
+Reserve `check_on_init` for one-time setup that must *not* repeat on return (loading initial data, setting defaults). As a rule of thumb: anything needed to **show the screen** belongs in a branch that also fires on navigation return.
+
 ### `check_on_event` Fires Once Per Roundtrip
 Every HTTP request carries at most one event. `check_on_event( )` returns `abap_true` exactly once per call to `main`, for that single event. If the user clicks two buttons in quick succession, the framework dispatches them as two independent `main` invocations — they are never batched into one request.
 


### PR DESCRIPTION
## Summary
Added comprehensive documentation explaining the distinction between `check_on_init` and `check_on_navigated` lifecycle methods, with a focus on correct handling when returning from sub-apps opened via `nav_app_call()`.

## Changes
- Added new subsection "Returning From a Sub-App Hits `check_on_navigated`, Not `check_on_init`" to the lifecycle documentation
- Included a detailed explanation of when each lifecycle method fires:
  - `check_on_init()` fires exactly once on first app instance creation
  - `check_on_navigated()` fires on first display AND on every return from a sub-app
- Provided a concrete "WRONG" code example showing the common pitfall of rendering only in `check_on_init`, which leaves a blank screen after returning from a sub-app
- Provided the corrected "CORRECT" code example using `check_on_navigated()` for view rendering
- Added guidance on proper separation of concerns: use `check_on_init` for one-time setup (data loading, defaults) and `check_on_navigated` for anything needed to display the screen

## Details
This documentation addresses a common source of confusion where developers build their view only under `check_on_init`, causing the screen to appear blank or stale when returning from a sub-app because `view_display()` is never called on the return path.

https://claude.ai/code/session_012oryGkLfKNTLkqAmvEwSSF