### PR TITLE
Reorganize UI5 version documentation and add runtime reading guide

### DIFF
--- a/docs/configuration/ui5_versions.md
+++ b/docs/configuration/ui5_versions.md
@@ -15,5 +15,44 @@ UI5 (SAPUI5) is the default version and ships with every ABAP system from a cert
 ### UI5 2.x
 UI5 2.x is the newest version of UI5, with deprecated APIs removed. We test abap2UI5 against this release on every change to stay compatible with upcoming releases.
 
+### Legacy-Free
+A dedicated frontend variant based on OpenUI5's legacy-free distribution removes deprecated features such as jQuery dependencies and synchronous APIs, providing a preview of the UI5 2.x API surface. For details, see [UI5 Legacy-Free](../advanced/legacy_free.md).
+
 ### Release-Specific
 Some controls and properties are only available on specific UI5 releases. The abap2UI5 framework and its samples support many UI5 versions, reducing compatibility issues. But when building your own apps, check compatibility with the UI5 version your system uses.
+
+## Reading the UI5 Version at Runtime
+abap2UI5 ships the current frontend state with every roundtrip. Read it from `client->get( )` — no custom control, no extra event needed.
+
+`client->get( )-s_ui5` returns the runtime UI5 framework details — handy for version-dependent branching or for logging which build a user runs on.
+
+```abap
+DATA(ui5) = client->get( )-s_ui5.
+
+DATA(version)         = ui5-version.           " e.g. `1.141.0`
+DATA(build_timestamp) = ui5-build_timestamp.
+DATA(gav)             = ui5-gav.               " group, artifact, version
+DATA(theme)           = ui5-theme.             " e.g. `sap_horizon`
+```
+
+### OpenUI5 or SAPUI5
+The `gav` (group–artifact–version) field tells you which UI5 distribution is loaded: SAPUI5 ships the `com.sap.ui5` modules, OpenUI5 does not. Checking whether `gav` contains `com.sap.ui5` is the same logic the framework itself uses internally to detect the distribution. No custom control and no extra roundtrip are needed — the info is part of every request, so it already works in `check_on_init( )`:
+
+```abap
+IF client->check_on_init( ).
+
+  DATA(ui5) = client->get( )-s_ui5.
+
+  DATA(text) = COND string(
+    WHEN ui5-gav IS INITIAL          THEN |UI5 distribution unknown ({ ui5-version })|
+    WHEN ui5-gav CS `com.sap.ui5`    THEN |SAPUI5 is running ({ ui5-version })|
+    ELSE                                  |OpenUI5 is running ({ ui5-version })| ).
+
+  client->message_box_display( text ).
+
+ENDIF.
+```
+
+::: tip
+`VersionInfo.load()` can fail on the frontend, leaving `gav` empty. Treat an initial `gav` as *unknown* rather than assuming OpenUI5 — hence the explicit `IS INITIAL` check above.
+:::

--- a/docs/cookbook/device_capabilities/info.md
+++ b/docs/cookbook/device_capabilities/info.md
@@ -11,39 +11,7 @@ For reading device information via `client->get( )-s_device`, see [Device Model]
 
 #### UI5
 
-`client->get( )-s_ui5` returns the runtime UI5 framework details — handy for version-dependent branching or for logging which build a user runs on.
-
-```abap
-DATA(ui5) = client->get( )-s_ui5.
-
-DATA(version)         = ui5-version.           " e.g. `1.141.0`
-DATA(build_timestamp) = ui5-build_timestamp.
-DATA(gav)             = ui5-gav.               " group, artifact, version
-DATA(theme)           = ui5-theme.             " e.g. `sap_horizon`
-```
-
-##### OpenUI5 or SAPUI5
-
-The `gav` (group–artifact–version) field tells you which UI5 [distribution](../../configuration/ui5_versions.md) is loaded: SAPUI5 ships the `com.sap.ui5` modules, OpenUI5 does not. Checking whether `gav` contains `com.sap.ui5` is the same logic the framework itself uses internally to detect the distribution. No custom control and no extra roundtrip are needed — the info is part of every request, so it already works in `check_on_init( )`:
-
-```abap
-IF client->check_on_init( ).
-
-  DATA(ui5) = client->get( )-s_ui5.
-
-  DATA(text) = COND string(
-    WHEN ui5-gav IS INITIAL          THEN |UI5 distribution unknown ({ ui5-version })|
-    WHEN ui5-gav CS `com.sap.ui5`    THEN |SAPUI5 is running ({ ui5-version })|
-    ELSE                                  |OpenUI5 is running ({ ui5-version })| ).
-
-  client->message_box_display( text ).
-
-ENDIF.
-```
-
-::: tip
-`VersionInfo.load()` can fail on the frontend, leaving `gav` empty. Treat an initial `gav` as *unknown* rather than assuming OpenUI5 — hence the explicit `IS INITIAL` check above.
-:::
+For reading the runtime UI5 framework details via `client->get( )-s_ui5`, see [UI5 Versions](../../configuration/ui5_versions.md).
 
 #### Focus
 


### PR DESCRIPTION
## Summary
This PR reorganizes UI5 version documentation by moving detailed runtime UI5 reading instructions from the device capabilities cookbook to the configuration guide, making it more discoverable and better organized.

## Key Changes
- **Moved UI5 runtime reading documentation** from `docs/cookbook/device_capabilities/info.md` to `docs/configuration/ui5_versions.md` under a new "Reading the UI5 Version at Runtime" section
- **Added Legacy-Free section** to the UI5 versions configuration page with a reference to the advanced documentation
- **Added comprehensive examples** showing how to:
  - Access UI5 framework details via `client->get( )-s_ui5`
  - Detect SAPUI5 vs OpenUI5 distributions using the `gav` field
  - Implement version-dependent branching in `check_on_init( )`
- **Updated device capabilities page** with a brief reference link to the moved content instead of duplicating the full documentation
- **Added tip section** explaining the edge case where `VersionInfo.load()` can fail on the frontend

## Implementation Details
- The moved content includes code examples for reading `version`, `build_timestamp`, `gav`, and `theme` fields
- Includes practical guidance on detecting UI5 distributions and handling unknown states
- Maintains all original code examples and explanatory text with improved context in the configuration section

https://claude.ai/code/session_01U47cGvXxxxpaTxc9n2c2f2