### PR TITLE
Update documentation: Replace client->action() with client->action->gen()

### DIFF
--- a/docs/cookbook/browser_interaction/clipboard.md
+++ b/docs/cookbook/browser_interaction/clipboard.md
@@ -31,7 +31,7 @@ CLASS z2ui5_cl_sample_clipboard IMPLEMENTATION.
             )->stringify( ) ).
 
       WHEN client->check_on_event( `COPY` ).
-        client->action(
+        client->action->gen(
             val   = client->cs_event-clipboard_copy
             t_arg = VALUE #( ( mv_text ) ) ).
         client->message_toast_display( `copied` ).

--- a/docs/cookbook/browser_interaction/focus.md
+++ b/docs/cookbook/browser_interaction/focus.md
@@ -25,7 +25,7 @@ This is useful for guided data entry, barcode scanning, or any flow where the ne
 
 #### Basic Usage
 
-After processing an event, call `client->action( )` with `cs_event-set_focus` and the id of the input to focus next:
+After processing an event, call `client->action->gen( )` with `cs_event-set_focus` and the id of the input to focus next:
 
 ```abap
 METHOD z2ui5_if_app~main.
@@ -45,11 +45,11 @@ METHOD z2ui5_if_app~main.
       client->view_display( page->stringify( ) ).
 
     ELSEIF client->check_on_event( `ONE_ENTER` ).
-        client->action( val   = client->cs_event-set_focus
+        client->action->gen( val   = client->cs_event-set_focus
                         t_arg = VALUE #( ( `id2` ) ) ).
 
     ELSEIF client->check_on_event( `TWO_ENTER` ).
-        client->action( val   = client->cs_event-set_focus
+        client->action->gen( val   = client->cs_event-set_focus
                         t_arg = VALUE #( ( `id1` ) ) ).
 
     ENDIF.
@@ -64,7 +64,7 @@ After the user presses Enter in `id1`, the backend fires `set_focus` for `id2` a
 To position the caret inside the field or pre-select a range, pass the start and end offsets as additional arguments:
 
 ```abap
-client->action( val   = client->cs_event-set_focus
+client->action->gen( val   = client->cs_event-set_focus
                 t_arg = VALUE #( ( `id1` ) ( `0` ) ( `5` ) ) ).
 ```
 

--- a/docs/cookbook/browser_interaction/scrolling.md
+++ b/docs/cookbook/browser_interaction/scrolling.md
@@ -52,10 +52,10 @@ CLASS z2ui5_cl_sample_scrolling IMPLEMENTATION.
 
     CASE client->get( )-event.
       WHEN `SCROLL_TOP`.
-        client->action( val   = client->cs_event-scroll_to
+        client->action->gen( val   = client->cs_event-scroll_to
                         t_arg = VALUE #( ( `id_page` ) ( `0` ) ) ).
       WHEN `SCROLL_BOTTOM`.
-        client->action( val   = client->cs_event-scroll_to
+        client->action->gen( val   = client->cs_event-scroll_to
                         t_arg = VALUE #( ( `id_page` ) ( `99999` ) ) ).
     ENDCASE.
 
@@ -66,7 +66,7 @@ ENDCLASS.
 The arguments for `scroll_to` are `id`, `scrollTop` (y, px), `scrollLeft` (x, px, optional), and `behavior` (optional):
 
 ```abap
-client->action( val   = client->cs_event-scroll_to
+client->action->gen( val   = client->cs_event-scroll_to
                 t_arg = VALUE #( ( `id_page` ) ( `500` ) ( `0` ) ( `smooth` ) ) ).
 ```
 
@@ -75,13 +75,13 @@ client->action( val   = client->cs_event-scroll_to
 To reveal a specific control — e.g. a row after a search — use `scroll_into_view` with the target control's id:
 
 ```abap
-client->action( val   = client->cs_event-scroll_into_view
+client->action->gen( val   = client->cs_event-scroll_into_view
                 t_arg = VALUE #( ( `id_row_42` ) ) ).
 ```
 
 Additional optional arguments mirror the browser's `scrollIntoView` options: `behavior` (`smooth` | `auto` | `instant`), `block` (`start` | `center` | `end` | `nearest`), `inline` (`nearest` | `start` | `center` | `end`):
 
 ```abap
-client->action( val   = client->cs_event-scroll_into_view
+client->action->gen( val   = client->cs_event-scroll_into_view
                 t_arg = VALUE #( ( `id_row_42` ) ( `smooth` ) ( `center` ) ) ).
 ```

--- a/docs/cookbook/browser_interaction/soft_keyboard.md
+++ b/docs/cookbook/browser_interaction/soft_keyboard.md
@@ -36,7 +36,7 @@ METHOD z2ui5_if_app~main.
 
     CASE client->get( )-event.
       WHEN `CALL_KEYBOARD`.
-        client->action( val   = client->cs_event-keyboard_set_mode
+        client->action->gen( val   = client->cs_event-keyboard_set_mode
                         t_arg = VALUE #( ( `ZINPUT` ) ( `none` ) ) ).
       WHEN `BACK`.
         client->nav_app_leave( ).

--- a/docs/cookbook/browser_interaction/timer.md
+++ b/docs/cookbook/browser_interaction/timer.md
@@ -8,7 +8,7 @@ Fire a backend event after a delay with the `start_timer` frontend event. Handy 
 Pass the event name to fire and the delay in milliseconds:
 
 ```abap
-client->action(
+client->action->gen(
     val   = client->cs_event-start_timer
     t_arg = VALUE #( ( `REFRESH` ) ( `2000` ) ) ).
 ```
@@ -38,13 +38,13 @@ CLASS z2ui5_cl_sample_timer IMPLEMENTATION.
             )->page( `abap2UI5 - Timer`
                 )->text( client->_bind( counter )
             )->stringify( ) ).
-        client->action( val   = client->cs_event-start_timer
+        client->action->gen( val   = client->cs_event-start_timer
                         t_arg = VALUE #( ( `TICK` ) ( `2000` ) ) ).
 
       WHEN client->check_on_event( `TICK` ).
         counter = counter + 1.
         client->view_model_update( ).
-        client->action( val   = client->cs_event-start_timer
+        client->action->gen( val   = client->cs_event-start_timer
                         t_arg = VALUE #( ( `TICK` ) ( `2000` ) ) ).
 
     ENDCASE.
@@ -61,11 +61,11 @@ A single `start_timer` call fires once — perfect for a deferred action like op
 
 ```abap
 WHEN client->check_on_event( `BUTTON_OPEN_NEW_TAB` ).
-  client->action( val   = client->cs_event-start_timer
+  client->action->gen( val   = client->cs_event-start_timer
                   t_arg = VALUE #( ( `FIRE_OPEN_TAB` ) ( `500` ) ) ).
 
 WHEN client->check_on_event( `FIRE_OPEN_TAB` ).
-  client->action( val   = client->cs_event-open_new_tab
+  client->action->gen( val   = client->cs_event-open_new_tab
                   t_arg = VALUE #( ( `https://www.google.com/search?q=abap2ui5` ) ) ).
 ```
 

--- a/docs/cookbook/browser_interaction/title.md
+++ b/docs/cookbook/browser_interaction/title.md
@@ -23,7 +23,7 @@ METHOD z2ui5_if_app~main.
             )->stringify( ) ).
 
       WHEN client->check_on_event( `RENAME` ).
-        client->action(
+        client->action->gen(
             val   = client->cs_event-set_title
             t_arg = VALUE #( ( `Invoice 4711` ) ) ).
 
@@ -37,7 +37,7 @@ METHOD z2ui5_if_app~main.
 When the app runs inside an SAP Fiori Launchpad shell, use the dedicated `set_title_launchpad` event instead. It forwards the title to the shell's `ShellUIService` rather than setting `document.title`:
 
 ```abap
-client->action(
+client->action->gen(
     val   = client->cs_event-set_title_launchpad
     t_arg = VALUE #( ( `Invoice 4711` ) ) ).
 ```

--- a/docs/cookbook/browser_interaction/url_handling.md
+++ b/docs/cookbook/browser_interaction/url_handling.md
@@ -16,7 +16,7 @@ DATA(lv_search) = client->get( )-s_config-search.
 Open a URL in a new browser tab via a frontend event:
 ```abap
 DATA(lv_url) = `https://www.abap2UI5.org`.
-client->action(
+client->action->gen(
     val   = client->cs_event-open_new_tab
     t_arg = VALUE #( ( lv_url ) ) ).
 ```

--- a/docs/cookbook/device_capabilities/audio.md
+++ b/docs/cookbook/device_capabilities/audio.md
@@ -37,7 +37,7 @@ CLASS z2ui5_cl_sample_sound IMPLEMENTATION.
 
     IF client->get( )-event = `CHECK_INPUT`.
       IF company_code IS INITIAL.
-        client->action( val   = client->cs_event-play_audio
+        client->action->gen( val   = client->cs_event-play_audio
                         t_arg = VALUE #( ( `/SAP/PUBLIC/BC/ABAP/mime_demo/bam.wav` ) ) ).
         client->message_box_display( type = `error` text = `Input is empty!` ).
       ELSE.

--- a/docs/cookbook/device_capabilities/barcode_scanning.md
+++ b/docs/cookbook/device_capabilities/barcode_scanning.md
@@ -86,10 +86,10 @@ CLASS z2ui5_cl_sample_focus IMPLEMENTATION.
 
     CASE client->get( )-event.
       WHEN `ONE_ENTER`.
-        client->action( val   = client->cs_event-set_focus
+        client->action->gen( val   = client->cs_event-set_focus
                         t_arg = VALUE #( ( `id2` ) ) ).
       WHEN `TWO_ENTER`.
-        client->action( val   = client->cs_event-set_focus
+        client->action->gen( val   = client->cs_event-set_focus
                         t_arg = VALUE #( ( `id1` ) ) ).
     ENDCASE.
 
@@ -131,7 +131,7 @@ CLASS z2ui5_cl_sample_sound IMPLEMENTATION.
 
     IF client->get( )-event = `CHECK_INPUT`.
       IF company_code IS INITIAL.
-        client->action( val   = client->cs_event-play_audio
+        client->action->gen( val   = client->cs_event-play_audio
                         t_arg = VALUE #( ( `/SAP/PUBLIC/BC/ABAP/mime_demo/bam.wav` ) ) ).
         client->message_box_display( type = `error` text = `Input is empty!` ).
       ELSE.

--- a/docs/cookbook/device_capabilities/pdf.md
+++ b/docs/cookbook/device_capabilities/pdf.md
@@ -41,7 +41,7 @@ ENDMETHOD.
 To let the user save the PDF rather than view it inline, use the [file download](./upload_download.md) pattern:
 
 ```abap
-client->action(
+client->action->gen(
     val   = client->cs_event-download_b64_file
     t_arg = VALUE #( ( `data:application/pdf;base64,` && lv_base64 )
                      ( `invoice_4711.pdf` ) ) ).

--- a/docs/cookbook/device_capabilities/spreadsheet.md
+++ b/docs/cookbook/device_capabilities/spreadsheet.md
@@ -118,7 +118,7 @@ Convert an internal table to an XLSX file and download it to the frontend:
         ( count = `3` value = `red` descr = `this is a description` ) ).
 
         DATA(lv_file) = lcl_help=>xlsx_get_by_itab( lt_tab ).
-        client->action(
+        client->action->gen(
             val   = client->cs_event-download_b64_file
             t_arg = VALUE #( ( lv_file ) ( `test.xlsx` ) ) ).
     ENDIF.
@@ -220,7 +220,7 @@ Instead of the XLSX API above (which can change between releases), consider the 
       ( count = `3` value = `red` descr = `this is a description` ) ).
 
     DATA(lv_file) = lcl_help=>get_xlsx_by_itab( lt_tab ).
-    client->action(
+    client->action->gen(
       val   = client->cs_event-download_b64_file
       t_arg = VALUE #( ( lv_file ) ( `test.xlsx` ) ) ).
   ENDIF.

--- a/docs/cookbook/device_capabilities/upload_download.md
+++ b/docs/cookbook/device_capabilities/upload_download.md
@@ -66,7 +66,7 @@ See also `Z2UI5_CL_DEMO_APP_186`:
         `/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQj` &&
         `LYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=`.
 
-        client->action(
+        client->action->gen(
             val   = client->cs_event-download_b64_file
             t_arg = VALUE #( ( lv_content ) ( lv_name ) ) ).
     ENDCASE.

--- a/docs/cookbook/event_navigation/action.md
+++ b/docs/cookbook/event_navigation/action.md
@@ -3,11 +3,11 @@ outline: [2, 4]
 ---
 # Action
 
-Sometimes you need to call a backend function and then act on the frontend right afterward. The `action` method covers this:
+Sometimes you need to call a backend function and then act on the frontend right afterward. The `action->gen` method covers this:
 ```abap
 METHOD z2ui5_if_app~main.
 
-    client->action(
+    client->action->gen(
         val   = client->cs_event-open_new_tab
         t_arg = VALUE #( ( `https://github.com/abap2UI5` ) ) ).
 

--- a/docs/cookbook/event_navigation/frontend.md
+++ b/docs/cookbook/event_navigation/frontend.md
@@ -8,7 +8,7 @@ If you don't want to handle the event in the backend, fire actions directly on t
 - **`client->_event( )`** — causes a backend roundtrip; the event runs in the `main` method
 - **`client->_event_client( )`** — runs an action directly in the browser; no backend call
 
-Use `_event_client` on a UI5 control property (like `press`) when the response should happen entirely in the browser. To fire a frontend event **after** backend processing has finished, use [`client->action`](./action.md) instead — it schedules the same frontend event but is called from the backend.
+Use `_event_client` on a UI5 control property (like `press`) when the response should happen entirely in the browser. To fire a frontend event **after** backend processing has finished, use [`client->action->gen`](./action.md) instead — it schedules the same frontend event but is called from the backend.
 
 The following frontend events are available:
 ```abap

--- a/docs/cookbook/expert_more/app_state_share.md
+++ b/docs/cookbook/expert_more/app_state_share.md
@@ -74,7 +74,7 @@ CLASS z2ui5_cl_sample_share IMPLEMENTATION.
 
       WHEN client->check_on_event( `BUTTON_POST` ).
 
-        client->action( z2ui5_if_client=>cs_event-clipboard_app_state ).
+        client->action->gen( z2ui5_if_client=>cs_event-clipboard_app_state ).
         client->message_toast_display( `clipboard copied` ).
 
     ENDCASE.

--- a/docs/cookbook/expert_more/custom_controls.md
+++ b/docs/cookbook/expert_more/custom_controls.md
@@ -4,7 +4,7 @@ outline: [2, 4]
 # Custom Controls (Obsolete)
 
 ::: warning Mostly Not Needed Anymore
-Earlier versions of abap2UI5 required custom UI5 controls to cover common browser interactions — setting the page title, moving focus, scrolling, copying to the clipboard, opening new tabs, and so on. These are now built into the framework as **frontend events**, callable from ABAP via `client->action( client->cs_event-... )`. The custom controls that used to wrap these behaviors are obsolete.
+Earlier versions of abap2UI5 required custom UI5 controls to cover common browser interactions — setting the page title, moving focus, scrolling, copying to the clipboard, opening new tabs, and so on. These are now built into the framework as **frontend events**, callable from ABAP via `client->action->gen( client->cs_event-... )`. The custom controls that used to wrap these behaviors are obsolete.
 
 :::
 
@@ -28,7 +28,7 @@ The table below lists custom controls that are no longer necessary and the built
 Instead of writing a custom control, call the matching action after an event:
 
 ```abap
-client->action( val   = client->cs_event-set_title
+client->action->gen( val   = client->cs_event-set_title
                 t_arg = VALUE #( ( `Invoice 4711` ) ) ).
 ```
 

--- a/docs/cookbook/expert_more/custom_js.md
+++ b/docs/cookbook/expert_more/custom_js.md
@@ -80,6 +80,6 @@ If you want to look at — or hand-craft — the raw XML view that abap2UI5 prod
 </mvc:View>
 ```
 
-The browser parses the `html:script` element and executes its content as JavaScript at view render time. The function becomes available globally and can then be triggered from the backend via the obsolete [`follow_up_action`](/cookbook/expert_more/follow_up_action) — or, ideally, replaced entirely with a built-in `client->action( )` call.
+The browser parses the `html:script` element and executes its content as JavaScript at view render time. The function becomes available globally and can then be triggered from the backend via the obsolete [`follow_up_action`](/cookbook/expert_more/follow_up_action) — or, ideally, replaced entirely with a built-in `client->action->gen( )` call.
 
 This is exactly what the `_generic` + `_cc_plain_xml` helpers shown above produce; the two approaches are equivalent. Both ship raw JavaScript from the backend to the browser, and both carry the security risks described above. Use neither unless there is genuinely no alternative.

--- a/docs/cookbook/expert_more/follow_up_action.md
+++ b/docs/cookbook/expert_more/follow_up_action.md
@@ -4,7 +4,7 @@ outline: [2, 4]
 # Follow-up Action (Obsolete)
 
 ::: warning Do Not Use Anymore
-`client->follow_up_action( )` is obsolete. Use `client->action( )` instead. It works the same way, but **does not allow sending arbitrary JavaScript to the frontend** — which is exactly why `follow_up_action` was deprecated. See [Custom JS](/cookbook/expert_more/custom_js) for the full reasoning behind removing direct JS execution.
+`client->follow_up_action( )` is obsolete. Use `client->action->gen( )` instead. It works the same way, but **does not allow sending arbitrary JavaScript to the frontend** — which is exactly why `follow_up_action` was deprecated. See [Custom JS](/cookbook/expert_more/custom_js) for the full reasoning behind removing direct JS execution.
 :::
 
 ## What Changed
@@ -18,11 +18,11 @@ client->follow_up_action( `myFunction()` ).
 
 This pattern made it possible to inject arbitrary JavaScript from the backend, with all the security risks described on the [Custom JS](/cookbook/expert_more/custom_js) page (XSS, bypassed output encoding, CSP breakage, no sandboxing).
 
-The replacement, `client->action( )`, calls a **predefined frontend event** by name and passes typed arguments — no raw JavaScript travels from ABAP to the browser:
+The replacement, `client->action->gen( )`, calls a **predefined frontend event** by name and passes typed arguments — no raw JavaScript travels from ABAP to the browser:
 
 ```abap
 " recommended
-client->action( val   = client->cs_event-set_title
+client->action->gen( val   = client->cs_event-set_title
                 t_arg = VALUE #( ( `Invoice 4711` ) ) ).
 ```
 
@@ -37,7 +37,7 @@ Replace each `follow_up_action` call with the equivalent `action` call:
 client->follow_up_action( `myFunction()` ).
 
 " after
-client->action( val   = client->cs_event-<event_name>
+client->action->gen( val   = client->cs_event-<event_name>
                 t_arg = VALUE #( ( `arg1` ) ( `arg2` ) ) ).
 ```
 

--- a/docs/cookbook/expert_more/odata.md
+++ b/docs/cookbook/expert_more/odata.md
@@ -8,7 +8,7 @@ By default, you bind public attributes of your class to UI5 properties with `_bi
 #### Define Additional Model
 As an example, we use the test OData service `/sap/opu/odata/DMO/UI_FLIGHT_R_V2/`, available on most ABAP systems. Make sure the service is publicly reachable. The method below defines the model and exposes it under the name `FLIGHT`:
 ```abap
-client->action(
+client->action->gen(
     val   = z2ui5_if_client=>cs_event-set_odata_model
     t_arg = VALUE #(
         ( `/sap/opu/odata/DMO/UI_FLIGHT_R_V2/` )
@@ -58,7 +58,7 @@ The full source code:
 
     client->view_display( tab->stringify( ) ).
 
-    client->action(
+    client->action->gen(
         val   = z2ui5_if_client=>cs_event-set_odata_model
         t_arg = VALUE #(
             ( `/sap/opu/odata/DMO/UI_FLIGHT_R_V2/` )
@@ -88,7 +88,7 @@ tab->items( )->column_list_item( )->cells(
 
 client->view_display( tab->stringify( ) ).
 
-client->action(
+client->action->gen(
     val   = z2ui5_if_client=>cs_event-set_odata_model
     t_arg = VALUE #(
         ( `/sap/opu/odata/DMO/API_TRAVEL_U_V2/` )
@@ -144,7 +144,7 @@ tab->items( )->column_list_item( )->cells(
 
 client->view_display( tab->stringify( ) ).
 
-client->action(
+client->action->gen(
     val   = z2ui5_if_client=>cs_event-set_odata_model
     t_arg = VALUE #(
         ( `/sap/opu/odata/DMO/API_TRAVEL_U_V2/` )

--- a/docs/cookbook/model/size_limit.md
+++ b/docs/cookbook/model/size_limit.md
@@ -8,9 +8,9 @@ Every UI5 JSON model has a built-in upper limit on the number of items it will e
 abap2UI5 exposes this setting through the built-in client event `SET_SIZE_LIMIT`, so you can raise (or reset) the limit per view directly from ABAP.
 
 ### Set the Limit
-Trigger the event from your controller with `client->action`. The first argument is the new limit, the second is the view key (`MAIN`, `NEST`, `NEST2`, `POPUP`, `POPOVER`) — use the constants in `client->cs_view` to stay type-safe:
+Trigger the event from your controller with `client->action->gen`. The first argument is the new limit, the second is the view key (`MAIN`, `NEST`, `NEST2`, `POPUP`, `POPOVER`) — use the constants in `client->cs_view` to stay type-safe:
 ```abap
-client->action(
+client->action->gen(
     val   = z2ui5_if_client=>cs_event-set_size_limit
     t_arg = VALUE #(
         ( `1000` )
@@ -21,7 +21,7 @@ After this call, the model bound to the main view accepts up to 1.000 entries pe
 ### Reset the Limit
 To restore the default of `100`, omit the limit argument and pass only the view key:
 ```abap
-client->action(
+client->action->gen(
     val   = z2ui5_if_client=>cs_event-set_size_limit
     t_arg = VALUE #( ( client->cs_view-main ) ) ).
 ```
@@ -52,7 +52,7 @@ CLASS z2ui5_cl_sample_size_limit IMPLEMENTATION.
 
     CASE client->get( )-event.
       WHEN `UPDATE_LIMIT`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-set_size_limit
             t_arg = VALUE #( ( CONV #( mv_size_limit ) ) ( client->cs_view-main ) ) ).
         client->message_toast_display( `Size limit updated` ).
@@ -98,17 +98,17 @@ ENDCLASS.
 The same call applies to nested views, popups and popovers — just swap the view key:
 ```abap
 " Popup
-client->action(
+client->action->gen(
     val   = z2ui5_if_client=>cs_event-set_size_limit
     t_arg = VALUE #( ( `500` ) ( client->cs_view-popup ) ) ).
 
 " Popover
-client->action(
+client->action->gen(
     val   = z2ui5_if_client=>cs_event-set_size_limit
     t_arg = VALUE #( ( `500` ) ( client->cs_view-popover ) ) ).
 
 " Nested view
-client->action(
+client->action->gen(
     val   = z2ui5_if_client=>cs_event-set_size_limit
     t_arg = VALUE #( ( `500` ) ( client->cs_view-nested ) ) ).
 ```


### PR DESCRIPTION
## Summary
This PR updates all documentation examples to use the new `client->action->gen()` method signature instead of the deprecated `client->action()` method. This reflects an API change in the abap2UI5 framework where frontend event actions are now called through a `gen` method on the `action` object.

## Changes Made
- Updated all code examples across multiple cookbook sections to use `client->action->gen()` instead of `client->action()`
- Affected documentation files:
  - Model size limit handling
  - Browser interactions (scrolling, timer, focus, title, clipboard, soft keyboard, URL handling)
  - Device capabilities (barcode scanning, audio, PDF, spreadsheet, upload/download)
  - Event navigation (action, frontend events)
  - Expert topics (follow-up actions, OData, custom controls, custom JS, app state sharing)

## Implementation Details
- All method calls maintain the same parameter structure (`val` and `t_arg` arguments)
- The change is purely a method naming/access pattern update - the functionality and behavior remain identical
- Documentation now consistently reflects the current API, ensuring users follow the correct pattern when implementing frontend events from ABAP

https://claude.ai/code/session_0123tcSwjTWxoGTG6YossyaN