### PR TITLE
Expand draft handling documentation with RAP context

### DIFF
--- a/docs/cookbook/eml_cds_sql/draft_handling.md
+++ b/docs/cookbook/eml_cds_sql/draft_handling.md
@@ -3,9 +3,22 @@ outline: [2, 4]
 ---
 # Draft Handling
 
+## Drafts Are a RAP Feature — and You Can Use Them with abap2UI5
+
+Draft handling is one of the headline features of the **ABAP RESTful Application Programming Model (RAP)**. If you have built RAP business objects before, you know the drill: add `with draft` to the behavior definition, define a draft table, and the RAP framework takes care of the rest — the shadow table, the pessimistic lock, and the standard draft actions `Edit`, `Resume`, `Activate`, and `Discard`.
+
+What is less well known: **none of this is tied to Fiori Elements or OData.** Because drafts are implemented inside the business object — not inside the UI — *any* consumer that speaks **EML** (Entity Manipulation Language) gets the full draft lifecycle for free. An abap2UI5 app is exactly such a consumer. You call the same draft actions you know from RAP, and SAP's framework handles locking and persistence — your abap2UI5 app just provides the UI on top.
+
+So this page serves two audiences:
+
+- **You know drafts from RAP?** Then the EML on this page is exactly what you already use — the only new part is wiring it to an abap2UI5 view instead of a Fiori Elements UI. Feel free to skim ahead to [The Four Building Blocks](#the-four-building-blocks).
+- **You have never heard of drafts?** Read on — the next section explains the concept from scratch. Just keep in mind that drafts are not an abap2UI5 invention: they are a standard part of RAP, and abap2UI5 simply consumes them.
+
 ## What Is a Draft?
 
 Imagine a user opens a form, fills in half of it, and then gets pulled into a meeting. With a normal save, they'd have to either commit half-finished (and possibly invalid) data, or lose everything. A **draft** is the third option: a private, work-in-progress copy that is parked safely on the server until the user is ready to finalize it.
+
+Drafts solve a real problem of modern, **stateless** web UIs. Classic Dynpro applications could hold a lock for as long as the user kept the transaction open — a web app cannot, because between two clicks there is no session holding anything. RAP's answer is to persist the intermediate state server-side in a draft table and let the framework manage the lock. In SAP's standard Fiori applications this is what powers the familiar *"keep draft"* behavior — and through EML, your abap2UI5 apps get the very same behavior.
 
 A helpful mental model:
 
@@ -18,7 +31,7 @@ A helpful mental model:
 
 While a draft is open, the underlying record is **locked** so nobody else can edit it at the same time — but the lock is held by SAP's RAP framework, not by your app. That means your abap2UI5 app can stay **stateless**: the user can close the browser, come back tomorrow, and resume exactly where they left off.
 
-In abap2UI5 you drive draft-enabled RAP business objects directly through **EML** (Entity Manipulation Language), exactly like any other entity — see also [EML](./eml.md).
+In abap2UI5 you drive draft-enabled RAP business objects directly through **EML** (Entity Manipulation Language), exactly like any other entity — see also [EML](./eml.md). There is no abap2UI5-specific draft API and nothing to configure: the EML statements in the examples below would work identically in any ABAP program. What the rest of this page adds is the abap2UI5 part — binding the draft values to input fields, reacting to button events, and walking the user through the draft lifecycle. Time for code.
 
 ::: tip You don't have to build anything
 On S/4HANA and the BTP ABAP Environment (Steampunk), many business objects already ship as draft-enabled BOs. All examples on this page use **`I_BankTP`**, a draft-enabled BO that ships with S/4HANA. You don't create a BO, and you don't create a draft table — SAP provides both. Your app just calls the standard BO via EML.
@@ -47,7 +60,7 @@ record       │  (user edits) │
 
 ## The Four Building Blocks
 
-Everything on this page is built from just four EML operations. Read these once — the full app below is simply these four, wired to buttons.
+Everything on this page is built from just four EML operations. If you come from RAP, you will recognize them immediately — they are the standard draft actions every draft-enabled BO ships with. Read these once — the full app below is simply these four, wired to buttons.
 
 #### 1. Open a Draft — `Edit`
 Open (acquire) a draft for an existing active record. This takes the lock:


### PR DESCRIPTION
## Summary
Enhanced the draft handling documentation to provide better context for both RAP-experienced developers and newcomers, clarifying that draft functionality is a RAP feature that abap2UI5 consumes rather than implements.

## Key Changes
- Added introductory section "Drafts Are a RAP Feature — and You Can Use Them with abap2UI5" that:
  - Explains draft handling as a RAP headline feature
  - Clarifies that drafts work with any EML consumer, not just Fiori Elements
  - Provides guidance for two audiences: RAP-familiar developers and newcomers
  
- Expanded "What Is a Draft?" section with:
  - Explanation of how drafts solve stateless web UI problems
  - Context about pessimistic locking and server-side state persistence
  - Connection to familiar Fiori application behavior

- Updated "The Four Building Blocks" introduction to:
  - Acknowledge that these are standard RAP draft actions
  - Set expectations for RAP-experienced readers

- Clarified in the main draft explanation that:
  - There is no abap2UI5-specific draft API
  - EML statements work identically across any ABAP program
  - The page focuses on UI binding and lifecycle management specific to abap2UI5

## Notable Details
The changes maintain the existing code examples and structure while adding conceptual framing that helps readers understand where draft functionality originates (RAP framework) versus what abap2UI5 adds (UI layer integration).

https://claude.ai/code/session_01GcYJJwAgFf9HRJpuGdL1Au