### PR TITLE
docs: explain CSP 'unsafe-eval' requirement when bootstrapping older UI5 releases

### DIFF
--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -23,7 +23,7 @@ The frontend is a Single-Page Application (SPA) built with SAPUI5 or OpenUI5. Th
 abap2UI5 never sends the app's business logic to the client. All business processes stay safely on the server, and sensitive data never reaches the frontend.
 
 ### Content-Security-Policy
-To strengthen security, abap2UI5 uses a Content Security Policy (CSP) by default. CSP blocks attacks like cross-site scripting (XSS) and data injection by restricting which resources the browser can load. The default policy allows a fixed set of trusted sources — the SAP and OpenUI5 CDNs plus jsDelivr and cdnjs; the complete policy is shown below.
+To strengthen security, abap2UI5 uses a Content Security Policy (CSP) by default. CSP blocks attacks like cross-site scripting (XSS) and data injection by restricting which resources the browser can load. The default policy allows a fixed set of trusted sources — the SAP and OpenUI5 CDNs plus jsDelivr and cdnjs; the complete policy is shown below. It deliberately does **not** contain `'unsafe-eval'`: current UI5 releases load all modules in a CSP-compliant way, so allowing `eval()` is unnecessary. If you bootstrap an older UI5 release, read [Bootstrapping Older UI5 Releases](#bootstrapping-older-ui5-releases) below.
 
 #### Default CSP
 By default, abap2UI5 uses the CSP below (defined in `z2ui5_cl_exit`):
@@ -38,12 +38,57 @@ By default, abap2UI5 uses the CSP below (defined in `z2ui5_cl_exit`):
 ```
 
 #### Customizing the CSP
-If needed, adjust the CSP by changing the HTTP handler call:
+If needed, adjust the CSP in the [user exit](/advanced/extensibility/user_exits). The exit runs after the framework fills in the defaults, so whatever you set there overrides the default policy:
 
 ```abap
 METHOD z2ui5_if_exit~set_config_http_get.
 
-    cs_config-content_security_policy = `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' ui5.sap.com *.ui5.sap.com sdk.openui5.org *.sdk.openui5.org cdn.jsdelivr.net *.cdn.jsdelivr.net"/>`.
+    cs_config-content_security_policy = `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' ui5.sap.com *.ui5.sap.com sdk.openui5.org *.sdk.openui5.org cdn.jsdelivr.net *.cdn.jsdelivr.net"/>`.
 
 ENDMETHOD.
 ```
+
+#### Bootstrapping Older UI5 Releases
+Older UI5 releases (for example `1.71`, the oldest supported version) still execute fetched modules via `eval()` in their module loader. The default CSP blocks `eval()`, so bootstrapping such a release fails: the page loads, but the component cannot start and the browser console shows an error like
+
+```
+Failed to load component for container container. Reason: EvalError: Evaluating a string as
+JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is
+not an allowed source of script: default-src 'self' 'unsafe-inline' data: ui5.sap.com ...
+```
+
+Newer UI5 releases load modules without `eval()` and work with the default CSP out of the box — this error only appears with old releases.
+
+To bootstrap an older release, override the CSP in the same exit where you set the bootstrap source and re-add `'unsafe-eval'` to `default-src` (or `script-src`). The example below is the default policy with only `'unsafe-eval'` added:
+
+```abap
+METHOD z2ui5_if_exit~set_config_http_get.
+
+    cs_config-src   = `https://ui5.sap.com/1.71/resources/sap-ui-core.js`.
+    cs_config-theme = `sap_fiori_3`.
+
+    " old UI5 releases still execute modules via eval() - re-add 'unsafe-eval'
+    cs_config-content_security_policy =
+      |<meta http-equiv="Content-Security-Policy" | &&
+      |content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data: | &&
+      |ui5.sap.com *.ui5.sap.com | &&
+      |sapui5.hana.ondemand.com *.sapui5.hana.ondemand.com | &&
+      |openui5.hana.ondemand.com *.openui5.hana.ondemand.com | &&
+      |sdk.openui5.org *.sdk.openui5.org | &&
+      |cdn.jsdelivr.net *.cdn.jsdelivr.net | &&
+      |cdnjs.cloudflare.com *.cdnjs.cloudflare.com schemas *.schemas; | &&
+      |connect-src 'self' | &&
+      |  ui5.sap.com *.ui5.sap.com | &&
+      |  sapui5.hana.ondemand.com *.sapui5.hana.ondemand.com | &&
+      |  openui5.hana.ondemand.com *.openui5.hana.ondemand.com | &&
+      |  sdk.openui5.org *.sdk.openui5.org | &&
+      |  cdn.jsdelivr.net *.cdn.jsdelivr.net | &&
+      |  cdnjs.cloudflare.com *.cdnjs.cloudflare.com; | &&
+      |worker-src 'self' blob:; "/>|.
+
+ENDMETHOD.
+```
+
+::: warning
+`'unsafe-eval'` weakens the protection CSP provides against cross-site scripting. Only add it when you must run a UI5 release that needs it, and remove it again once you upgrade to a newer release.
+:::

--- a/docs/configuration/setup/ui5_bootstrapping.md
+++ b/docs/configuration/setup/ui5_bootstrapping.md
@@ -29,6 +29,10 @@ Without an override, abap2UI5 uses the OpenUI5 cache-buster URL — i.e. the cur
 | `/sap/public/bc/ui5_ui5/resources/sap-ui-core.js`                         | Locally hosted UI5 on the same SAP system |
 | `https://ui5.sap.com/1.71/resources/sap-ui-core.js`                         | Oldest supported version |
 
+::: warning Older releases need a CSP adjustment
+The default Content Security Policy does not allow `eval()`, but the module loader of older UI5 releases (such as `1.71`) still relies on it. Bootstrapping such a release with the default CSP fails with an `EvalError` in the browser console ("Failed to load component for container container"). Re-add `'unsafe-eval'` to the CSP in the same exit where you set the bootstrap source — see [Bootstrapping Older UI5 Releases](/configuration/security#bootstrapping-older-ui5-releases).
+:::
+
 ### OpenUI5 vs SAPUI5
 
 - **OpenUI5** (`sdk.openui5.org`) is the Apache-licensed open-source subset of UI5. It contains all libraries a typical abap2UI5 app uses: `sap.m`, `sap.ui.core`, `sap.ui.layout`, `sap.ui.table`, `sap.ui.unified`, `sap.uxap`, `sap.f`, `sap.tnt`, `sap.viz`.


### PR DESCRIPTION
## Summary

The abap2UI5 default Content Security Policy no longer contains `'unsafe-eval'` (removed 21.11.2025 in `z2ui5_cl_exit`). Current UI5 releases load modules CSP-compliantly, so this is fine — but the module loader of older UI5 releases (e.g. `1.71`, the oldest supported version) still executes fetched modules via `eval()`. Bootstrapping such a release with the default CSP therefore fails: the page loads, but the component cannot start and the browser console shows

```
Failed to load component for container container. Reason: EvalError: Evaluating a string as
JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is
not an allowed source of script: ...
```

This is easy to hit and hard to diagnose, so it deserves documentation.

## Changes

- **`docs/configuration/security.md`**
  - New section **"Bootstrapping Older UI5 Releases"**: explains why the default CSP omits `'unsafe-eval'`, shows the exact console error symptom, and provides a complete, verified user-exit example (default policy with only `'unsafe-eval'` added, alongside the bootstrap source). A warning box points out the security trade-off and recommends removing `'unsafe-eval'` again after upgrading.
  - The generic "Customizing the CSP" example no longer includes `'unsafe-eval'` (it now lives only in the dedicated section, with context) and documents that the user exit runs after the framework defaults, so settings there override the default policy.
- **`docs/configuration/setup/ui5_bootstrapping.md`**
  - Warning box directly below the bootstrap-source table (next to the `1.71` "oldest supported version" row) describing the symptom and linking to the new security section.

## Validation

- Full VitePress build passes (`npm run docs:build`)
- Cross-page anchor `/configuration/security#bootstrapping-older-ui5-releases` verified against the generated HTML
- The documented exit code is the fix a user confirmed working on a real system bootstrapping SAPUI5 1.71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHwMvvRGvLUV7CoLCB5A7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHwMvvRGvLUV7CoLCB5A7e)_