### PR TITLE
Pin GitHub Actions to specific commit SHAs with version tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,24 +29,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
-      # - uses: pnpm/action-setup@v3 # Uncomment this if you're using pnpm
-      # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm # or pnpm / yarn
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
       - name: Install dependencies
         run: npm ci # or pnpm install / yarn install / bun install
       - name: Build with VitePress
         run: npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/.vitepress/dist
 
@@ -61,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary
Updated all GitHub Actions workflow dependencies to use pinned commit SHAs instead of version tags, improving supply chain security and build reproducibility.

## Key Changes
- Pinned `actions/checkout` to commit SHA `11d5960a326750d5838078e36cf38b85af677262` (v4.4.0)
- Pinned `actions/setup-node` to commit SHA `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0)
- Pinned `actions/configure-pages` to commit SHA `1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d` (v4.0.0)
- Pinned `actions/upload-pages-artifact` to commit SHA `56afc609e74202658d3ffba0e8f6dda462b719fa` (v3.0.1)
- Pinned `actions/deploy-pages` to commit SHA `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` (v4.0.5)
- Removed commented-out pnpm and Bun setup steps for clarity

## Implementation Details
Each action now references a specific commit SHA with the corresponding version tag as a comment for maintainability. This approach prevents potential supply chain attacks where a version tag could be reassigned to a different commit, ensuring that the exact same code is executed across all workflow runs.

https://claude.ai/code/session_013NA4sHtsK85U1f6YKxP7YW