### PR TITLE
docs: catch up with framework 1.142 — routing, CSRF, smart controls, drift fixes

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -168,6 +168,7 @@ export default defineConfig({
               },
               { text: "Action", link: "/cookbook/event_navigation/action" },
               { text: "Navigation", link: "/cookbook/event_navigation/navigation" },
+              { text: "Routing", link: "/cookbook/event_navigation/routing" },
               { text: "Exception", link: "/cookbook/event_navigation/exception" },
             ],
           },
@@ -203,6 +204,7 @@ export default defineConfig({
               { text: "Clipboard", link: "/cookbook/browser_interaction/clipboard" },
               { text: "URL Handling", link: "/cookbook/browser_interaction/url_handling" },
               { text: "Soft Keyboard", link: "/cookbook/browser_interaction/soft_keyboard" },
+              { text: "Keyboard Shortcuts", link: "/cookbook/browser_interaction/keyboard_shortcuts" },
             ],
           },
           {
@@ -241,6 +243,7 @@ export default defineConfig({
               { text: "WebSocket", link: "/cookbook/expert_more/websocket" },
               { text: "Logout", link: "/configuration/logout" },
               { text: "OData", link: "/cookbook/expert_more/odata" },
+              { text: "Smart Controls", link: "/cookbook/expert_more/smart_controls" },
               { text: "App State, Share", link: "/cookbook/expert_more/app_state_share" },
             ],
           },

--- a/docs/advanced/agent.md
+++ b/docs/advanced/agent.md
@@ -83,7 +83,7 @@ Views, events, binding, navigation, messages — everything goes through the `cl
 | Popups / popovers | `popup_display`, `popup_destroy`, `popover_display`, `popover_destroy` |
 | Binding | `_bind( var )` (read-only), `_bind( var )` (two-way) |
 | Events | `_event( 'NAME' )`, `check_on_event( 'NAME' )`, `get_event_arg( i )` |
-| Navigation | `nav_app_call( app )`, `nav_app_leave( )`, `get_app_prev( )` |
+| Navigation | `nav_app_call( app )`, `nav_app_leave( )`, `get_app_prev( )`, `set_nav_routing( )` |
 | Messages | `message_box_display`, `message_toast_display` |
 | Lifecycle | `check_on_init`, `check_on_event`, `check_on_navigated` |
 
@@ -242,6 +242,7 @@ When an AI needs deeper information than this page provides:
 | Data binding (`_bind`) | [Cookbook → Binding](/cookbook/model/binding) |
 | Tables and trees | [Cookbook → Tables](/cookbook/model/tables), [Trees](/cookbook/model/trees) |
 | Events, actions, exceptions | [Cookbook → Event, Navigation](/cookbook/event_navigation/life_cycle) |
+| Hash routing, browser Back/Forward | [Cookbook → Routing](/cookbook/event_navigation/routing) |
 | Popups and popovers | [Cookbook → Popup, Popover](/cookbook/popup_popover/popup) |
 | Messages, toasts, i18n | [Cookbook → Translation, Messages](/cookbook/translation_messages/message) |
 | Browser interaction (focus, scroll, URL) | [Cookbook → Browser Interaction](/cookbook/browser_interaction/title) |

--- a/docs/advanced/agent.md
+++ b/docs/advanced/agent.md
@@ -5,7 +5,7 @@ outline: [2, 4]
 
 This page is the entry point for any AI assistant (Claude, Copilot, Cursor, …) that should build abap2UI5 apps. It collects, in one place, every source of information the model needs and points to the canonical references in the three project repositories.
 
-If you are pasting context into an AI tool, **start here**, then follow the links — the linked files (especially the `CLAUDE.md` files in the source repositories) are kept up to date with every release and are the source of truth.
+If you are pasting context into an AI tool, **start here**, then follow the links — the linked files (especially the `AGENTS.md` files in the source repositories) are kept up to date with every release and are the source of truth.
 
 ## The Three Repositories
 
@@ -13,16 +13,16 @@ abap2UI5 lives in three repositories. Each carries information an AI assistant s
 
 | Repository | What's in it | Why an AI needs it |
 |---|---|---|
-| **[abap2UI5/abap2UI5](https://github.com/abap2UI5/abap2UI5)** | Core framework — interfaces, view builder, runtime | The public API (`z2ui5_if_app`, `z2ui5_if_client`, `z2ui5_cl_xml_view`, `z2ui5_cl_util_xml`) the app interacts with |
-| **[abap2UI5/samples](https://github.com/abap2UI5/samples)** | 250+ working demo apps + app-development guide | Canonical patterns and a copy-pastable example for almost every UI5 control and feature |
+| **[abap2UI5/abap2UI5](https://github.com/abap2UI5/abap2UI5)** | Core framework — interfaces, view builder, runtime | The public API (`z2ui5_if_app`, `z2ui5_if_client`, `z2ui5_cl_xml_view`) the app interacts with |
+| **[abap2UI5/samples](https://github.com/abap2UI5/samples)** | Hundreds of working demo apps + app-development guide | Canonical patterns and a copy-pastable example for almost every UI5 control and feature |
 | **[abap2UI5/docs](https://github.com/abap2UI5/docs)** | This documentation site | Conceptual background, lifecycle, cookbook recipes |
 
 ## Source-Repo Briefings (for Framework / Sample Contributors)
 
-The two source repositories carry `CLAUDE.md` briefings aimed at AI tools that work **inside those repos** — they are not needed for building apps:
+The two source repositories carry `AGENTS.md` briefings aimed at AI tools that work **inside those repos** — they are not needed for building apps:
 
-- **[abap2UI5/CLAUDE.md](https://github.com/abap2UI5/abap2UI5/blob/main/CLAUDE.md)** — for AI assistants **modifying the framework itself**: layered architecture (`src/00` utilities, `src/01` engine, `src/02` public API), coding rules, naming, abaplint setup, Clean-ABAP exceptions, public-API stability contract.
-- **[samples/CLAUDE.md](https://github.com/abap2UI5/samples/blob/main/CLAUDE.md)** — for AI assistants **contributing sample apps**: formatting rules (blank lines, indentation), file/class conventions, abaplint setup.
+- **[abap2UI5/AGENTS.md](https://github.com/abap2UI5/abap2UI5/blob/main/AGENTS.md)** — for AI assistants **modifying the framework itself**: layered architecture, coding rules, naming, abaplint setup, Clean-ABAP exceptions, public-API stability contract.
+- **[samples/AGENTS.md](https://github.com/abap2UI5/samples/blob/main/AGENTS.md)** — for AI assistants **contributing sample apps**: folder scheme, formatting rules (blank lines, indentation), file/class conventions, abaplint setup.
 
 If you only want to **build an abap2UI5 app**, this page is the single source — you do not need to read those files.
 
@@ -81,41 +81,42 @@ Views, events, binding, navigation, messages — everything goes through the `cl
 |---|---|
 | Views | `view_display`, `view_destroy`, `view_model_update` |
 | Popups / popovers | `popup_display`, `popup_destroy`, `popover_display`, `popover_destroy` |
-| Binding | `_bind( var )` (read-only), `_bind( var )` (two-way) |
-| Events | `_event( 'NAME' )`, `check_on_event( 'NAME' )`, `get_event_arg( i )` |
+| Binding | `_bind( var )` (two-way; `_bind_edit` is an obsolete alias of it) |
+| Events | `_event( 'NAME' )`, `check_on_event( 'NAME' )`, `get_event_arg( )` |
 | Navigation | `nav_app_call( app )`, `nav_app_leave( )`, `get_app_prev( )`, `set_nav_routing( )` |
 | Messages | `message_box_display`, `message_toast_display` |
 | Lifecycle | `check_on_init`, `check_on_event`, `check_on_navigated` |
 
 Read the full interface at [`z2ui5_if_client.intf.abap`](https://github.com/abap2UI5/abap2UI5/blob/main/src/02/z2ui5_if_client.intf.abap).
 
-#### 5. Views are XML — built with one of two builders
+#### 5. Views are XML — built with the fluent builder
 
-Views are UI5 XML strings passed to `client->view_display( ... )`. The framework ships two builders, both fully supported:
+Views are UI5 XML strings passed to `client->view_display( ... )`. Build them with **`z2ui5_cl_xml_view`** — the fluent builder with one ABAP method per UI5 control. Every sample app uses it; it is the only supported builder.
 
-- **`z2ui5_cl_util_xml`** — generic XML builder. Element name + attributes as strings → maps **1:1** to the UI5 SDK. **Recommended for AI-generated code.**
-- **`z2ui5_cl_xml_view`** — fluent builder with one ABAP method per UI5 control (~446 methods). Convenient for humans, but has naming inconsistencies and incomplete coverage → harder for an AI to use correctly.
+For any control or property the fluent API does not cover, drop down to its generic method `_generic( name = ... ns = ... t_prop = ... )`, which emits any XML element with any attributes — a 1:1 translation of the UI5 SDK. Both styles mix freely in the same view.
 
 → [View Definition](/cookbook/view/definition)
 
-## Recommended Builder for AI: `z2ui5_cl_util_xml`
+::: warning Do not use `z2ui5_cl_util_xml`
+The former standalone XML builder `z2ui5_cl_util_xml` is **retired** (it lives in the framework's obsolete package and is scheduled for removal). No sample uses it anymore — do not generate new code with it. Use `z2ui5_cl_xml_view`, with `_generic( )` for anything it doesn't wrap.
+:::
 
-Translate any UI5 XML example from the [UI5 SDK](https://sapui5.hana.ondemand.com/sdk) **1:1** into ABAP — no wrapper, no abstraction:
+## Using the Builder: `z2ui5_cl_xml_view`
 
-| UI5 XML | ABAP with `z2ui5_cl_util_xml` |
-|---|---|
-| `<Button text="Send" />` | `->__( n = `Button` a = `text` v = `Send` )` |
-| `press="onPress"` | `a = `press` v = client->_event( `BUTTON_POST` )` |
-| `value="{/name}"` | `a = `value` v = client->_bind( name )` |
-| `<FeedInput><actions>…</actions></FeedInput>` | `->_( `FeedInput` )->_( `actions` )->__( … )` |
+The fluent API follows a small set of conventions (details in [View Definition](/cookbook/view/definition#mapping-ui5-xml-abap-fluent-api)):
 
-Builder methods:
+- Control methods are snake_case of the UI5 control class — `sap.m.MultiComboBox` → `->multi_combo_box( )`, `sap.m.Text` → `->text( )`.
+- Properties are named parameters, lowercased without underscores (`enabled`, `placeholder`, `selectedkey`).
+- Aggregations are methods named after the aggregation (`->items( )`, `->content( )`); calling one returns the builder so children chain inside it.
+- `->stringify( )` serializes the view for `client->view_display( )`.
 
-- `_( n, ns, p )` — add child, **go into** it (next call adds a grandchild)
-- `__( n, ns, a, v, p )` — add child, **stay** at current level (leaf / sibling)
-- `p( n, v )` — add a single attribute to the current node
-- `n( 'Name' )` / `n( )` — navigate to named ancestor / parent
-- `stringify( indent = abap_true )` — serialize to XML
+When a control, property or aggregation is missing from the fluent API, translate the UI5 SDK XML 1:1 with `_generic( )`:
+
+```abap
+view->_generic( name = `MultiComboBox` ns = `sap.m`
+    t_prop = VALUE #( ( n = `selectedKeys` v = `{/keys}` )
+                      ( n = `placeholder`  v = `Pick one` ) ) ).
+```
 
 ::: warning Boolean attribute values
 Always pass `'true'` or `'false'` as **string literals** — never `abap_true` / `abap_false`. `abap_false` (space) is silently dropped; `abap_true` (`'X'`) produces an invalid XML attribute value.
@@ -168,9 +169,9 @@ CLASS zcl_app_xxx IMPLEMENTATION.
 ENDCLASS.
 ```
 
-The full template (with formatting and blank-line rules) lives in [samples/CLAUDE.md](https://github.com/abap2UI5/samples/blob/main/CLAUDE.md#app-structure).
+The full template (with formatting and blank-line rules) lives in [samples/AGENTS.md](https://github.com/abap2UI5/samples/blob/main/AGENTS.md).
 
-## Sample Apps — 250+ Working Examples
+## Sample Apps — Hundreds of Working Examples
 
 The fastest way for an AI to ground a generation in working code is to look up a similar app in the [samples repository](https://github.com/abap2UI5/samples/tree/main/src). Each `z2ui5_cl_demo_app_*` class is a self-contained, abapGit-installable app demonstrating a single feature or control.
 
@@ -180,7 +181,7 @@ Browse them online (no system needed): <https://abap2ui5.github.io/web-abap2ui5-
 
 Before building a custom dialog, check whether one of the built-in popup classes already covers the case:
 
-`Z2UI5_CL_POP_TO_CONFIRM`, `Z2UI5_CL_POP_TO_INFORM`, `Z2UI5_CL_POP_TO_SELECT`, `Z2UI5_CL_POP_FILE_UL`, `Z2UI5_CL_POP_FILE_DL`, `Z2UI5_CL_POP_TABLE`, `Z2UI5_CL_POP_DATA`, `Z2UI5_CL_POP_TEXTEDIT`, `Z2UI5_CL_POP_PDF`, `Z2UI5_CL_POP_HTML`, `Z2UI5_CL_POP_IMAGE_EDITOR`, `Z2UI5_CL_POP_MESSAGES`, `Z2UI5_CL_POP_BAL`, `Z2UI5_CL_POP_ERROR`, `Z2UI5_CL_POP_GET_RANGE`, `Z2UI5_CL_POP_GET_RANGE_M`, `Z2UI5_CL_POP_INPUT_VAL`, `Z2UI5_CL_POP_JS_LOADER`, `Z2UI5_CL_POP_DEMO_OUTPUT`
+`Z2UI5_CL_POP_TO_CONFIRM`, `Z2UI5_CL_POP_TO_INFORM`, `Z2UI5_CL_POP_TO_SELECT`, `Z2UI5_CL_POP_FILE_UL`, `Z2UI5_CL_POP_FILE_DL`, `Z2UI5_CL_POP_TABLE`, `Z2UI5_CL_POP_DATA`, `Z2UI5_CL_POP_TEXTEDIT`, `Z2UI5_CL_POP_PDF`, `Z2UI5_CL_POP_HTML`, `Z2UI5_CL_POP_IMAGE_EDITOR`, `Z2UI5_CL_POP_MESSAGES`, `Z2UI5_CL_POP_ERROR`, `Z2UI5_CL_POP_GET_RANGE`, `Z2UI5_CL_POP_GET_RANGE_M`, `Z2UI5_CL_POP_INPUT_VAL`, `Z2UI5_CL_POP_JS_LOADER`, `Z2UI5_CL_POP_DEMO_OUTPUT`
 
 → [Built-in popups](/cookbook/popup_popover/built_in)
 
@@ -255,7 +256,7 @@ When an AI needs deeper information than this page provides:
 
 A prompt that gives an AI assistant enough context to produce a working app:
 
-> You are building an abap2UI5 app. Read <https://abap2ui5.github.io/docs/advanced/agent.html> first — it is the single source of truth for app-building (template, client API, lifecycle, view builder, deprecated controls, documentation map). For working examples, browse <https://github.com/abap2UI5/samples/tree/main/src> (250+ apps, one feature per app). Use `z2ui5_cl_util_xml` as the view builder. Look up any UI5 control at <https://ui5.sap.com/#/api> and translate the XML 1:1 to ABAP. Do not use any control listed in this page's "Deprecated UI5 Controls" section. Always call `view_display( )` in the `check_on_navigated( )` branch — otherwise the screen is blank after returning from a called sub-app.
+> You are building an abap2UI5 app. Read <https://abap2ui5.github.io/docs/advanced/agent.html> first — it is the single source of truth for app-building (template, client API, lifecycle, view builder, deprecated controls, documentation map). For working examples, browse <https://github.com/abap2UI5/samples/tree/main/src> (hundreds of apps, one feature per app). Use `z2ui5_cl_xml_view` as the view builder; for controls it does not wrap, look up the UI5 control at <https://ui5.sap.com/#/api> and translate the XML 1:1 with `_generic( )`. Do not use any control listed in this page's "Deprecated UI5 Controls" section. Always call `view_display( )` in the `check_on_navigated( )` branch — otherwise the screen is blank after returning from a called sub-app.
 
 ## Hard Rules (Cheat Sheet)
 
@@ -265,11 +266,11 @@ A prompt that gives an AI assistant enough context to produce a working app:
 | Bound attributes must be `PUBLIC` | The framework binds via dynamic ASSIGN; `PROTECTED`/`PRIVATE` are silently ignored |
 | Use `IF` / `ELSEIF` with `check_on_init` / `check_on_event( 'NAME' )` / `check_on_navigated` | Canonical dispatcher pattern |
 | Always call `view_display( )` in the `check_on_navigated` branch | The browser still shows the called sub-app's view after `nav_app_leave( )` — without a re-display the screen stays blank |
-| Use `z2ui5_cl_util_xml` for AI-generated views | Maps 1:1 to UI5 SDK; no wrapper to learn |
+| Use `z2ui5_cl_xml_view` for views (`_generic( )` for uncovered controls) | The only supported builder; `z2ui5_cl_util_xml` is retired |
 | Pass XML boolean attributes as string literals `'true'` / `'false'` | `abap_true` / `abap_false` produce invalid or empty attributes |
 | Use backtick string literals (`` ` ``), not single quotes | Project-wide convention enforced by abaplint |
-| Never use a deprecated control | See list in framework `CLAUDE.md` |
+| Never use a deprecated control | See the list on this page |
 | Use built-in popups (`z2ui5_cl_pop_*`) before building custom ones | Tested, consistent, less code |
 | Run `npx abaplint` on every change in the framework / samples repos | Primary quality gate; must report 0 issues |
 
-That's the briefing. Hand the link to this page (or the two `CLAUDE.md` files it points to) to any AI tool and it has everything it needs to build a working abap2UI5 app.
+That's the briefing. Hand the link to this page (or the two `AGENTS.md` files it points to) to any AI tool and it has everything it needs to build a working abap2UI5 app.

--- a/docs/advanced/extensibility/user_exits.md
+++ b/docs/advanced/extensibility/user_exits.md
@@ -32,6 +32,10 @@ CLASS zcl_a2ui5_user_exit IMPLEMENTATION.
 
     cs_config-draft_exp_time_in_hours = 8.
 
+    " CSRF protection is on by default; disable it only if your endpoint
+    " must accept cross-origin POSTs (see the Security page)
+    " cs_config-check_csrf_active = abap_false.
+
   ENDMETHOD.
 
 ENDCLASS.

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -92,3 +92,17 @@ ENDMETHOD.
 ::: warning
 `'unsafe-eval'` weakens the protection CSP provides against cross-site scripting. Only add it when you must run a UI5 release that needs it, and remove it again once you upgrade to a newer release.
 :::
+
+### Cross-Site Request Forgery (CSRF)
+Every state-changing request in abap2UI5 is a POST, so the framework ships its own CSRF defense instead of relying on a fronting SAP ICF/CSRF layer that may or may not be there. The check compares the host authority of the request's `Origin` (or `Referer`) header against the `Host` header — a cross-origin POST is rejected with an error response before any app logic runs.
+
+**CSRF protection is active by default.** A fresh install rejects cross-origin POSTs without any configuration. If your endpoint must accept cross-origin POSTs (for example, behind a proxy setup where the origin legitimately differs), opt out in the [user exit](/advanced/extensibility/user_exits):
+
+```abap
+METHOD z2ui5_if_exit~set_config_http_post.
+
+    " escape hatch - only disable this if your endpoint must accept cross-origin POSTs
+    cs_config-check_csrf_active = abap_false.
+
+ENDMETHOD.
+```

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -23,18 +23,21 @@ The frontend is a Single-Page Application (SPA) built with SAPUI5 or OpenUI5. Th
 abap2UI5 never sends the app's business logic to the client. All business processes stay safely on the server, and sensitive data never reaches the frontend.
 
 ### Content-Security-Policy
-To strengthen security, abap2UI5 uses a Content Security Policy (CSP) by default. CSP blocks attacks like cross-site scripting (XSS) and data injection by restricting which resources the browser can load. The default policy allows a fixed set of trusted sources — the SAP and OpenUI5 CDNs plus jsDelivr and cdnjs; the complete policy is shown below. It deliberately does **not** contain `'unsafe-eval'`: current UI5 releases load all modules in a CSP-compliant way, so allowing `eval()` is unnecessary. If you bootstrap an older UI5 release, read [Bootstrapping Older UI5 Releases](#bootstrapping-older-ui5-releases) below.
+To strengthen security, abap2UI5 uses a Content Security Policy (CSP) by default. CSP blocks attacks like cross-site scripting (XSS) and data injection by restricting which resources the browser can load. The default policy allows a fixed set of trusted sources — the SAP and OpenUI5 CDNs plus jsDelivr and cdnjs; the complete policy is shown below. It also carries hardening directives (`object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'self'`) that block plugin content, pin `<base>` to the app origin and forbid cross-origin framing.
+
+The default **does** contain `'unsafe-eval'`: the ui5loader of OpenUI5 `1.71` — the oldest supported release — still evaluates module source as a string, and without `'unsafe-eval'` a `1.71` bootstrap fails with a CSP `EvalError`. Modern UI5 releases load all modules without `eval()`, so if you pin a modern release you can tighten the policy — see [Hardening: Dropping `'unsafe-eval'`](#hardening-dropping-unsafe-eval) below.
 
 #### Default CSP
 By default, abap2UI5 uses the CSP below (defined in `z2ui5_cl_exit`):
 ```xml
-<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' data:
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:
     ui5.sap.com *.ui5.sap.com sapui5.hana.ondemand.com *.sapui5.hana.ondemand.com openui5.hana.ondemand.com *.openui5.hana.ondemand.com
     sdk.openui5.org *.sdk.openui5.org cdn.jsdelivr.net *.cdn.jsdelivr.net cdnjs.cloudflare.com *.cdnjs.cloudflare.com schemas *.schemas;
     connect-src 'self' ui5.sap.com *.ui5.sap.com sapui5.hana.ondemand.com *.sapui5.hana.ondemand.com
     openui5.hana.ondemand.com *.openui5.hana.ondemand.com sdk.openui5.org *.sdk.openui5.org
     cdn.jsdelivr.net *.cdn.jsdelivr.net cdnjs.cloudflare.com *.cdnjs.cloudflare.com;
-    worker-src 'self' blob:;"/>
+    worker-src 'self' blob:;
+    object-src 'none'; base-uri 'self'; frame-ancestors 'self';"/>
 ```
 
 #### Customizing the CSP
@@ -48,29 +51,19 @@ METHOD z2ui5_if_exit~set_config_http_get.
 ENDMETHOD.
 ```
 
-#### Bootstrapping Older UI5 Releases
-Older UI5 releases (for example `1.71`, the oldest supported version) still execute fetched modules via `eval()` in their module loader. The default CSP blocks `eval()`, so bootstrapping such a release fails: the page loads, but the component cannot start and the browser console shows an error like
-
-```
-Failed to load component for container container. Reason: EvalError: Evaluating a string as
-JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is
-not an allowed source of script: default-src 'self' 'unsafe-inline' data: ui5.sap.com ...
-```
-
-Newer UI5 releases load modules without `eval()` and work with the default CSP out of the box — this error only appears with old releases.
-
-To bootstrap an older release, override the CSP in the same exit where you set the bootstrap source and re-add `'unsafe-eval'` to `default-src` (or `script-src`). The example below is the default policy with only `'unsafe-eval'` added:
+#### Hardening: Dropping `'unsafe-eval'`
+`'unsafe-eval'` weakens the protection CSP provides against script injection. The default keeps it only because OpenUI5 `1.71` — the oldest supported release — still executes fetched modules via `eval()` in its module loader. If you pin a modern UI5 release, no `eval()` is involved and you can remove `'unsafe-eval'` in the same exit where you set the bootstrap source. The example below is the default policy without `'unsafe-eval'`:
 
 ```abap
 METHOD z2ui5_if_exit~set_config_http_get.
 
-    cs_config-src   = `https://ui5.sap.com/1.71/resources/sap-ui-core.js`.
-    cs_config-theme = `sap_fiori_3`.
+    cs_config-src   = `https://ui5.sap.com/resources/sap-ui-core.js`.
+    cs_config-theme = `sap_horizon`.
 
-    " old UI5 releases still execute modules via eval() - re-add 'unsafe-eval'
+    " modern UI5 loads modules without eval() - drop 'unsafe-eval'
     cs_config-content_security_policy =
       |<meta http-equiv="Content-Security-Policy" | &&
-      |content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data: | &&
+      |content="default-src 'self' 'unsafe-inline' data: | &&
       |ui5.sap.com *.ui5.sap.com | &&
       |sapui5.hana.ondemand.com *.sapui5.hana.ondemand.com | &&
       |openui5.hana.ondemand.com *.openui5.hana.ondemand.com | &&
@@ -84,13 +77,22 @@ METHOD z2ui5_if_exit~set_config_http_get.
       |  sdk.openui5.org *.sdk.openui5.org | &&
       |  cdn.jsdelivr.net *.cdn.jsdelivr.net | &&
       |  cdnjs.cloudflare.com *.cdnjs.cloudflare.com; | &&
-      |worker-src 'self' blob:; "/>|.
+      |worker-src 'self' blob:; | &&
+      |object-src 'none'; base-uri 'self'; frame-ancestors 'self'; "/>|.
 
 ENDMETHOD.
 ```
 
 ::: warning
-`'unsafe-eval'` weakens the protection CSP provides against cross-site scripting. Only add it when you must run a UI5 release that needs it, and remove it again once you upgrade to a newer release.
+With `'unsafe-eval'` removed, bootstrapping an old release such as `1.71` fails: the page loads, but the component cannot start and the browser console shows an error like
+
+```
+Failed to load component for container container. Reason: EvalError: Evaluating a string as
+JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is
+not an allowed source of script: default-src 'self' 'unsafe-inline' data: ui5.sap.com ...
+```
+
+Only tighten the policy when every system you deploy to bootstraps a modern release.
 :::
 
 ### Cross-Site Request Forgery (CSRF)

--- a/docs/configuration/setup/ui5_bootstrapping.md
+++ b/docs/configuration/setup/ui5_bootstrapping.md
@@ -29,8 +29,8 @@ Without an override, abap2UI5 uses the OpenUI5 cache-buster URL — i.e. the cur
 | `/sap/public/bc/ui5_ui5/resources/sap-ui-core.js`                         | Locally hosted UI5 on the same SAP system |
 | `https://ui5.sap.com/1.71/resources/sap-ui-core.js`                         | Oldest supported version |
 
-::: warning Older releases need a CSP adjustment
-The default Content Security Policy does not allow `eval()`, but the module loader of older UI5 releases (such as `1.71`) still relies on it. Bootstrapping such a release with the default CSP fails with an `EvalError` in the browser console ("Failed to load component for container container"). Re-add `'unsafe-eval'` to the CSP in the same exit where you set the bootstrap source — see [Bootstrapping Older UI5 Releases](/configuration/security#bootstrapping-older-ui5-releases).
+::: tip CSP and older releases
+The module loader of older UI5 releases (such as `1.71`) still relies on `eval()`. The default Content Security Policy therefore includes `'unsafe-eval'`, so even `1.71` bootstraps out of the box. If you pin a modern release, consider removing `'unsafe-eval'` from the CSP for extra hardening — see [Hardening: Dropping `'unsafe-eval'`](/configuration/security#hardening-dropping-unsafe-eval).
 :::
 
 ### OpenUI5 vs SAPUI5

--- a/docs/configuration/troubleshooting.md
+++ b/docs/configuration/troubleshooting.md
@@ -10,10 +10,12 @@ Set a breakpoint in your abap2UI5 app to debug the code. Check that the XML view
 ### Frontend
 On the frontend, abap2UI5 behaves like a standard UI5 app, so the usual tools and debugging features work.
 
-#### Debugging Tools
-Press `Ctrl+F12` to open the built-in debugging tools of abap2UI5:
-![Built-in debugger showing XML View and Data Model inspection](/configuration/debug.png)
-From here you can review the XML View and check the Data Model bound to the view.
+#### Developer Tools
+Press `Ctrl+F12` to open the built-in **Developer Tools** of abap2UI5:
+![Developer Tools showing XML View and Data Model inspection](/configuration/debug.png)
+Tabs cover the whole roundtrip: **Error** and **Log**, the **System** info, the **Previous Request** and **Response**, the app's **Source Code**, and for every view slot (main, popup, popover, nested) the rendered **View** XML and its **Model** data.
+
+The footer offers **Logout**, **Restart**, a jump to **ADT**, and an **Export** that bundles everything — including the running app's ABAP class source — into one blob you can attach to a bug report. Error popups also carry a copy-to-clipboard button for the same purpose.
 
 #### UI5 Inspector
 Another option: the SAP default debugging tool, the [UI5 Inspector](https://chromewebstore.google.com/detail/ui5-inspector/bebecogbafbighhaildooiibipcnbngo).

--- a/docs/cookbook/browser_interaction/keyboard_shortcuts.md
+++ b/docs/cookbook/browser_interaction/keyboard_shortcuts.md
@@ -1,0 +1,59 @@
+---
+outline: [2, 4]
+---
+# Keyboard Shortcuts
+
+The `keyboard_shortcut` frontend event binds a key combination to a **named backend event** — the declarative equivalent of a `sap.ui.core.CommandExecution` shortcut, which needs a controller method and therefore has no place in a controller-less abap2UI5 app. The binding is pure data: the key combination and the name of the backend event it fires.
+
+## Registering a Shortcut
+
+`t_arg` is positional — the key combination and the backend event name:
+
+```abap
+METHOD z2ui5_if_app~main.
+
+  IF client->check_on_init( ).
+
+    client->follow_up_action( val   = client->cs_event-keyboard_shortcut
+                              t_arg = VALUE #( ( `Ctrl+S` )
+                                               ( `SAVE` ) ) ).
+
+    client->follow_up_action( val   = client->cs_event-keyboard_shortcut
+                              t_arg = VALUE #( ( `Ctrl+D` )
+                                               ( `DELETE` ) ) ).
+    view_display( ).
+  ENDIF.
+
+  CASE client->get( )-event.
+    WHEN `SAVE`.
+      client->message_toast_display( `Saved via Ctrl+S` ).
+    WHEN `DELETE`.
+      client->message_toast_display( `Deleted via Ctrl+D` ).
+  ENDCASE.
+
+ENDMETHOD.
+```
+
+Pressing the combination fires the backend event exactly like a button press would — and the browser default for the combination is suppressed.
+
+## Behavior
+
+- **Spelling** follows the UI5 convention: `Ctrl+S`, `Ctrl+Shift+D`, `F2`. Common aliases are normalized (`Cmd`/`Command` → `Meta`, `Control` → `Ctrl`, `Esc` → `Escape`, `Return` → `Enter`, …), so registration and keypress match for any spelling.
+- **One registration per combination.** Registering the same combination again rebinds it — no need to unregister first.
+- **Unregister** a combination by sending it with an empty event name:
+
+```abap
+client->follow_up_action( val   = client->cs_event-keyboard_shortcut
+                          t_arg = VALUE #( ( `Ctrl+S` )
+                                           ( `` ) ) ).
+```
+
+- **Lifetime:** the registry lives in the frontend and survives every roundtrip until the app is left. Navigating to another app starts from an empty set.
+
+The same registration also works without a backend roundtrip via `client->_event_client( )` with the identical `t_arg`.
+
+::: tip
+See demo app 471 in the [samples repository](https://github.com/abap2UI5/samples) for a complete example.
+:::
+
+For controlling the *soft keyboard* on mobile devices, see [Soft Keyboard](/cookbook/browser_interaction/soft_keyboard).

--- a/docs/cookbook/browser_interaction/url_handling.md
+++ b/docs/cookbook/browser_interaction/url_handling.md
@@ -35,3 +35,7 @@ client->set_nav_back( ).
 ```
 
 For a complete example, see sample `Z2UI5_CL_DEMO_APP_139`.
+
+::: tip Hash-based app routing
+For app-to-app navigation, the framework can own the URL hash itself: with [Routing](/cookbook/event_navigation/routing) enabled, each app gets a bookmarkable route and the browser Back/Forward buttons navigate the app stack — no manual push states needed.
+:::

--- a/docs/cookbook/device_capabilities/upload_download.md
+++ b/docs/cookbook/device_capabilities/upload_download.md
@@ -6,7 +6,6 @@ outline: [2, 4]
 abap2UI5 handles file uploads and downloads by sending base64-encoded data over two-way binding.
 
 #### Upload
-See also `Z2UI5_CL_DEMO_APP_075`:
 ```abap
 CLASS z2ui5_cl_sample_upload DEFINITION PUBLIC.
 

--- a/docs/cookbook/event_navigation/action.md
+++ b/docs/cookbook/event_navigation/action.md
@@ -32,5 +32,4 @@ client->follow_up_action(
 
 `val` is one of the frontend events from `z2ui5_if_client=>cs_event` (see
 [Frontend](./frontend.md)); `t_arg` carries the arguments the event expects. See
-[Follow-up Action](/cookbook/expert_more/follow_up_action) for the full details
-and sample `Z2UI5_CL_DEMO_APP_180` for a complete example.
+[Follow-up Action](/cookbook/expert_more/follow_up_action) for the full details.

--- a/docs/cookbook/event_navigation/exception.md
+++ b/docs/cookbook/event_navigation/exception.md
@@ -31,7 +31,7 @@ ENDMETHOD.
 ```
 
 #### Uncatchable Exceptions / Short Dumps
-What happens if your code raises uncatchable exceptions? Instead of an abap2UI5 popup, the raw ABAP runtime error (short dump) from the HTTP handler appears. Processing halts, and the user has to reload the browser. Reserve this for unexpected cases:
+What happens if your code raises uncatchable exceptions? The backend dumps, and the frontend shows its unified **fatal-error overlay**: a dialog that extracts and displays the server's error details, with a **Details** view, a **Copy** button for the error text and **Refresh / Logout** actions to restart. Processing halts until the user restarts the app from that dialog. Reserve this for unexpected cases:
 
 ```abap
 METHOD z2ui5_if_app~main.

--- a/docs/cookbook/event_navigation/frontend.md
+++ b/docs/cookbook/event_navigation/frontend.md
@@ -45,7 +45,7 @@ The following frontend events are available:
       play_audio                TYPE string VALUE `PLAY_AUDIO`,
       wizard_set_next_step      TYPE string VALUE `WIZARD_SET_NEXT_STEP`,
 
-      "Control calls (whitelisted, positional t_arg)
+      "Control calls (positional t_arg)
       control_by_id             TYPE string VALUE `CONTROL_BY_ID`,
       control_global            TYPE string VALUE `CONTROL_GLOBAL`,
       binding_call              TYPE string VALUE `BINDING_CALL`,
@@ -75,13 +75,16 @@ ENDMETHOD.
 
 ## Calling control methods on the frontend
 
-The last three constants — `control_by_id`, `control_global` and `binding_call` — are frontend events too, but instead of a fixed built-in action they invoke a *whitelisted* method on a control, a global object or a binding. Their arguments are **positional**: an empty argument between two filled ones keeps its slot as `` `` ``.
+The control-call constants — `control_by_id`, `control_global`, `binding_call` and `bind_element` — are frontend events too, but instead of a fixed built-in action they operate on a control, a global object, a binding or a whole view slot. Their arguments are **positional**: an empty argument between two filled ones keeps its slot as `` `` ``.
 
 | Event            | `t_arg` (positional)                                                                 |
 | ---------------- | ------------------------------------------------------------------------------------ |
-| `control_by_id`  | `id`, `method`, `params…` — call a whitelisted method on a control resolved by id     |
+| `control_by_id`  | `id`, `method`, `params…` — call a method on a control resolved by id                 |
 | `control_global` | `object`, `method`, `params…` — `MESSAGE_TOAST`, `MESSAGE_BOX`, `BUSY_INDICATOR`, `THEMING` |
-| `binding_call`   | `path`, `method`, `params…` — e.g. `filter` (operator, value1, value2) or `sort` (path, descending, group) |
+| `binding_call`   | `id`, `aggregation`, `method`, `params…` — e.g. `filter` (path, operator, value1, value2) or `sort` (path, descending, group) on the aggregation's binding |
+| `bind_element`   | `index`, `_bind( table )` — element-bind a whole view slot to a table row, see below  |
+
+For `control_by_id`, any public control method is callable as long as it is not on the framework's **denylist**: methods that would break abap2UI5's own invariants (destroying views, re-rendering, detaching the framework's handlers, …) are blocked, ordinary setters and toggles (`setVisible`, `toggleBy`, `enablePostButton`, …) simply work. A small set of methods is additionally special-cased for typed arguments. `control_global` and `binding_call` remain strict whitelists — only the listed global objects and the binding methods `filter` / `sort` are callable.
 
 ```abap
 " toggle a MessagePopover open, anchored to the pressing button, no roundtrip
@@ -91,6 +94,20 @@ press = client->_event_client(
 ```
 
 The same events also work from the backend with `client->follow_up_action( )` using the identical `t_arg`.
+
+### Element-binding a view slot: `bind_element`
+
+`bind_element` binds a whole view slot (popup, popover, main, …) to one row of a bound table — the abap2UI5 equivalent of `oControl.bindElement( )`. All *relative* bindings in that slot (`{NAME}`, `{CATEGORY}`, nested aggregations) then resolve against the selected row, so a detail popup needs no data copied into event arguments:
+
+```abap
+" element-bind the popup slot to row <index> of t_product
+client->follow_up_action(
+    val   = client->cs_event-bind_element
+    view  = client->cs_view-popup
+    t_arg = VALUE #( ( index ) ( client->_bind( t_product ) ) ) ).
+```
+
+The `view` parameter selects the slot to bind; `t_arg` carries the row index and the table's binding path. See demo app 470 in the [samples repository](https://github.com/abap2UI5/samples) for a complete example.
 
 ### The `view` parameter
 
@@ -107,8 +124,8 @@ press = client->_event_client(
     t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
 ```
 
-::: tip Migrated from a positional view slot
-The view used to be the second entry of `t_arg` (`id`, `view`, `method`, …). It is now the dedicated `view` importing parameter, so main-view calls simply omit it. Older examples that still pass `` `MAIN` `` as the second `t_arg` element continue to work.
+::: warning Migrated from a positional view slot
+The view used to be the second entry of `t_arg` (`id`, `view`, `method`, …). It is now the dedicated `view` importing parameter, and the framework injects it into the argument list itself. Older examples that still pass `` `MAIN` `` as the second `t_arg` element **no longer work** — the extra entry shifts every argument by one and the call fails on the frontend. Drop the positional view entry and use the `view` parameter instead.
 :::
 
-`control_global` and `binding_call` are not resolved by id and ignore `view`.
+`control_global` ignores `view` (it is not resolved by id), and `binding_call` always resolves its id across all open views. For `bind_element`, `view` selects the slot to element-bind (see above).

--- a/docs/cookbook/event_navigation/frontend.md
+++ b/docs/cookbook/event_navigation/frontend.md
@@ -33,22 +33,31 @@ The following frontend events are available:
       scroll_into_view          TYPE string VALUE `SCROLL_INTO_VIEW`,
       start_timer               TYPE string VALUE `START_TIMER`,
       keyboard_set_mode         TYPE string VALUE `KEYBOARD_SET_MODE`,
+      keyboard_shortcut         TYPE string VALUE `KEYBOARD_SHORTCUT`,
       open_new_tab              TYPE string VALUE `OPEN_NEW_TAB`,
       location_reload           TYPE string VALUE `LOCATION_RELOAD`,
+      nav_to_route              TYPE string VALUE `NAV_TO_ROUTE`,
       system_logout             TYPE string VALUE `SYSTEM_LOGOUT`,
       download_b64_file         TYPE string VALUE `DOWNLOAD_B64_FILE`,
       urlhelper                 TYPE string VALUE `URLHELPER`,
       history_back              TYPE string VALUE `HISTORY_BACK`,
       store_data                TYPE string VALUE `STORE_DATA`,
       play_audio                TYPE string VALUE `PLAY_AUDIO`,
+      wizard_set_next_step      TYPE string VALUE `WIZARD_SET_NEXT_STEP`,
 
       "Control calls (whitelisted, positional t_arg)
       control_by_id             TYPE string VALUE `CONTROL_BY_ID`,
       control_global            TYPE string VALUE `CONTROL_GLOBAL`,
       binding_call              TYPE string VALUE `BINDING_CALL`,
+      bind_element              TYPE string VALUE `BIND_ELEMENT`,
+
+      "Smart controls (sap.ui.comp)
+      smart_variant_init        TYPE string VALUE `SMART_VARIANT_INIT`,
+      filter_bar_variant_init   TYPE string VALUE `FILTER_BAR_VARIANT_INIT`,
 
     END OF cs_event.
 ```
+Some of these events have their own pages: [`keyboard_shortcut`](/cookbook/browser_interaction/keyboard_shortcuts) binds key combinations to backend events, [`nav_to_route`](/cookbook/event_navigation/routing) navigates by hash route, and [`smart_variant_init` / `filter_bar_variant_init`](/cookbook/expert_more/smart_controls) wire variant management for smart controls.
 For example, to open a new tab directly from a button press (no backend involved):
 ```abap
 METHOD z2ui5_if_app~main.

--- a/docs/cookbook/event_navigation/life_cycle.md
+++ b/docs/cookbook/event_navigation/life_cycle.md
@@ -55,7 +55,7 @@ For a tiny app with one or two events, inline the view and the handler directly 
 A few details of the request lifecycle are easy to miss and produce bugs that look like framework issues but are actually pattern mistakes. These are not enforced by the compiler and not reported at runtime.
 
 ### Bound Attributes Must Be Public
-Anything passed to `client->_bind( )` or `client->_bind( )` must live in `PUBLIC SECTION` — the framework binds via dynamic ASSIGN and silently ignores `PROTECTED`/`PRIVATE` attributes. Helper variables that never appear in a `_bind( )` call can stay private. Details and rationale on [Binding → Bound Attributes Must Be Public](/cookbook/model/binding#bound-attributes-must-be-public).
+Anything passed to `client->_bind( )` must live in `PUBLIC SECTION` — the framework binds via dynamic ASSIGN and silently ignores `PROTECTED`/`PRIVATE` attributes. Helper variables that never appear in a `_bind( )` call can stay private. Details and rationale on [Binding → Bound Attributes Must Be Public](/cookbook/model/binding#bound-attributes-must-be-public).
 
 ### The View Is Only Sent When You Call `view_display`
 abap2UI5 does not re-render the view automatically. After an event, if you do **not** call `client->view_display( ... )` again, the frontend keeps the previous view tree and only the model data is updated from the serialized state. This is the common case — most event handlers should mutate state and return, leaving the view alone.

--- a/docs/cookbook/event_navigation/navigation.md
+++ b/docs/cookbook/event_navigation/navigation.md
@@ -53,6 +53,10 @@ ENDMETHOD.
 Sounds familiar? The abap2UI5 framework echoes classic `call screen` and `leave to screen` behavior.
 :::
 
+::: tip Browser Back & Forward
+By default, the browser's Back button leaves the abap2UI5 page — it does not step through the app stack. Enable [hash-based routing](/cookbook/event_navigation/routing) with `client->set_nav_routing( )` to couple the browser's Back/Forward buttons to `nav_app_call` / `nav_app_leave` and make apps bookmarkable.
+:::
+
 For Launchpad-based cross app navigation, see the [Fiori Launchpad](/configuration/launchpad) page.
 
 ## Inner App Navigation

--- a/docs/cookbook/event_navigation/routing.md
+++ b/docs/cookbook/event_navigation/routing.md
@@ -1,0 +1,62 @@
+---
+outline: [2, 4]
+---
+# Routing
+
+By default, abap2UI5 leaves the URL hash untouched — the browser's Back and Forward buttons navigate away from the abap2UI5 page instead of moving between your apps. With **hash-based app routing** (UI5 Router style), the URL hash mirrors the running app as a bookmarkable route, and the browser Back/Forward buttons drive the server-side app stack.
+
+## Enabling Routing
+
+Enable routing once per session with `client->set_nav_routing( )` — typically in the launcher app's `check_on_init` branch:
+
+```abap
+METHOD z2ui5_if_app~main.
+
+  IF client->check_on_init( ).
+    client->set_nav_routing( ).   " mode defaults to cs_nav_mode-keep
+    view_display( ).
+  ENDIF.
+
+ENDMETHOD.
+```
+
+Once enabled, a forward navigation to another app (`client->nav_app_call`) pushes a new route history entry — the routing equivalent of a UI5 `navTo`. The browser Back button then returns to the calling app instead of leaving the page.
+
+## Routing Modes
+
+The mode (see `cs_nav_mode`) decides how much of the running app the URL hash carries — and therefore what Back/Forward, a reload, or a bookmark restores:
+
+| Mode      | Route                     | Back / Forward / reload / bookmark restore                                                                                     |
+| --------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `default` | *(hash untouched)*        | No routing — framework behavior as before this feature.                                                                        |
+| `fresh`   | `#/app/<CLASS>`           | The app starts **fresh**: a clean instance, no preserved input.                                                                |
+| `keep`    | `#/app/<CLASS>/<DRAFT>`   | The exact preserved state is restored (all user input), falling back to a fresh start once the draft has expired.              |
+
+```abap
+" route by class only - Back/reload/bookmark always restart the app fresh
+client->set_nav_routing( client->cs_nav_mode-fresh ).
+```
+
+::: tip Back restores the calling app as the user left it
+In `keep` mode, the calling app's route entry is advanced to the draft saved for it during the `nav_app_call`. Pressing Back therefore restores the calling app **as the user left it** — including everything two-way bound that changed on the client since the last render and traveled to the backend with the triggering event.
+:::
+
+::: warning Draft expiry
+`keep` routes carry a server draft id. Once the draft has expired (see `draft_exp_time_in_hours` in the [User Exits](/advanced/extensibility/user_exits)), the route falls back to a fresh start of the app class.
+:::
+
+## Navigating by Route
+
+With routing enabled, the `nav_to_route` frontend event navigates to another app by setting the hash route — without a backend roundtrip. It adds a browser history entry, so Back returns to the current app:
+
+```abap
+press = client->_event_client(
+    val   = client->cs_event-nav_to_route
+    t_arg = VALUE #( ( `Z2UI5_CL_NEW_APP` ) ) )
+```
+
+The argument is the target app class (or a full `app/<CLASS>` route). The event is a no-op unless the session has enabled routing.
+
+## Relation to Manual History Control
+
+Routing coexists with the manual history methods described in [URL Handling](/cookbook/browser_interaction/url_handling) (`set_push_state`, the `history_back` event). Those manipulate the hash yourself; routing lets the framework own the hash and map it to apps. For app-to-app navigation, prefer routing — reach for manual push states only for fine-grained in-app states.

--- a/docs/cookbook/expert_more/app_state_share.md
+++ b/docs/cookbook/expert_more/app_state_share.md
@@ -9,7 +9,7 @@ abap2UI5 saves the current app state so you can return to it later — like how 
 Each state persists as a draft with a unique ID. Calling `client->set_app_state_active` appends this ID as a hash fragment to the URL. The resulting URL is shareable — copy it and open it in another browser window (or send it to a colleague) to restore the same app state. The hash value (`z2ui5-xapp-state=...`) is a server-side key that points to the saved draft. Drafts expire after a configurable time (default: 4 hours, adjustable via [User Exits](/advanced/extensibility/user_exits)).
 
 An example URL: <br>
-`.../sap/bc/z2ui5?sap-client=001&app_start=z2ui5_cl_demo_app_000#/z2ui5-xapp-state=024251849E5A1EDFB1DAE2C97C8CE8C2`
+`.../sap/bc/z2ui5?sap-client=001&app_start=z2ui5_cl_demo_app_004#/z2ui5-xapp-state=024251849E5A1EDFB1DAE2C97C8CE8C2`
 
 ### Sample Code
 An implementation of the app state feature:

--- a/docs/cookbook/expert_more/follow_up_action.md
+++ b/docs/cookbook/expert_more/follow_up_action.md
@@ -55,9 +55,11 @@ anything containing JavaScript syntax runs verbatim.
 
 ## Calling a control method
 
-The whitelisted control calls — `cs_event-control_by_id`, `control_global` and
-`binding_call` — are frontend events too, so `follow_up_action( )` can invoke a
-method on a control once the backend response arrives. Their `t_arg` is
+The control calls — `cs_event-control_by_id`, `control_global`, `binding_call`
+and `bind_element` — are frontend events too, so `follow_up_action( )` can invoke a
+method on a control once the backend response arrives. For `control_by_id`, any
+public control method works unless it is on the framework's denylist;
+`control_global` and `binding_call` are strict whitelists. Their `t_arg` is
 positional (see [Frontend → Calling control methods](/cookbook/event_navigation/frontend#calling-control-methods-on-the-frontend)):
 
 ```abap
@@ -79,4 +81,4 @@ client->follow_up_action(
     t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `detail` ) ) ).
 ```
 
-See sample `Z2UI5_CL_DEMO_APP_180` for a complete example.
+See demo apps 470 (element binding) and 471 (keyboard shortcuts) in the [samples repository](https://github.com/abap2UI5/samples) for complete `follow_up_action` examples.

--- a/docs/cookbook/expert_more/lock.md
+++ b/docs/cookbook/expert_more/lock.md
@@ -16,7 +16,7 @@ The patterns below combine in different ways. The examples use the sales order h
 The minimal starting point — the user edits and saves, no lock and no conflict check. Last save wins, silently. Fine for personal sandboxes and throwaway demos, but rarely what you want in production.
 
 <details>
-<summary>Full source — <code>Z2UI5_CL_DEMO_APP_S_07</code></summary>
+<summary>Full source — <code>Z2UI5_CL_SAMPLE_LOCK_1</code></summary>
 
 ```abap
 * Scenario 1 — Naive editing (no locking)
@@ -29,7 +29,7 @@ The minimal starting point — the user edits and saves, no lock and no conflict
 *   - Personal sandboxes, throwaway demos, internal tools where only
 *     one user ever touches a record.
 
-CLASS z2ui5_cl_demo_app_s_07 DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_lock_1 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
@@ -50,7 +50,7 @@ CLASS z2ui5_cl_demo_app_s_07 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-CLASS z2ui5_cl_demo_app_s_07 IMPLEMENTATION.
+CLASS z2ui5_cl_sample_lock_1 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
@@ -166,7 +166,7 @@ ENDMETHOD.
 The lock exists for milliseconds, so this scales — but two parallel saves can still race if the timestamps line up, and the second one silently overwrites the first.
 
 <details>
-<summary>Full source — <code>Z2UI5_CL_DEMO_APP_S_08</code></summary>
+<summary>Full source — <code>Z2UI5_CL_SAMPLE_LOCK_2</code></summary>
 
 ```abap
 * Scenario 2 — Edit + Enqueue at save
@@ -179,7 +179,7 @@ The lock exists for milliseconds, so this scales — but two parallel saves can 
 *   - Quick edits with low chance of two users hitting the same record
 *   - Default starting point for most stateless editing apps
 
-CLASS z2ui5_cl_demo_app_s_08 DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_lock_2 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
@@ -198,7 +198,7 @@ CLASS z2ui5_cl_demo_app_s_08 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-CLASS z2ui5_cl_demo_app_s_08 IMPLEMENTATION.
+CLASS z2ui5_cl_sample_lock_2 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
@@ -322,7 +322,7 @@ No lock is held during the edit phase, so this scales to many concurrent users a
 Pick a column that *always* updates on writes. If anyone writes the table bypassing `AEDAT` / `UPD_TMSTMP`, the check silently misses real conflicts.
 
 <details>
-<summary>Full source — <code>Z2UI5_CL_DEMO_APP_S_09</code></summary>
+<summary>Full source — <code>Z2UI5_CL_SAMPLE_LOCK_3</code></summary>
 
 ```abap
 * Scenario 3 — Optimistic locking (timestamp check)
@@ -336,7 +336,7 @@ Pick a column that *always* updates on writes. If anyone writes the table bypass
 *   - Combine with Scenario 2 — it costs almost nothing and catches
 *     real bugs
 
-CLASS z2ui5_cl_demo_app_s_09 DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_lock_3 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
@@ -358,7 +358,7 @@ CLASS z2ui5_cl_demo_app_s_09 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-CLASS z2ui5_cl_demo_app_s_09 IMPLEMENTATION.
+CLASS z2ui5_cl_sample_lock_3 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
@@ -456,7 +456,7 @@ ENDCLASS.
 **Lock at Save** plus the **Optimistic Check** is the safest stateless pattern and the sensible production default — the enqueue serializes parallel saves of *this* app, the timestamp check catches everyone else.
 
 <details>
-<summary>Full source — <code>Z2UI5_CL_DEMO_APP_S_10</code></summary>
+<summary>Full source — <code>Z2UI5_CL_SAMPLE_LOCK_4</code></summary>
 
 ```abap
 * Scenario 4 — Combined (the recommended default)
@@ -470,7 +470,7 @@ ENDCLASS.
 *   - The timestamp check catches anyone who slipped in via another
 *     path (SE16, batch job, classic SAP GUI) between read and write.
 
-CLASS z2ui5_cl_demo_app_s_10 DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_lock_4 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
@@ -492,7 +492,7 @@ CLASS z2ui5_cl_demo_app_s_10 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-CLASS z2ui5_cl_demo_app_s_10 IMPLEMENTATION.
+CLASS z2ui5_cl_sample_lock_4 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
@@ -656,7 +656,7 @@ Each active user pins a work process. Use stateful sessions only for low-traffic
 :::
 
 <details>
-<summary>Full source — <code>Z2UI5_CL_DEMO_APP_S_11</code></summary>
+<summary>Full source — <code>Z2UI5_CL_SAMPLE_LOCK_5</code></summary>
 
 ```abap
 * Scenario 5 — Stateful session with a persistent enqueue
@@ -673,7 +673,7 @@ Each active user pins a work process. Use stateful sessions only for low-traffic
 * Cost: each active user pins a work process. Do NOT use this for
 * high-traffic apps.
 
-CLASS z2ui5_cl_demo_app_s_11 DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_lock_5 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
@@ -695,7 +695,7 @@ CLASS z2ui5_cl_demo_app_s_11 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-CLASS z2ui5_cl_demo_app_s_11 IMPLEMENTATION.
+CLASS z2ui5_cl_sample_lock_5 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
@@ -840,7 +840,7 @@ A soft lock is a row in a custom Z table marking *"user X is editing object Y"*.
 A user closing the browser without pressing *Release* leaves the row behind, so add a cleanup job that deletes entries older than, say, 30 minutes. The example below uses a matching `Z2UI5_SAMPLE_01` table.
 
 <details>
-<summary>Full source — <code>Z2UI5_CL_DEMO_APP_S_12</code></summary>
+<summary>Full source — <code>Z2UI5_CL_SAMPLE_LOCK_6</code></summary>
 
 ```abap
 * Scenario 6 — Soft lock (advisory only)
@@ -858,7 +858,7 @@ A user closing the browser without pressing *Release* leaves the row behind, so 
 *   LOCKED_AT  TIMESTAMPL  When the lock started
 * Delivery class A.
 
-CLASS z2ui5_cl_demo_app_s_12 DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_lock_6 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
@@ -885,7 +885,7 @@ CLASS z2ui5_cl_demo_app_s_12 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-CLASS z2ui5_cl_demo_app_s_12 IMPLEMENTATION.
+CLASS z2ui5_cl_sample_lock_6 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 

--- a/docs/cookbook/expert_more/smart_controls.md
+++ b/docs/cookbook/expert_more/smart_controls.md
@@ -1,0 +1,70 @@
+---
+outline: [2, 4]
+---
+# Smart Controls
+
+Smart controls from the `sap.ui.comp` library (SmartFilterBar, SmartTable, SmartForm, SmartField, SmartChart) build their UI from **OData V2 metadata** — combined with variant management, they give you a full list report without hand-built columns or filters.
+
+::: warning SAPUI5 only
+The `sap.ui.comp` library ships with SAPUI5 but not with OpenUI5 — apps using smart controls require a SAPUI5 bootstrap. See [UI5 Bootstrapping](/configuration/setup/ui5_bootstrapping).
+:::
+
+## Supported Controls
+
+The XML view builder covers the `sap.ui.comp` namespaces `smartfilterbar`, `smarttable`, `smartvariants`, `smartform`, `smartfield`, `smartchart` and `navpopover`. Since smart controls are metadata-driven, the app usually carries no ABAP data at all — it switches the default model to an OData service instead (see [OData](/cookbook/expert_more/odata)):
+
+```abap
+client->view_display( val                       = view->stringify( )
+                      switch_default_model_path = `/sap/opu/odata/IWBEP/GWSAMPLE_BASIC/` ).
+```
+
+## Page Variant
+
+A page variant is one `SmartVariantManagement` that owns the persistency for the whole page; SmartFilterBar and SmartTable register with it through their `smartvariant` association, each contributing its own `persistencykey`:
+
+```abap
+page->smart_variant_management(
+    id             = `pageVariantId`
+    persistencykey = `PageVariantPKey` ).
+
+page->smart_filter_bar(
+    id             = `smartFilterBar`
+    entityset      = `ProductSet`
+    smartvariant   = `pageVariantId`
+    persistencykey = `SmartFilterPKey` ).
+
+page->smart_table(
+    id                     = `smartTable`
+    smartfilterid          = `smartFilterBar`
+    smartvariant           = `pageVariantId`
+    entityset              = `ProductSet`
+    initiallyvisiblefields = `ProductID,Name,Category,Price`
+    usevariantmanagement   = `true`
+    persistencykey         = `SmartTablePKey` ).
+```
+
+### The `SMART_VARIANT_INIT` Handshake
+
+In a classic UI5 app, the controller calls `initialise( )` on the variant management once the smart controls have registered. Without it, the page variant never gets a personalizable control — saving a view fails in `sap.ui.fl` and stored views are never loaded. In abap2UI5, the `smart_variant_init` frontend event performs this handshake; it waits until the smart controls have registered (which they do once their OData metadata has arrived):
+
+```abap
+client->follow_up_action( val   = client->cs_event-smart_variant_init
+                          t_arg = VALUE #( ( `pageVariantId` ) ( `smartFilterBar` ) ) ).
+```
+
+`t_arg` is positional: the id of the `SmartVariantManagement` and the id of the `SmartFilterBar`.
+
+## Classic FilterBar with Variants
+
+A **classic** `sap.ui.comp.filterbar.FilterBar` knows nothing about variants: every list-report controller hand-writes the same callbacks (`registerFetchData` / `registerApplyData` / `registerGetFiltersWithValues`), adds a `PersonalizableInfo` and marks the variant dirty on each filter change. That is boilerplate over the bar's own filter items — data, not app logic — so the framework owns it. The `filter_bar_variant_init` frontend event wires a classic FilterBar to a `SmartVariantManagement` with no JavaScript in the app:
+
+```abap
+client->follow_up_action( val   = client->cs_event-filter_bar_variant_init
+                          t_arg = VALUE #( ( `variantId` ) ( `filterBarId` ) ) ).
+```
+
+`t_arg` is positional: the id of the `SmartVariantManagement` and the id of the `FilterBar`.
+
+::: tip Samples
+Demo apps **475–479** in the [samples repository](https://github.com/abap2UI5/samples) cover SmartField, SmartForm, SmartTable, the page variant handshake and SmartChart.
+:::

--- a/docs/cookbook/expert_more/snippets.md
+++ b/docs/cookbook/expert_more/snippets.md
@@ -252,4 +252,4 @@ CLASS z2ui5_cl_app_table_sort IMPLEMENTATION.
 ENDCLASS.
 ```
 
-For an interactive personalization dialog (column visibility, multi-sort, grouped filters), pair the table with `sap.m.p13n.Engine` or wrap it in a `SmartTable` — see the [UI5 SDK](https://sapui5.hana.ondemand.com) for the full feature set.
+For an interactive personalization dialog (column visibility, multi-sort, grouped filters), pair the table with `sap.m.p13n.Engine` or use a `SmartTable` with variant management — supported natively, see [Smart Controls](/cookbook/expert_more/smart_controls).

--- a/docs/cookbook/overview.md
+++ b/docs/cookbook/overview.md
@@ -11,7 +11,7 @@ The Cookbook collects task-oriented recipes for everyday abap2UI5 development. E
 Build the XML view your app sends to the browser. Covers the basic view definition, nesting views inside other views, and XML templating for repeating structures.
 
 #### [Model](/cookbook/model/binding)
-Share data between ABAP and the frontend. Explains one-way and two-way binding, expressions and formatters, tables and trees, the device model, and how to deal with the model size limit.
+Share data between ABAP and the frontend. Explains two-way data binding, expressions and formatters, tables and trees, the device model, and how to deal with the model size limit.
 
 #### [Event, Navigation](/cookbook/event_navigation/life_cycle)
 Understand how a request flows through your app. Covers the lifecycle, backend and frontend events, actions, navigation between apps, and exception handling.
@@ -38,7 +38,7 @@ EML/CDS/SQL integration with RAP, recurring patterns and helpers, troubleshootin
 
 - Each recipe stands on its own — read only the section you need.
 - Code snippets are copy-paste ready. Drop them into a class that implements `z2ui5_if_app`.
-- For full sample apps, browse the 250+ examples in the [samples repository](https://github.com/abap2UI5/samples).
+- For full sample apps, browse the hundreds of examples in the [samples repository](https://github.com/abap2UI5/samples).
 - For the API surface (`z2ui5_if_client`, `z2ui5_cl_xml_view`, …), read the source in the [main repository](https://github.com/abap2UI5/abap2UI5).
 
 → New to abap2UI5? Start with the [Getting Started Guide](/get_started/quickstart).

--- a/docs/cookbook/popup_popover/built_in.md
+++ b/docs/cookbook/popup_popover/built_in.md
@@ -22,7 +22,6 @@ Pre-built popup classes cover the most common cases. Call them via [navigation](
 | `Z2UI5_CL_POP_HTML` | Display HTML content |
 | `Z2UI5_CL_POP_IMAGE_EDITOR` | Edit an image (crop, resize, filter) |
 | `Z2UI5_CL_POP_MESSAGES` | Display a message table |
-| `Z2UI5_CL_POP_BAL` | Display a Business Application Log (BAL) |
 | `Z2UI5_CL_POP_ERROR` | Error display |
 | `Z2UI5_CL_POP_JS_LOADER` | Load custom JavaScript libraries |
 | `Z2UI5_CL_POP_DEMO_OUTPUT` | Quick demo-style output of arbitrary data |

--- a/docs/cookbook/translation_messages/logging.md
+++ b/docs/cookbook/translation_messages/logging.md
@@ -59,8 +59,8 @@ METHOD z2ui5_if_app~main.
 ENDMETHOD.
 ```
 
-#### BAL Popup
-Unlike message classes, BAL logs carry more detail — like timestamps. Use the dedicated BAL log popup to show them. All examples above also work with the `Z2UI5_CL_POP_BAL` popup for richer output. An example with abap-logger:
+#### BAL Logs
+Unlike message classes, BAL logs carry more detail — like timestamps. `Z2UI5_CL_POP_MESSAGES` accepts them like any other message source, so the examples above work for BAL logs too:
 
 ```abap
 METHOD z2ui5_if_app~main.
@@ -68,7 +68,7 @@ METHOD z2ui5_if_app~main.
   DATA(lo_log) = zcl_logger_factory=>create_log( desc = `ABAP Logger` ).
   lo_log->e( `This is an error...` ).
 
-  client->nav_app_call( z2ui5_cl_pop_bal=>factory( lo_log ) ).
+  client->nav_app_call( z2ui5_cl_pop_messages=>factory( lo_log ) ).
 
 ENDMETHOD.
 ```

--- a/docs/cookbook/troubleshooting/common_failures.md
+++ b/docs/cookbook/troubleshooting/common_failures.md
@@ -5,6 +5,10 @@ outline: [2, 4]
 
 Not every problem raises an ABAP exception. Many failures surface only in the browser, fail silently, or look like framework bugs when they are actually pattern mistakes. The sections below cover the ten most common ones — what the symptom looks like and where to find the real cause.
 
+::: tip Developer Tools first
+Press `Ctrl+F12` in the running app to open the built-in [Developer Tools](/configuration/troubleshooting) — the **Error**, **Log**, **Previous Request** and **Response** tabs show most of what the browser-DevTools steps below dig for, without leaving the app.
+:::
+
 ## Binding-Path Mismatch
 
 When a `_bind` path does not resolve against the JSON model on the frontend — typically because the public attribute was renamed, the data was never sent, or the path is mistyped — UI5 does **not** raise an ABAP exception. The control simply renders empty or with a default value.
@@ -18,7 +22,7 @@ Two-way binding silently drops the write-back when the path is invalid — your 
 
 ## Bound Attribute Not Public
 
-`_bind( )` and `_bind( )` resolve attributes via dynamic `ASSIGN` and only see the `PUBLIC SECTION`. Anything declared `PROTECTED` or `PRIVATE` is silently ignored — the binding path is generated, but no data is ever serialized for it. There is no compile-time or runtime error.
+`_bind( )` resolves attributes via dynamic `ASSIGN` and only sees the `PUBLIC SECTION`. Anything declared `PROTECTED` or `PRIVATE` is silently ignored — the binding path is generated, but no data is ever serialized for it. There is no compile-time or runtime error.
 
 Where to look:
 - **Symptom is identical to a binding-path mismatch.** The browser console shows the same `Binding "/path/..." was not found in model` warning, because the path was never populated on the wire.

--- a/docs/cookbook/view/nested_views.md
+++ b/docs/cookbook/view/nested_views.md
@@ -77,15 +77,15 @@ The whole point of nested views is to re-render only what changed. Four calls co
 | --------------------------------- | --------------------------------------------------------------------------------------------- |
 | `client->view_display( ... )`     | Replaces the main view's XML. The anchor is recreated, so any nested content is lost too.    |
 | `client->nest_view_display( ... )`| Replaces only the nested view. The main view stays on screen.                                |
-| `client->nest_view_model_update( )` | Pushes current ABAP data values into the **already-rendered** nested view. No re-render.   |
+| `client->view_model_update( )`    | Pushes current ABAP data values into **all already-rendered views**. No re-render.           |
 | `client->nest_view_destroy( )`    | Removes the nested view from the frontend without touching the main view.                    |
 
-The matching calls for the main view are `client->view_model_update( )` — push data changes into the rendered main view without re-rendering it — and `client->view_destroy( )`. The second nested slot has the same trio: `nest2_view_display( )`, `nest2_view_model_update( )` and `nest2_view_destroy( )`.
+The main view has the matching `client->view_destroy( )`; the second nested slot has `nest2_view_display( )` and `nest2_view_destroy( )`.
 
 A rule of thumb:
 
 - **Layout changed** (different controls, new columns, new sections) → `view_display` / `nest_view_display`.
-- **Only the data changed** (a flag flipped, a row added to a bound table) → `view_model_update` / `nest_view_model_update`.
+- **Only the data changed** (a flag flipped, a row added to a bound table) → `view_model_update`.
 
 `Z2UI5_CL_DEMO_APP_065` shows the difference between the three options in a single screen with one button per call.
 
@@ -129,7 +129,7 @@ METHOD view_display_detail.
 ENDMETHOD.
 ```
 
-The layout is bound editable (`mv_layout`), so events like *full-screen mode* or *close detail* simply update `mv_layout` and call `view_model_update` / `nest_view_model_update`. The FCL transitions itself; no view is rebuilt.
+The layout is bound editable (`mv_layout`), so events like *full-screen mode* or *close detail* simply update `mv_layout` and call `view_model_update`. The FCL transitions itself; no view is rebuilt.
 
 End-to-end samples:
 
@@ -137,23 +137,17 @@ End-to-end samples:
 - `Z2UI5_CL_DEMO_APP_097` — list master, `sap.ui.table.Table` in the detail with sort/filter/row actions.
 - `Z2UI5_CL_DEMO_APP_085` — full master-detail with an `ObjectPageLayout` as the nested detail, including search, sort, and the FCL fullscreen toggle.
 
-#### Refreshing the Right View
+#### Refreshing After Data Changes
 
-All bound data lives in a **single client-side model**, regardless of which view a binding was built in — `client->_bind( ... )` always writes to that one root model. What differs is *which rendered view you refresh* after the ABAP data changes: call the update method that matches the view.
+All bound data lives in a **single client-side model**, regardless of which view a binding was built in — `client->_bind( ... )` always writes to that one root model. One call therefore refreshes everything: after the ABAP data changes, `client->view_model_update( )` pushes the new values into every rendered view — main, nested, second nested.
 
 ```abap
 DELETE t_tab2 WHERE title = ls_arg-title.
-client->nest_view_model_update( ).   " push the new data into the nested view
+client->view_model_update( ).   " push the new data into all rendered views
 ```
 
-| Rendered view | Refresh call                          |
-| ------------- | ------------------------------------- |
-| main          | `client->view_model_update( )`        |
-| nested        | `client->nest_view_model_update( )`   |
-| nested (2nd)  | `client->nest2_view_model_update( )`  |
-
-::: tip `_bind`'s `view` parameter is obsolete
-Earlier releases kept a separate model per view and asked you to tag each binding with `view = client->cs_view-...` so the framework knew which model to refresh. That separation is gone — there is now one root model — and the `view` parameter of `_bind` / `_bind_edit` is an inert no-op kept only for backward compatibility. Omit it, and pick the target view through the matching `..._view_model_update( )` call instead.
+::: tip `nest_view_model_update` and the `view` parameter of `_bind` are obsolete
+Earlier releases kept a separate model per view: bindings were tagged with `view = client->cs_view-...` and each view had its own refresh call (`nest_view_model_update( )`, `nest2_view_model_update( )`). That separation is gone — there is now one root model. The old per-view refresh methods still exist as compatibility aliases and behave like `view_model_update( )`, and the `view` parameter of `_bind` / `_bind_edit` is an inert no-op. In new code, omit the parameter and use `view_model_update( )` only.
 :::
 
 #### Two Levels of Nesting
@@ -193,7 +187,7 @@ Plain composition is the right starting point: keep helper methods that take a p
 - The anchor id must be unique in the main view. The framework calls `byId` on the rendered view to find it; duplicate ids break the lookup.
 - Always provide `method_destroy` when a nested slot will be replaced more than once. Forgetting it causes nested fragments to accumulate.
 - Build the nested view in its own method (e.g. `view_display_detail`) and call it both from the initial render and from event handlers. Two call sites, one definition.
-- If a nested view does not pick up a data change, you probably need `nest_view_model_update( )`; if a control simply isn't there, you need `nest_view_display( )` again.
+- If a nested view does not pick up a data change, you probably need `view_model_update( )`; if a control simply isn't there, you need `nest_view_display( )` again.
 - For very large apps, look at `Z2UI5_CL_DEMO_APP_104`, which loads each detail screen from a separate `z2ui5_if_app` class and renders it into the nested slot. It is an advanced pattern — start with the simpler form first.
 
 See `Z2UI5_CL_DEMO_APP_065`, `Z2UI5_CL_DEMO_APP_069`, `Z2UI5_CL_DEMO_APP_085`, `Z2UI5_CL_DEMO_APP_097`, `Z2UI5_CL_DEMO_APP_098`, and `Z2UI5_CL_DEMO_APP_104` for runnable examples covering every variation above.

--- a/docs/cookbook/view/nested_views.md
+++ b/docs/cookbook/view/nested_views.md
@@ -133,7 +133,6 @@ The layout is bound editable (`mv_layout`), so events like *full-screen mode* or
 
 End-to-end samples:
 
-- `Z2UI5_CL_DEMO_APP_069` — tree master, two interchangeable detail apps (`addMidColumnPage`).
 - `Z2UI5_CL_DEMO_APP_097` — list master, `sap.ui.table.Table` in the detail with sort/filter/row actions.
 - `Z2UI5_CL_DEMO_APP_085` — full master-detail with an `ObjectPageLayout` as the nested detail, including search, sort, and the FCL fullscreen toggle.
 
@@ -190,4 +189,4 @@ Plain composition is the right starting point: keep helper methods that take a p
 - If a nested view does not pick up a data change, you probably need `view_model_update( )`; if a control simply isn't there, you need `nest_view_display( )` again.
 - For very large apps, look at `Z2UI5_CL_DEMO_APP_104`, which loads each detail screen from a separate `z2ui5_if_app` class and renders it into the nested slot. It is an advanced pattern — start with the simpler form first.
 
-See `Z2UI5_CL_DEMO_APP_065`, `Z2UI5_CL_DEMO_APP_069`, `Z2UI5_CL_DEMO_APP_085`, `Z2UI5_CL_DEMO_APP_097`, `Z2UI5_CL_DEMO_APP_098`, and `Z2UI5_CL_DEMO_APP_104` for runnable examples covering every variation above.
+See `Z2UI5_CL_DEMO_APP_065`, `Z2UI5_CL_DEMO_APP_085`, `Z2UI5_CL_DEMO_APP_097`, `Z2UI5_CL_DEMO_APP_098`, and `Z2UI5_CL_DEMO_APP_104` for runnable examples covering every variation above.

--- a/docs/get_started/hello_world.md
+++ b/docs/get_started/hello_world.md
@@ -148,5 +148,5 @@ ENDCLASS.
 That's all you need. Set a breakpoint to watch the communication and data updates in action, then try changing the view, events, and data flow.
 
 ### Jump into the Code
-Press `Ctrl+F12` in any running app to open the source code, view, and model side by side:
-![Source code viewer opened with Ctrl+F12 showing code, view, and model](/get_started/image-2.png)
+Press `Ctrl+F12` in any running app to open the **Developer Tools** — tabs for the app's source code, the rendered view XML, the model data, the request/response pair and the error log:
+![Developer Tools opened with Ctrl+F12 showing code, view, and model](/get_started/image-2.png)

--- a/docs/get_started/next.md
+++ b/docs/get_started/next.md
@@ -6,7 +6,7 @@ outline: [2, 4]
 You've installed abap2UI5 and built your first app. From here, pick the direction that fits your goals.
 
 #### Sample Apps
-With 250+ samples, the [samples repository](https://github.com/abap2UI5/samples) is the fastest way to learn abap2UI5. Browse tables, lists, trees, and other UI5 controls — copy and paste snippets to speed up your own work:
+With hundreds of samples, the [samples repository](https://github.com/abap2UI5/samples) is the fastest way to learn abap2UI5. Browse tables, lists, trees, and other UI5 controls — copy and paste snippets to speed up your own work:
 
 ![Sample apps overview showing tables, lists, trees, and other UI5 controls](/get_started/image-1.png)
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -9,12 +9,14 @@ Key facts for AI assistants generating abap2UI5 apps:
 - CRITICAL — most common bug: always call `view_display( )` in the `check_on_navigated( )` branch. After returning from a sub-app called via `nav_app_call( )`, the browser still shows the sub-app's view — the framework does not restore the previous view automatically. App state survives the roundtrip serialization, so no data re-read is needed; only the view must be rendered again. Skipping this leaves a blank screen after navigating back.
 - Build views as UI5 XML strings with `z2ui5_cl_util_xml` (1:1 translation of UI5 SDK XML, recommended for AI) or `z2ui5_cl_xml_view` (fluent API).
 - Attributes bound with `_bind` / `_bind_edit` must be PUBLIC; use backtick string literals.
+- Optional hash-based routing: `client->set_nav_routing( )` (once, e.g. in the launcher app's `check_on_init`) makes apps bookmarkable and couples browser Back/Forward to `nav_app_call` / `nav_app_leave`.
 
 ## Docs
 
 - [AI Agent Briefing](https://abap2ui5.github.io/docs/advanced/agent.html): single source of truth for app-building (template, client API, lifecycle, view builders, deprecated controls)
 - [Life Cycle](https://abap2ui5.github.io/docs/cookbook/event_navigation/life_cycle.html): lifecycle checks and pitfalls, including the blank-screen-after-navigation bug
 - [Navigation](https://abap2ui5.github.io/docs/cookbook/event_navigation/navigation.html): cross-app navigation and re-displaying the view on return
+- [Routing](https://abap2ui5.github.io/docs/cookbook/event_navigation/routing.html): hash-based app routing, browser Back/Forward, bookmarkable apps
 - [Quickstart](https://abap2ui5.github.io/docs/get_started/quickstart.html): installation and first app
 
 ## Examples

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -5,7 +5,7 @@
 Key facts for AI assistants generating abap2UI5 apps:
 
 - The canonical AI briefing is https://abap2ui5.github.io/docs/advanced/agent.html — read it before generating any app code.
-- Dispatch inside `main( )` with `IF` / `ELSEIF` over `client->check_on_init( )`, `client->check_on_navigated( )` and `client->check_on_event( 'NAME' )`.
+- Dispatch inside `main( )` with `IF` / `ELSEIF` over `client->check_on_init( )`, `client->check_on_navigated( )` and `client->check_on_event( 'NAME' )`. For the event branch, `CASE client->get( )-event` is an equally common alternative — both are fully supported.
 - CRITICAL — most common bug: always call `view_display( )` in the `check_on_navigated( )` branch. After returning from a sub-app called via `nav_app_call( )`, the browser still shows the sub-app's view — the framework does not restore the previous view automatically. App state survives the roundtrip serialization, so no data re-read is needed; only the view must be rendered again. Skipping this leaves a blank screen after navigating back.
 - Build views as UI5 XML strings with `z2ui5_cl_util_xml` (1:1 translation of UI5 SDK XML, recommended for AI) or `z2ui5_cl_xml_view` (fluent API).
 - Attributes bound with `_bind` / `_bind_edit` must be PUBLIC; use backtick string literals.

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Release Notes
 
+### 1.142.0
+2026-07-20
+- Added frontend action functions: `control_by_id`, `binding_call`
+- Added new frontend events, e.g. `SYSTEM_LOGOUT` and `KEYBOARD_SET_MODE`
+- Extended the Debug Tool with error/log tabs and export (renamed to Developer Tools)
+- Performance: introduced delta data transfer — only changed fields/rows are sent to the backend
+- Compatibility: UI5 1.71 / UI5 2.x fixes (lazy module loading, lifecycle, aggregation escaping)
+- Security: error message sanitization, security response headers, fatal-error overlay
+- Samples repository fully reworked
+- Various small improvements and bug fixes
+
 ### 1.141.0
 2025-12-14
 - Added Image Editor popup for image manipulation

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -20,7 +20,7 @@ outline: [2, 4]
 - Added Camera Selector control with facing mode support
 - Added Camera Picture control with configurable height/width
 - Implemented security headers in HTTP response handling
-- Added experimental `check_on_event` method for improved event handling *(since adopted as the standard dispatch API used throughout these docs)*
+- Added experimental `check_on_event` method for improved event handling *(since adopted as a fully supported dispatch API alongside `CASE client->get( )-event`)*
 - Added experimental `_event_nav_app_leave` method for navigation
 - Improved error handling with enhanced error popup
 - Updated ajson library to latest version

--- a/docs/technical/concept.md
+++ b/docs/technical/concept.md
@@ -170,9 +170,7 @@ And its View Model:
 ```json
 {
    "MODEL": {
-      "XX": {
-         "NAME": "test"
-      }
+      "NAME": "test"
    }
 }
 ```


### PR DESCRIPTION
Two commits: the first documents the July framework features that were still missing, the second fixes documentation drift found by cross-checking every page against the framework and samples sources.

## New feature documentation

- **Routing** (new page): hash-based app routing — `set_nav_routing( )`, the `cs_nav_mode` modes (DEFAULT / FRESH / KEEP) with their route formats and restore behavior, the `NAV_TO_ROUTE` event, draft expiry, and the relation to manual push states. Cross-linked from Navigation, URL Handling, the AI briefing and `llms.txt`.
- **Keyboard Shortcuts** (new page): `cs_event-keyboard_shortcut` — registration, aliases, rebind/unregister, registry lifetime (demo app 471).
- **Smart Controls** (new page): supported `sap.ui.comp` namespaces, the `SMART_VARIANT_INIT` and `FILTER_BAR_VARIANT_INIT` handshakes, SAPUI5-only caveat (demo apps 475–479). `snippets.md` now points here instead of sending readers to the UI5 SDK.
- **Security**: CSRF defense documented — on by default, opt-out via `check_csrf_active` in the POST user exit.
- `frontend.md`: `cs_event` constants synced with `z2ui5_if_client`; `bind_element` documented (sample-470 pattern).
- `nested_views.md`: `nest_view_model_update` is an obsolete alias — one root model, `view_model_update` refreshes all rendered views.
- Changelog: v1.142.0 release notes.

## Drift fixes (verified against the sources)

- **`agent.md`**: recommended builder is `z2ui5_cl_xml_view` (+ `_generic( )`) — `z2ui5_cl_util_xml` is retired in the framework's obsolete package and used by no sample; briefing links now point at `AGENTS.md` (the `CLAUDE.md` files are gone/stubs); garbled `_bind` table row fixed; non-existent `Z2UI5_CL_POP_BAL` removed; volatile counts dropped.
- **`security.md` / `ui5_bootstrapping.md`**: the default CSP **does** include `'unsafe-eval'` (required by the 1.71 ui5loader) plus the `object-src` / `base-uri` / `frame-ancestors` hardening directives; the obsolete "older releases" workaround is replaced by a hardening section on dropping `'unsafe-eval'`.
- **`frontend.md` / `follow_up_action.md`**: `control_by_id` is denylist-based since #2473 (`control_global` / `binding_call` stay whitelists); `binding_call` args corrected to `id`, `aggregation`, `method`, `params…`; the positional `MAIN` view slot no longer works — compat tip flipped to a migration warning.
- `exception.md`: backend dumps surface in the fatal-error overlay (details, copy, refresh/logout), not as a raw dump page.
- `concept.md`: removed `XX` model node dropped from the JSON example.
- Developer Tools: `troubleshooting.md`, `hello_world.md` and `common_failures.md` now use the current name and document the tab set and the export (including ABAP class source).
- `Z2UI5_CL_POP_BAL` removed from `built_in.md` / `logging.md` (class never existed; the BAL example uses `pop_messages`).
- Stale sample references cleaned up: apps 069/075/139/180 (obsolete or deleted) dropped or replaced; `lock.md`'s phantom classes `S_07`–`S_12` renamed to didactic `z2ui5_cl_sample_lock_*` names; `app_state_share.md` example URL fixed.
- `llms.txt` / `changelog.md`: both event-dispatch styles (`check_on_event` and `CASE get( )-event`) are supported — the "standard throughout these docs" claim is gone.

VitePress build passes (dead-link check included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbpfvqvhEousDhRHWRaWMj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbpfvqvhEousDhRHWRaWMj)_