### PR TITLE
Document check_on_navigated behavior for keep route restores

### DIFF
--- a/docs/cookbook/event_navigation/routing.md
+++ b/docs/cookbook/event_navigation/routing.md
@@ -45,6 +45,10 @@ In `keep` mode, the calling app's route entry is advanced to the draft saved for
 `keep` routes carry a server draft id. Once the draft has expired (see `draft_exp_time_in_hours` in the [User Exits](/advanced/extensibility/user_exits)), the route falls back to a fresh start of the app class.
 :::
 
+::: warning A `keep` restore enters through `check_on_navigated`, not `check_on_init`
+Restoring a `keep` route (browser Back/Forward, a reload, a bookmark) loads the app from its draft and runs `main( )` with `client->check_on_navigated( )` true — `check_on_init( )` stays false, the instance already exists. As everywhere else, render the view in that branch (see [Life Cycle](/cookbook/event_navigation/life_cycle#returning-from-a-sub-app-hits-check_on_navigated-not-check_on_init)). An app that renders only on `check_on_init( )` answers without a view and the browser keeps showing the previous screen — a Forward press onto such an app appears to do nothing. This applies to **every** app reachable through routing, including detail pages that are only ever entered via `nav_app_call( )`.
+:::
+
 ## Navigating by Route
 
 With routing enabled, the `nav_to_route` frontend event navigates to another app by setting the hash route — without a backend roundtrip. It adds a browser history entry, so Back returns to the current app:


### PR DESCRIPTION
## Summary
Added documentation clarifying the lifecycle behavior when restoring a `keep` route through browser navigation, reload, or bookmarks.

## Changes
- Added a warning note explaining that restoring a `keep` route invokes `check_on_navigated()` rather than `check_on_init()`
- Documented that the app instance already exists when restoring, so `check_on_init()` remains false
- Clarified that views must be rendered in the `check_on_navigated` branch to avoid showing stale UI
- Warned that apps rendering only on `check_on_init()` will appear unresponsive when restored via Forward navigation
- Noted this behavior applies to all routable apps, including detail pages entered via `nav_app_call()`

## Details
This documentation addition helps developers understand a critical lifecycle distinction: when users navigate back/forward through browser history or reload a bookmarked `keep` route, the app loads from its draft and follows the `check_on_navigated` path, not the initialization path. Apps that only render conditionally on `check_on_init()` will fail to display properly in these scenarios, potentially confusing users.

https://claude.ai/code/session_016USY5fyCFzP56BZTFz6iTM