### PR TITLE
Clarify binding behavior and remove "two-way" terminology

### DIFF
--- a/docs/cookbook/device_capabilities/geolocation.md
+++ b/docs/cookbook/device_capabilities/geolocation.md
@@ -5,7 +5,7 @@ outline: [2, 4]
 
 abap2UI5 offers a custom control for reading geolocation data from the user's device — longitude, latitude, altitude, speed, and accuracy values. This is handy for logistics apps, field service tools, or any scenario where location matters.
 
-The control fires a `finished` event once the browser resolves the device position, and two-way binding writes every value back into your ABAP attributes. See also `Z2UI5_CL_DEMO_APP_120`.
+The control fires a `finished` event once the browser resolves the device position, and the binding writes every value back into your ABAP attributes. See also `Z2UI5_CL_DEMO_APP_120`.
 
 ```abap
 CLASS z2ui5_cl_sample_geolocation DEFINITION PUBLIC.

--- a/docs/cookbook/device_capabilities/upload_download.md
+++ b/docs/cookbook/device_capabilities/upload_download.md
@@ -3,7 +3,7 @@ outline: [2, 4]
 ---
 # Upload, Download
 
-abap2UI5 handles file uploads and downloads by sending base64-encoded data over two-way binding.
+abap2UI5 handles file uploads and downloads by sending base64-encoded data over the binding.
 
 #### Upload
 ```abap

--- a/docs/cookbook/eml_cds_sql/draft_handling.md
+++ b/docs/cookbook/eml_cds_sql/draft_handling.md
@@ -222,7 +222,7 @@ ENDCLASS.
 That's a complete, working draft app. The three numbered comments map one-to-one onto the lifecycle diagram: **open → edit → activate**.
 
 ::: warning Why two steps to save?
-Notice that *Save* does two things: `UPDATE FIELDS` (copy the user's typed values into the draft) **then** `Activate` (promote the draft to active). The fields are two-way bound with `_bind`, so on each roundtrip the user's input lives in your ABAP variables — but it is **not** in the draft yet until you push it back with `UPDATE FIELDS`. Forgetting this step is the most common beginner mistake: the activate succeeds but saves the *old* values.
+Notice that *Save* does two things: `UPDATE FIELDS` (copy the user's typed values into the draft) **then** `Activate` (promote the draft to active). The fields are bound with `_bind`, so on each roundtrip the user's input lives in your ABAP variables — but it is **not** in the draft yet until you push it back with `UPDATE FIELDS`. Forgetting this step is the most common beginner mistake: the activate succeeds but saves the *old* values.
 :::
 
 ## The Full App — A Real-World Edit Screen
@@ -381,7 +381,7 @@ ENDMETHOD.
 ```
 
 #### 6. Saving Typed Values Back to the Draft
-The fields are two-way bound (`client->_bind( … )`), so user input lives in ABAP variables on the next roundtrip. To persist them in the draft, push them back with `UPDATE FIELDS`.
+The fields are bound (`client->_bind( … )`), so user input lives in ABAP variables on the next roundtrip. To persist them in the draft, push them back with `UPDATE FIELDS`.
 ```abap
 METHOD save_current_to_draft.
   MODIFY ENTITIES OF i_banktp

--- a/docs/cookbook/event_navigation/routing.md
+++ b/docs/cookbook/event_navigation/routing.md
@@ -38,7 +38,7 @@ client->set_nav_routing( client->cs_nav_mode-fresh ).
 ```
 
 ::: tip Back restores the calling app as the user left it
-In `keep` mode, the calling app's route entry is advanced to the draft saved for it during the `nav_app_call`. Pressing Back therefore restores the calling app **as the user left it** — including everything two-way bound that changed on the client since the last render and traveled to the backend with the triggering event.
+In `keep` mode, the calling app's route entry is advanced to the draft saved for it during the `nav_app_call`. Pressing Back therefore restores the calling app **as the user left it** — including every bound value that changed on the client since the last render and traveled to the backend with the triggering event.
 :::
 
 ::: warning Draft expiry

--- a/docs/cookbook/model/binding.md
+++ b/docs/cookbook/model/binding.md
@@ -3,7 +3,7 @@ outline: [2, 4]
 ---
 # Binding
 
-In abap2UI5 you share data between your ABAP code and the UI5 frontend with `client->_bind( )`. Binding is **two-way**: when the value is changed in an editable control, the framework writes it back to your ABAP attribute before the next event handler runs. Only the paths the user actually edited are transported back (a delta), so read-only data costs nothing on the way back.
+In abap2UI5 you share data between your ABAP code and the UI5 frontend with `client->_bind( )`. There is only one binding, and it works **in both directions**: when the value is changed in an editable control, the framework writes it back to your ABAP attribute before the next event handler runs. Only the paths the user actually edited are transported back (a delta), so read-only data costs nothing on the way back.
 
 #### Displaying Data
 Bind an attribute to a display-only control (e.g. `text`) — nothing is editable there, so nothing syncs back:
@@ -64,7 +64,7 @@ ENDCLASS.
 ```
 
 ::: tip `_bind_edit` is obsolete
-Earlier releases split binding into `_bind` (one-way) and `_bind_edit` (two-way). Both now bind two-way and write to the same model, so `_bind_edit` is only an obsolete alias of `_bind` — prefer `_bind( )`. You will still find `_bind_edit` in older examples.
+Earlier releases split binding into a display-only `_bind` and a writable `_bind_edit`. Both now write to the same model and behave identically, so `_bind_edit` is only an obsolete alias of `_bind` — prefer `_bind( )`. You will still find `_bind_edit` in older examples.
 :::
 
 ::: warning **Bound Attributes Must Be Public**

--- a/docs/cookbook/model/formatter.md
+++ b/docs/cookbook/model/formatter.md
@@ -9,7 +9,7 @@ UI5 formatter types use a special JSON-based binding syntax with these key eleme
 - **`parts: [...]`** — lists the model paths used as input (e.g., amount + currency)
 - **`type: '...'`** — the UI5 formatter type (e.g., `sap.ui.model.type.Currency`)
 - **`formatOptions: {...}`** — optional settings that control the output format
-- **`constraints: {...}`** — optional input constraints for two-way binding
+- **`constraints: {...}`** — optional constraints applied when user input is parsed back
 
 Note on ABAP syntax: inside string templates (`|...|`), escape the curly braces as `\{` and `\}`, because `{ }` normally denotes an embedded ABAP expression.
 
@@ -95,7 +95,7 @@ ABAP `abap_bool` is `"X"` or `""`. UI5's `CheckBox` expects `true` / `false`. Tw
 ```
 This resolves to `{= ${/MV_FLAG} === 'X' }`. Note that expression bindings cannot write back — checking the box will not flip the ABAP attribute.
 
-**ABAP-side conversion** — keep a parallel `string`-typed attribute (`'true'` / `'false'`) for two-way binding, and translate before/after each event:
+**ABAP-side conversion** — keep a parallel `string`-typed attribute (`'true'` / `'false'`) to bind against, and translate before/after each event:
 ```abap
 DATA flag_bool TYPE abap_bool.
 DATA flag_str  TYPE string.   " 'true' / 'false' for the checkbox

--- a/docs/cookbook/overview.md
+++ b/docs/cookbook/overview.md
@@ -14,7 +14,7 @@ The rules that decide whether an app works or fails in a hard-to-debug way, cond
 Build the XML view your app sends to the browser. Covers the basic view definition, deprecated controls to stay away from, nesting views inside other views, and XML templating for repeating structures.
 
 #### [Model](/cookbook/model/binding)
-Share data between ABAP and the frontend. Explains two-way data binding, expressions and formatters, tables and trees, the device model, and how to deal with the model size limit.
+Share data between ABAP and the frontend. Explains data binding, expressions and formatters, tables and trees, the device model, and how to deal with the model size limit.
 
 #### [Event, Navigation](/cookbook/event_navigation/life_cycle)
 Understand how a request flows through your app. Covers the lifecycle, backend and frontend events, actions, navigation between apps, and exception handling.

--- a/docs/cookbook/troubleshooting/common_failures.md
+++ b/docs/cookbook/troubleshooting/common_failures.md
@@ -18,7 +18,7 @@ Where to look:
 - **Network tab.** Inspect the abap2UI5 response payload — the JSON model is included verbatim. If the field is absent or named differently than your binding path, you have your answer.
 - **ABAP side.** Nothing. The backend never learns the binding failed. Asserting "no console warnings" is the only way to catch this in tests.
 
-Two-way binding silently drops the write-back when the path is invalid — your ABAP attribute keeps its old value after the next event. Cross-check the attribute value in the debugger if data is mysteriously not updating.
+Binding silently drops the write-back when the path is invalid — your ABAP attribute keeps its old value after the next event. Cross-check the attribute value in the debugger if data is mysteriously not updating.
 
 ## Bound Attribute Not Public
 
@@ -40,7 +40,7 @@ Where to look:
 
 See [Binding → Data-Type Mapping](/cookbook/model/binding#data-type-mapping) for the type-mapping table and [Formatter](/cookbook/model/formatter) for the patterns.
 
-## Two-Way Binding Through a Typed Formatter
+## Write-Back Through a Typed Formatter
 
 When `_bind( )` is wrapped in a `parts: [ … ], type: 'sap.ui.model.type.…'` binding, the type owns both directions — display and parse. If the value the user types does not match the formatter's expectations (locale, pattern, decimals, currency code), UI5 raises a parse exception and drops the write-back on the frontend. The ABAP attribute keeps its old value, and the next event arrives with stale data.
 

--- a/docs/resources/deprecations.md
+++ b/docs/resources/deprecations.md
@@ -18,9 +18,10 @@ UI5 itself (`sap.ui.commons`, the legacy charts, the Belize themes …) see
 
 ### `_bind_edit( )` → `_bind( )`
 
-Earlier releases split binding into `_bind` (one-way) and `_bind_edit`
-(two-way). That split is gone: both bind **two-way** and write to the same root
-model, so `_bind_edit` is only an alias.
+Earlier releases split binding into a display-only `_bind` and a writable
+`_bind_edit`. That split is gone: there is only **one** binding left — both
+write to the same root model and behave identically, so `_bind_edit` is only an
+alias.
 
 ```abap
 " old


### PR DESCRIPTION
## Summary
This PR updates documentation to clarify the binding behavior in abap2UI5 and removes outdated "two-way binding" terminology that no longer accurately reflects the current implementation.

## Key Changes
- **Clarified binding semantics**: Updated descriptions to explain that there is now only **one** binding method (`_bind`) that works in both directions, rather than separate one-way and two-way bindings
- **Removed "two-way binding" terminology**: Replaced instances of "two-way binding" with more precise language like "binding", "write-back", or "works in both directions" throughout the documentation
- **Updated deprecation notes**: Clarified that `_bind_edit` is an obsolete alias of `_bind`, with both now behaving identically and writing to the same model
- **Improved formatter documentation**: Changed "constraints for two-way binding" to "constraints applied when user input is parsed back" for better clarity
- **Consistent terminology**: Applied these changes across multiple documentation files including:
  - Deprecations guide
  - Draft handling cookbook
  - Binding model documentation
  - Formatter documentation
  - Troubleshooting guide
  - Device capabilities (geolocation, upload/download)
  - Routing documentation
  - Overview page

## Notable Details
The changes maintain technical accuracy while improving clarity for users. The binding mechanism itself hasn't changed — only the documentation's explanation of how it works has been refined to be more precise and less confusing for new users who might misunderstand "two-way" as implying separate code paths.

https://claude.ai/code/session_01HzHBXbRjKGA5rLRYPJKGX9