### PR TITLE
Every ABAP example now compiles and is linted; the frozen builder is gone from all 122 pages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,42 @@
+# What a pull request against this documentation gets checked for.
+#
+# There was nothing before this: deploy.yml runs on push to main, so a broken
+# build or a broken example reached the site and was found there. A docs
+# repository has no compiler for its prose - but the fenced ABAP is code, and
+# the site build is a build, so both can be decided before a merge.
+name: check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+
+      # a page that does not build is a page nobody can read
+      - name: vitepress build
+        run: npm run docs:build
+
+      # the ABAP in the fenced blocks, against the real framework: does it
+      # compile, and does the view it builds name controls and properties that
+      # exist on the UI5 floor this documentation targets
+      - name: ABAP examples
+        if: ${{ !cancelled() }}
+        run: npm run check:examples

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -89,7 +89,9 @@ export default defineConfig({
         ],
       },
       {
-        text: "1.141.0",
+        // the released framework version — z2ui5_if_app=>version in
+        // abap2UI5/src/02/z2ui5_if_app.intf.abap is where it comes from
+        text: "1.142.0",
         items: [
           { text: "Release", link: "/resources/changelog" },
           { text: "Support", link: "/resources/support" },
@@ -114,6 +116,7 @@ export default defineConfig({
               { text: "Full Example", link: "/get_started/full_example" },
             ],
           },
+          { text: "Tooling", link: "/get_started/tooling" },
           { text: `What's Next?`, link: "/get_started/next" },
         ],
       },

--- a/docs/advanced/extensibility/custom_control.md
+++ b/docs/advanced/extensibility/custom_control.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Custom Controls
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 You can build your own UI5 custom controls and use them in abap2UI5 apps.
 
 First, set up your VS Code environment with the abap2UI5 frontend artifacts, following the [Frontend](/advanced/extensibility/frontend) page.
@@ -23,5 +12,25 @@ First, set up your VS Code environment with the abap2UI5 frontend artifacts, fol
 Write the JavaScript for your new custom control. Each custom control lives in its own file under [app/webapp/cc/](https://github.com/abap2UI5/abap2UI5/tree/main/app/webapp/cc) — copy an existing one (e.g. `Timer.js`) and adapt it to your needs.
 
 #### Backend
-Extend the custom control view class by adding a method and defining the new control's properties:
-[z2ui5_cl_xml_view_cc.clas.abap](https://github.com/abap2UI5/abap2UI5/blob/main/src/99/z2ui5_cl_xml_view_cc.clas.abap)
+
+Nothing. The current view builder has no method per control, so a custom
+control needs no backend counterpart — write the element and its properties
+directly, in the `z2ui5.cc` namespace the frontend registers:
+
+```abap
+view->ele( n = `View` ns = `mvc`
+    )->a( n = `xmlns`       v = `sap.m`
+    )->a( n = `xmlns:mvc`   v = `sap.ui.core.mvc`
+    )->a( n = `xmlns:z2ui5` v = `z2ui5.cc`
+
+    )->ele( `Page`
+        )->tag( n = `MyControl` ns = `z2ui5`
+            )->a( n = `value`   v = client->_bind( mv_value )
+            )->a( n = `onEvent` v = client->_event( `MY_EVENT` ) ).
+```
+
+The wrapper class the previous builder needed for this
+([`z2ui5_cl_xml_view_cc`](https://github.com/abap2UI5/abap2UI5/blob/main/src/99/z2ui5_cl_xml_view_cc.clas.abap))
+is frozen along with the builder itself, and adding a method to it is no longer
+part of shipping a custom control.
+

--- a/docs/advanced/extensibility/custom_control.md
+++ b/docs/advanced/extensibility/custom_control.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Custom Controls
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 You can build your own UI5 custom controls and use them in abap2UI5 apps.
 
 First, set up your VS Code environment with the abap2UI5 frontend artifacts, following the [Frontend](/advanced/extensibility/frontend) page.

--- a/docs/advanced/fiori.md
+++ b/docs/advanced/fiori.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Integration into Fiori Elements Apps
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Extend the object page of a Fiori list report app with an abap2UI5 app. See the [ABAP2UI5_COMP_CONT repository](https://github.com/axelmohnen/ABAP2UI5_COMP_CONT) for a complete example.
 
 <img width="747" height="387" alt="abap2UI5 app embedded in Fiori Elements object page" src="https://github.com/user-attachments/assets/c14d5732-3b8c-4fa5-83ab-6d188a4d87db" />
@@ -95,13 +84,22 @@ On the ABAP side, the app receives the Fiori startup parameters (like the app cl
 
     ENDIF.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->page( showheader = abap_false
-                             backgrounddesign = `List` )->content( ). "Backgrounddesign "List" sets a white background color
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-    page->text( `TEXT` ).
+            )->ele( `Page`
+                )->a( n = `showHeader` b = abap_false
+                " backgroundDesign "List" sets a white background color
+                )->a( n = `backgroundDesign` v = `List`
+
+                )->ele( `content`
+                    )->tag( `Text`
+                        )->a( n = `text` v = `TEXT` ).
 
     client->view_display( view->stringify( ) ).
+
 
   ENDMETHOD.
 ```

--- a/docs/advanced/fiori.md
+++ b/docs/advanced/fiori.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Integration into Fiori Elements Apps
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Extend the object page of a Fiori list report app with an abap2UI5 app. See the [ABAP2UI5_COMP_CONT repository](https://github.com/axelmohnen/ABAP2UI5_COMP_CONT) for a complete example.
 
 <img width="747" height="387" alt="abap2UI5 app embedded in Fiori Elements object page" src="https://github.com/user-attachments/assets/c14d5732-3b8c-4fa5-83ab-6d188a4d87db" />

--- a/docs/configuration/authorization.md
+++ b/docs/configuration/authorization.md
@@ -9,7 +9,7 @@ abap2UI5 gives you flexibility in managing authorization. It has no built-in aut
 The easiest way to manage access to different apps is to add authorization checks in the HTTP handler. This approach restricts access to individual apps based on the `app_start` URL parameter, directly in the ICF service handler class.
 
 #### Example: Restricting Access Based on URL Parameters
-In this example, we use the ICF handler class to control which apps users can access. The `get_form_field( `app_start` )` call reads the `app_start` URL parameter that names the abap2UI5 app class to launch (e.g. `...?app_start=my_app`). If the user requests an unauthorized app, the handler refuses access.
+In this example, we use the ICF handler class to control which apps users can access. The ``get_form_field( `app_start` )`` call reads the `app_start` URL parameter that names the abap2UI5 app class to launch (e.g. `...?app_start=my_app`). If the user requests an unauthorized app, the handler refuses access.
 ```abap
 CLASS z2ui5_cl_my_http_handler DEFINITION PUBLIC.
 

--- a/docs/configuration/launchpad.md
+++ b/docs/configuration/launchpad.md
@@ -51,21 +51,21 @@ DATA(lv_product) = VALUE #( lt_params[ n = `PRODUCT` ]-v OPTIONAL ).
 Handle view changes and popups through the abap2UI5 backend as usual. But for navigation *between* apps in a Launchpad, use the Launchpad's own cross-app navigation instead of a backend roundtrip — this keeps browser navigation and history working. Fire the `cross_app_nav_to_ext` event with the target intent (and optional parameters, here taken from a bound structure):
 
 ```abap
-)->button(
-    text  = `go to app 128`
-    press = client->_event_client(
-        val   = client->cs_event-cross_app_nav_to_ext
-        t_arg = VALUE #(
-            ( `{ semanticObject: "Z2UI5_CL_LP_SAMPLE_04", action: "display" }` )
-            ( `$` && client->_bind( nav_params ) ) ) ) )
+)->tag( `Button`
+    )->a( n = `text`  v = `go to app 128`
+    )->a( n = `press` v = client->follow_up_action(
+              val   = client->cs_event-cross_app_nav_to_ext
+              t_arg = VALUE #(
+                  ( `{ semanticObject: "Z2UI5_CL_LP_SAMPLE_04", action: "display" }` )
+                  ( `$` && client->_bind( nav_params ) ) ) )
 ```
 
 To navigate back to the previous Launchpad app, use `cross_app_nav_to_prev_app`:
 
 ```abap
-)->button(
-    text  = `BACK`
-    press = client->_event_client( client->cs_event-cross_app_nav_to_prev_app ) )
+)->tag( `Button`
+    )->a( n = `text`  v = `BACK`
+    )->a( n = `press` v = client->follow_up_action( client->cs_event-cross_app_nav_to_prev_app )
 ```
 
 ### Troubleshooting

--- a/docs/configuration/performance.md
+++ b/docs/configuration/performance.md
@@ -3,29 +3,18 @@ outline: [2, 4]
 ---
 # Performance
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 abap2UI5 is fast. Almost all processing runs on the ABAP backend, which is much faster than the browser.
 
 abap2UI5 keeps frontend logic minimal: no business logic runs in the browser. Everything goes straight to the UI5 framework, which focuses only on UI rendering.
 
 We've tested abap2UI5 with tables holding large numbers of entries and columns, so you can build your app with confidence — performance shouldn't be a concern.
 
-### `view_display` vs. `view_model_update`
+### Call `view_display( )` once
 
-The biggest optimization is choosing the right update method:
+The biggest optimization is **not** rebuilding the view on every event:
 
-- **`client->view_display( )`** — sends a new XML view and model to the frontend. UI5 destroys the current view and creates a new one from scratch. Use this only on initialization or when the view structure changes.
-- **`client->view_model_update( )`** — sends only updated model data. UI5 refreshes the existing view via data binding, re-rendering only the changed controls. This keeps UI state (scroll position, focus, etc.) and is much faster.
+- **`client->view_display( )`** — sends a new XML view and model to the frontend. UI5 destroys the current view and creates a new one from scratch. Use this on initialization, and when the view *structure* changes.
+- **Change your bound attribute and return.** The framework compares the model before and after the roundtrip and pushes what changed by itself. UI5 refreshes the existing view via data binding, re-rendering only the affected controls, and the UI keeps its state — scroll position, focus, everything.
 
 ```abap
 METHOD z2ui5_if_app~main.
@@ -33,24 +22,43 @@ METHOD z2ui5_if_app~main.
   CASE abap_true.
 
     WHEN client->check_on_init( ).
-      DATA(view) = z2ui5_cl_xml_view=>factory(
-        )->page( `My App`
-        )->text( client->_bind( mv_text )
-        )->button( text = `update` press = client->_event( `UPDATE` ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->a( n = `title` v = `My App`
+
+                  )->tag( `Text`
+                      )->a( n = `text` v = client->_bind( mv_text )
+                  )->tag( `Button`
+                      )->a( n = `text`  v = `update`
+                      )->a( n = `press` v = client->_event( `UPDATE` ) ).
+
       client->view_display( view->stringify( ) ).
 
     WHEN client->check_on_event( `UPDATE` ).
+      " no view_display( ), and nothing else either - the changed value is
+      " pushed with the response
       mv_text = `new value`.
-      client->view_model_update( ).
 
   ENDCASE.
 
 ENDMETHOD.
 ```
 
+::: tip You may see `client->view_model_update( )` in older code
+It used to be the way to ask for that push. It is a **no-op** now — the
+framework does it unconditionally — and it is scheduled for removal. Delete
+the call; nothing replaces it.
+:::
+
+
 ### Suggestions
 Want to tune your app further? A few tips:
-- Call `client->view_display` only when needed. Prefer `client->view_model_update` so the UI5 framework only re-renders controls that have changed.
+- Call `client->view_display` only when needed — on initialization and when the view structure changes. For a pure data change, set the attribute and return; the framework pushes the delta and UI5 re-renders only the controls that changed.
+
 - Bind data with `client->_bind` — the framework sends only the paths the user actually edited back to ABAP (a delta), so read-only and untouched fields cost nothing on the return trip. (`_bind_edit` is an obsolete alias of `_bind`.)
 - Declare public attributes in your app class only for variables shown on the frontend. This keeps the framework from reading unused values.
 - Follow standard ABAP best practices, like cutting loops and choosing sorted tables, just like in any other ABAP project.

--- a/docs/configuration/performance.md
+++ b/docs/configuration/performance.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Performance
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 abap2UI5 is fast. Almost all processing runs on the ABAP backend, which is much faster than the browser.
 
 abap2UI5 keeps frontend logic minimal: no business logic runs in the browser. Everything goes straight to the UI5 framework, which focuses only on UI rendering.

--- a/docs/configuration/s4_public_cloud.md
+++ b/docs/configuration/s4_public_cloud.md
@@ -70,6 +70,14 @@ Since ADT abapGit doesn't support UI5 apps (BSPs) directly, deploy the app manua
 1. Download the app folder from the [frontend](https://github.com/abap2UI5/frontend) repository
 2. Deploy it to your system with the [SAP deployment guide](https://developers.sap.com/tutorials/abap-s4hanacloud-procurement-purchasereq-shop-ui.html#4c15de5c-bce6-46d0-a634-0008261b3117)
 
+::: tip **Where the deployed app sends its requests**
+Only the *separately deployed* app needs this — when the backend serves the page itself, it tells the frontend to post back to the same URL.
+
+The `cloud` and `cloud_v2` branches ship `sap.app.dataSources.http.uri` as `/sap/bc/http/sap/z2ui5`, the path an HTTP service with ID `Z2UI5` is published under. If you created the service under a **different ID**, change that entry in `manifest.json` to match — otherwise the POSTs go to a service that does not exist and the app fails with a `403 ICFEUCONFORBIDDEN` (UCON) error, which does not say which URL it was.
+
+The on-premise branches (`standard`, `standard_v2`) use the SICF path `/sap/bc/z2ui5` instead.
+:::
+
 ### 5. Configure Launchpad and Tiles (Optional)
 
 Set up the Fiori Launchpad, pages, sections, and tiles for the abap2UI5 apps:

--- a/docs/configuration/s4_public_cloud.md
+++ b/docs/configuration/s4_public_cloud.md
@@ -13,6 +13,12 @@ S/4 Public Cloud supports only the ADT abapGit version. abap2UI5 contains only c
 
 Use the standard installation process with [abapGit for Eclipse](https://eclipse.abapgit.org/).
 
+::: warning **Two choices you cannot change later without relinking**
+**Folder logic must be `PREFIX`.** It is what `.abapgit.xml` declares, and the repository's package tree is built for it.
+
+**Keep the target package name short.** abap2UI5 ships sub-packages two levels deep (`src/00/01`, `src/01/04`, …), and with `PREFIX` logic every derived sub-package name starts with the name you pick here. ABAP caps a package name at 30 characters, so a long root leaves the deeper ones no room — the pull then fails and the repository has to be unlinked and linked again against a shorter package. Something like `ZABAP2UI5` is plenty.
+:::
+
 <img width="649" height="573" alt="abapGit repository link dialog in ADT" src="https://github.com/user-attachments/assets/9ea46657-5ff5-4075-af12-4b5b359c212d" />
 
 <img width="650" height="571" alt="abapGit pull dialog for abap2UI5 repository" src="https://github.com/user-attachments/assets/41558033-3802-4234-8f50-2611574c870a" />
@@ -37,7 +43,7 @@ When installing repositories with ADT abapGit, all artifacts arrive inactive. Ac
 
 <img width="691" height="732" alt="Inactive artifacts list requiring activation" src="https://github.com/user-attachments/assets/f7ef6eb9-c13d-4d2f-a541-8854ac27300c" />
 
-Trigger the mass activation for all inactive artifacts:
+Trigger the mass activation for all inactive artifacts. Some objects may refuse to activate on the first pass because something they depend on is still inactive — repeat the mass activation, or force it, until the list is empty:
 
 <img width="638" height="179" alt="Mass activation of abap2UI5 artifacts in progress" src="https://github.com/user-attachments/assets/e133ba2f-d284-47fa-8dbe-cadee9679f2e" />
 
@@ -65,10 +71,19 @@ For production, finish the frontend deployment and tile configuration in the ste
 
 ### 4. Deploy the UI5 App (Optional)
 
-Since ADT abapGit doesn't support UI5 apps (BSPs) directly, deploy the app manually:
+Up to here the HTTP service is enough — you can open it and use abap2UI5 with a developer role. Deploying the app is what makes it reachable for **business users**, through a Launchpad tile.
 
-1. Download the app folder from the [frontend](https://github.com/abap2UI5/frontend) repository
-2. Deploy it to your system with the [SAP deployment guide](https://developers.sap.com/tutorials/abap-s4hanacloud-procurement-purchasereq-shop-ui.html#4c15de5c-bce6-46d0-a634-0008261b3117)
+ADT abapGit cannot import a UI5 app (BSP), so this step runs from VS Code with the [SAP Fiori Tools](https://marketplace.visualstudio.com/items?itemName=SAPSE.sap-ux-fiori-tools-extension-pack) extension pack instead.
+
+1. Clone the branch that matches your stack — `cloud_v2` for the current UI5 runtime:
+
+   ```sh
+   git clone --branch cloud_v2 --single-branch https://github.com/abap2UI5/frontend.git
+   ```
+
+2. In the `app` folder, open the Fiori **Application Info** page and add a **deployment configuration** pointing at your system. Keep the target package name short here too.
+3. Add a **Launchpad configuration** in the same place. It writes the descriptors that let a tile start the app; pick the semantic object and action that suit your scenario.
+4. Deploy.
 
 ::: tip **Where the deployed app sends its requests**
 Only the *separately deployed* app needs this — when the backend serves the page itself, it tells the frontend to post back to the same URL.
@@ -78,12 +93,29 @@ The `cloud` and `cloud_v2` branches ship `sap.app.dataSources.http.uri` as `/sap
 The on-premise branches (`standard`, `standard_v2`) use the SICF path `/sap/bc/z2ui5` instead.
 :::
 
-### 5. Configure Launchpad and Tiles (Optional)
+### 5. Give Business Users Access (Optional)
 
-Set up the Fiori Launchpad, pages, sections, and tiles for the abap2UI5 apps:
+Opening the HTTP service directly works because a developer has `S_DEVELOP`. A business user has not, so the app has to be reached through a tile — which means one chain of objects, each published locally before the next one can see it:
 
-1. Follow the [SAP Launchpad configuration guide](https://developers.sap.com/tutorials/abap-s4hanacloud-procurement-purchasereq-flp.html)
-2. Configure tiles for business users and manage permissions
+**LADI → IAM App → Business Catalog → Business Role → Space, Page, Tile**
+
+1. **Launchpad App Descriptor Item (LADI)** — create it and add the navigation parameters naming the app to start.
+
+   ::: warning **The `id` has to be UPPERCASE**
+   A lower-case `id` is rejected, and the form editor may refuse to save without making clear why. Use *Open With → Source Editor* to edit the descriptor directly.
+   :::
+
+2. **IAM App** — create one, include the **HTTP service**, add the LADI from step 1, and publish locally.
+3. **Business Catalog** — link the IAM App to it and publish locally.
+4. **Business Role** — add the business catalog to a role in the ABAP Launchpad.
+5. **Space and page** — create them and place the tile, so the user has somewhere to click.
+
+SAP's [Launchpad configuration guide](https://developers.sap.com/tutorials/abap-s4hanacloud-procurement-purchasereq-flp.html) covers the generic mechanics of these objects.
+
+::: tip **A walkthrough with screenshots**
+Warren Eiserman documented a full first install of this scenario, step by step and with screenshots of every dialog:
+[UI5 in ABAP Cloud (without RAP or Fiori Elements)](https://blog.decabase.com/ui5-in-abap-cloud-without-rap-or-fiori-elements-4e8a70d961c3). Several of the warnings on this page come from that write-up.
+:::
 
 ::: tip **BTP ABAP Environment**
 BTP ABAP Environment shares the same technical base as S/4 Public Cloud. The instructions above work for both systems.

--- a/docs/cookbook/browser_interaction/clipboard.md
+++ b/docs/cookbook/browser_interaction/clipboard.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Clipboard
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Copy arbitrary text to the user's clipboard with the frontend event `client->cs_event-clipboard_copy`. The text travels as the first `t_arg` entry and is passed to the browser's `navigator.clipboard.writeText` API, which performs the copy entirely in the browser.
 
 ```abap

--- a/docs/cookbook/browser_interaction/clipboard.md
+++ b/docs/cookbook/browser_interaction/clipboard.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Clipboard
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Copy arbitrary text to the user's clipboard with the frontend event `client->cs_event-clipboard_copy`. The text travels as the first `t_arg` entry and is passed to the browser's `navigator.clipboard.writeText` API, which performs the copy entirely in the browser.
 
 ```abap
@@ -33,13 +22,19 @@ CLASS z2ui5_cl_sample_clipboard IMPLEMENTATION.
       WHEN client->check_on_init( ).
         mv_text = `Hello from abap2UI5`.
 
-        client->view_display( z2ui5_cl_xml_view=>factory(
-            )->page(
-                )->input( client->_bind( mv_text )
-                )->button(
-                    text  = `copy to clipboard`
-                    press = client->_event( `COPY` )
-            )->stringify( ) ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+                )->ele( `Page`
+                    )->tag( `Input`
+                        )->a( n = `value` v = client->_bind( mv_text )
+                    )->tag( `Button`
+                        )->a( n = `text`  v = `copy to clipboard`
+                        )->a( n = `press` v = client->_event( `COPY` ) ).
+
+        client->view_display( view->stringify( ) ).
 
       WHEN client->check_on_event( `COPY` ).
         client->follow_up_action(

--- a/docs/cookbook/browser_interaction/focus.md
+++ b/docs/cookbook/browser_interaction/focus.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Focus
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Read which control currently holds the focus from the backend, or move the focus from the backend to a specific field — both work without any custom control.
 
 #### Read the Current Focus

--- a/docs/cookbook/browser_interaction/focus.md
+++ b/docs/cookbook/browser_interaction/focus.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Focus
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Read which control currently holds the focus from the backend, or move the focus from the backend to a specific field — both work without any custom control.
 
 #### Read the Current Focus
@@ -42,18 +31,28 @@ After processing an event, call `client->follow_up_action( )` with `cs_event-set
 METHOD z2ui5_if_app~main.
 
     IF client->check_on_init( ).
-      DATA(page) = z2ui5_cl_xml_view=>factory( )->page( ).
-      page->simple_form(
-         )->content( ns = `form`
-         )->label( `One`
-         )->input(
-              id     = `id1`
-              submit = client->_event( `ONE_ENTER` )
-         )->label( `Two`
-         )->input(
-              id     = `id2`
-              submit = client->_event( `TWO_ENTER` ) ).
-      client->view_display( page->stringify( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`      v = `sap.m`
+              )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+              )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+              )->ele( `Page`
+                  )->ele( n = `SimpleForm` ns = `form`
+                      )->ele( n = `content` ns = `form`
+                          )->tag( `Label`
+                              )->a( n = `text` v = `One`
+                          )->tag( `Input`
+                              )->a( n = `id`     v = `id1`
+                              )->a( n = `submit` v = client->_event( `ONE_ENTER` )
+                          )->tag( `Label`
+                              )->a( n = `text` v = `Two`
+                          )->tag( `Input`
+                              )->a( n = `id`     v = `id2`
+                              )->a( n = `submit` v = client->_event( `TWO_ENTER` ) ).
+
+      client->view_display( view->stringify( ) ).
+
 
     ELSEIF client->check_on_event( `ONE_ENTER` ).
         client->follow_up_action( val   = client->cs_event-set_focus

--- a/docs/cookbook/browser_interaction/scrolling.md
+++ b/docs/cookbook/browser_interaction/scrolling.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Scrolling
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Read the current scroll positions from the backend, or scroll a control programmatically from the backend with two frontend events:
 
 - **`cs_event-scroll_to`** — scroll a container to a specific pixel position.

--- a/docs/cookbook/browser_interaction/scrolling.md
+++ b/docs/cookbook/browser_interaction/scrolling.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Scrolling
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Read the current scroll positions from the backend, or scroll a control programmatically from the backend with two frontend events:
 
 - **`cs_event-scroll_to`** — scroll a container to a specific pixel position.
@@ -51,13 +40,25 @@ CLASS z2ui5_cl_sample_scrolling IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_init( ).
-      DATA(page) = z2ui5_cl_xml_view=>factory( )->page( id = `id_page` ).
-      page->footer( )->overflow_toolbar(
-         )->button( text  = `Top`
-                    press = client->_event( `SCROLL_TOP` )
-         )->button( text  = `Bottom`
-                    press = client->_event( `SCROLL_BOTTOM` ) ).
-      client->view_display( page->stringify( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->a( n = `id` v = `id_page`
+
+                  )->ele( `footer`
+                      )->ele( `OverflowToolbar`
+                          )->tag( `Button`
+                              )->a( n = `text`  v = `Top`
+                              )->a( n = `press` v = client->_event( `SCROLL_TOP` )
+                          )->tag( `Button`
+                              )->a( n = `text`  v = `Bottom`
+                              )->a( n = `press` v = client->_event( `SCROLL_BOTTOM` ) ).
+
+      client->view_display( view->stringify( ) ).
+
       RETURN.
     ENDIF.
 

--- a/docs/cookbook/browser_interaction/soft_keyboard.md
+++ b/docs/cookbook/browser_interaction/soft_keyboard.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Soft Keyboard
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 #### Hide Soft Keyboard
 
 For UI5 input fields, the soft keyboard pops up automatically when an input receives focus. Sometimes — for example, in warehouses with small devices used mainly for barcode scanning — you don't want this behavior.

--- a/docs/cookbook/browser_interaction/soft_keyboard.md
+++ b/docs/cookbook/browser_interaction/soft_keyboard.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Soft Keyboard
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 #### Hide Soft Keyboard
 
 For UI5 input fields, the soft keyboard pops up automatically when an input receives focus. Sometimes — for example, in warehouses with small devices used mainly for barcode scanning — you don't want this behavior.
@@ -27,21 +16,35 @@ METHOD z2ui5_if_app~main.
 
     IF client->check_on_init( ).
 
-      DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-             )->page( title          = `abap2UI5 - Softkeyboard on/off`
-                      navbuttonpress = client->_event( `BACK` )
-                      shownavbutton  = client->check_app_prev_stack( )
-             )->simple_form( editable = abap_true
-                 )->content( `form`
-                     )->title( `Keyboard on/off`
-                     )->label( `Input`
-                     )->input( id               = `ZINPUT`
-                               value            = client->_bind( input )
-                               showvaluehelp    = abap_true
-                               valuehelprequest = client->_event( `CALL_KEYBOARD` )
-                               valuehelpiconsrc = `sap-icon://keyboard-and-mouse` ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`      v = `sap.m`
+              )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+              )->a( n = `xmlns:form` v = `sap.ui.layout.form`
 
-      client->view_display( page->stringify( ) ).
+              )->ele( `Shell`
+                  )->ele( `Page`
+                      )->a( n = `title`          v = `abap2UI5 - Softkeyboard on/off`
+                      )->a( n = `navButtonPress` v = client->_event( `BACK` )
+                      )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+
+                      )->ele( n = `SimpleForm` ns = `form`
+                          )->a( n = `editable` b = abap_true
+
+                          )->ele( n = `content` ns = `form`
+                              )->tag( `Title`
+                                  )->a( n = `text` v = `Keyboard on/off`
+                              )->tag( `Label`
+                                  )->a( n = `text` v = `Input`
+                              )->tag( `Input`
+                                  )->a( n = `id`               v = `ZINPUT`
+                                  )->a( n = `value`            v = client->_bind( input )
+                                  )->a( n = `valueHelpRequest` v = client->_event( `CALL_KEYBOARD` )
+                                  )->a( n = `valueHelpIconSrc` v = `sap-icon://keyboard-and-mouse`
+                                  )->a( n = `showValueHelp`    b = abap_true ).
+
+      client->view_display( view->stringify( ) ).
+
       RETURN.
     ENDIF.
 

--- a/docs/cookbook/browser_interaction/timer.md
+++ b/docs/cookbook/browser_interaction/timer.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Timer
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Fire a backend event after a delay with the `start_timer` frontend event. Handy for dashboards, status monitors, or any case that needs a delayed or periodic update without user interaction.
 
 Pass the event name to fire and the delay in milliseconds:

--- a/docs/cookbook/browser_interaction/timer.md
+++ b/docs/cookbook/browser_interaction/timer.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Timer
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Fire a backend event after a delay with the `start_timer` frontend event. Handy for dashboards, status monitors, or any case that needs a delayed or periodic update without user interaction.
 
 Pass the event name to fire and the delay in milliseconds:
@@ -45,16 +34,24 @@ CLASS z2ui5_cl_sample_timer IMPLEMENTATION.
     CASE abap_true.
 
       WHEN client->check_on_init( ).
-        client->view_display( z2ui5_cl_xml_view=>factory(
-            )->page( `abap2UI5 - Timer`
-                )->text( client->_bind( counter )
-            )->stringify( ) ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+                )->ele( `Page`
+                    )->a( n = `title` v = `abap2UI5 - Timer`
+
+                    )->tag( `Text`
+                        )->a( n = `text` v = client->_bind( counter ) ).
+
+        client->view_display( view->stringify( ) ).
+
         client->follow_up_action( val   = client->cs_event-start_timer
                         t_arg = VALUE #( ( `TICK` ) ( `2000` ) ) ).
 
       WHEN client->check_on_event( `TICK` ).
         counter = counter + 1.
-        client->view_model_update( ).
         client->follow_up_action( val   = client->cs_event-start_timer
                         t_arg = VALUE #( ( `TICK` ) ( `2000` ) ) ).
 

--- a/docs/cookbook/browser_interaction/title.md
+++ b/docs/cookbook/browser_interaction/title.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Title
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Set the text the browser shows in the tab and window title bar.
 
 #### Standalone

--- a/docs/cookbook/browser_interaction/title.md
+++ b/docs/cookbook/browser_interaction/title.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Title
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Set the text the browser shows in the tab and window title bar.
 
 #### Standalone
@@ -26,12 +15,18 @@ METHOD z2ui5_if_app~main.
     CASE abap_true.
 
       WHEN client->check_on_init( ).
-        client->view_display( z2ui5_cl_xml_view=>factory(
-            )->page(
-                )->button(
-                    text  = `change title`
-                    press = client->_event( `RENAME` )
-            )->stringify( ) ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+                )->ele( `Page`
+                    )->tag( `Button`
+                        )->a( n = `text`  v = `change title`
+                        )->a( n = `press` v = client->_event( `RENAME` ) ).
+
+        client->view_display( view->stringify( ) ).
+
 
       WHEN client->check_on_event( `RENAME` ).
         client->follow_up_action(

--- a/docs/cookbook/browser_interaction/url_handling.md
+++ b/docs/cookbook/browser_interaction/url_handling.md
@@ -29,10 +29,10 @@ Push a new history entry — the value is appended to the URL hash, so app state
 client->set_push_state( `&my-app-state=detail` ).
 ```
 
-Trigger a browser back navigation (`history.back()`) with the next response:
-```abap
-client->set_nav_back( ).
-```
+There is no method that presses the browser's back button for you — the
+pushed states above are what the back button walks through, and leaving an
+app is [`nav_app_leave( )`](/cookbook/event_navigation/navigation), which
+returns to the calling app rather than to the previous URL.
 
 For a complete example, see sample `Z2UI5_CL_DEMO_APP_139`.
 

--- a/docs/cookbook/cheat_sheet.md
+++ b/docs/cookbook/cheat_sheet.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Cheat Sheet
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 A one-page recap of the rules that decide whether an abap2UI5 app works or misbehaves in a way that is hard to debug. Each row links to the recipe that explains it in full — read this page as a checklist, not as an introduction.
 
 | Rule | Why it matters |
@@ -23,7 +12,8 @@ A one-page recap of the rules that decide whether an abap2UI5 app works or misbe
 | Always call `view_display( )` in the `check_on_navigated( )` branch | After a called app returns via `nav_app_leave( )`, the browser still shows *its* view — without a re-display the user is left on a stale or blank screen → [Navigation](/cookbook/event_navigation/navigation) |
 | Declare every attribute you bind in the `PUBLIC SECTION` | Binding works via dynamic `ASSIGN`; `PROTECTED` and `PRIVATE` attributes are silently ignored → [Binding](/cookbook/model/binding) |
 | Keep state in public attributes, not in local variables | Between two events the controller is serialized to the client and back — locals, `DATA(...)` declarations, open cursors and locks do not survive → [Statefulness](/cookbook/expert_more/statefulness) |
-| Respect the UI5 aggregation rules even though the builder does not enforce them | `z2ui5_cl_xml_view` lets you nest anything inside anything; UI5 does not, and the mismatch surfaces as broken rendering rather than a syntax error → [Definition](/cookbook/view/definition) |
+| Respect the UI5 aggregation rules even though the builder does not enforce them | The builder lets you nest anything inside anything; UI5 does not, and the mismatch surfaces as broken rendering rather than a syntax error → [Definition](/cookbook/view/definition) |
+
 | Never use a deprecated UI5 control | It renders today and vanishes on the next UI5 upgrade → [Deprecated Controls](/cookbook/view/deprecated_controls) |
 | Check the built-in popups before building a custom dialog | Roughly twenty ready-made dialogs ship with the framework — confirm, select, file up/download, ranges, PDF, … → [Built-In](/cookbook/popup_popover/built_in) |
 | Use backtick string literals (`` ` ``) | Project-wide convention in the framework, the samples and this documentation; keeps ABAP string handling consistent |

--- a/docs/cookbook/cheat_sheet.md
+++ b/docs/cookbook/cheat_sheet.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Cheat Sheet
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 A one-page recap of the rules that decide whether an abap2UI5 app works or misbehaves in a way that is hard to debug. Each row links to the recipe that explains it in full — read this page as a checklist, not as an introduction.
 
 | Rule | Why it matters |

--- a/docs/cookbook/device_capabilities/audio.md
+++ b/docs/cookbook/device_capabilities/audio.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Audio
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 #### Play Sounds
 
 Audio feedback is handy in some scenarios. Fire the `play_audio` frontend event with the URL of a sound file — for example a `.wav` from the SAP MIME repository at `/SAP/PUBLIC/BC/ABAP/mime_demo/bam.wav`.
@@ -34,17 +23,25 @@ CLASS z2ui5_cl_sample_sound IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(vbox) = view->page( )->vbox( ).
-      vbox->input( id          = `inputApp`
-                   value       = client->_bind( company_code )
-                   type        = `Number`
-                   placeholder = `Company Code`
-                   submit      = client->_event( `CHECK_INPUT` ) ).
-      vbox->button( text  = `check`
-                    press = client->_event( `CHECK_INPUT` ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->ele( `VBox`
+                      )->tag( `Input`
+                          )->a( n = `id`          v = `inputApp`
+                          )->a( n = `value`       v = client->_bind( company_code )
+                          )->a( n = `type`        v = `Number`
+                          )->a( n = `placeholder` v = `Company Code`
+                          )->a( n = `submit`      v = client->_event( `CHECK_INPUT` )
+                      )->tag( `Button`
+                          )->a( n = `text`  v = `check`
+                          )->a( n = `press` v = client->_event( `CHECK_INPUT` ) ).
 
       client->view_display( view->stringify( ) ).
+
       RETURN.
     ENDIF.
 
@@ -56,7 +53,6 @@ CLASS z2ui5_cl_sample_sound IMPLEMENTATION.
       ELSE.
         CLEAR company_code.
       ENDIF.
-      client->view_model_update( ).
     ENDIF.
 
   ENDMETHOD.

--- a/docs/cookbook/device_capabilities/audio.md
+++ b/docs/cookbook/device_capabilities/audio.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Audio
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 #### Play Sounds
 
 Audio feedback is handy in some scenarios. Fire the `play_audio` frontend event with the URL of a sound file — for example a `.wav` from the SAP MIME repository at `/SAP/PUBLIC/BC/ABAP/mime_demo/bam.wav`.

--- a/docs/cookbook/device_capabilities/barcode_scanning.md
+++ b/docs/cookbook/device_capabilities/barcode_scanning.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Barcode Scanning
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Barcode scanning is common in enterprise apps. With abap2UI5, you can:
 - Scan barcodes
 - Handle focus transitions
@@ -29,15 +18,20 @@ Since UI5 version 1.102, the `sap.ndc.BarcodeScannerButton` control is part of t
 ```abap
   METHOD z2ui5_if_app~main.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory(
-        )->page(
-            )->barcode_scanner_button(
-                dialogtitle = `Barcode Scanner`
-                scansuccess = client->_event(
-                    val   = `SCAN_SUCCESS`
-                    t_arg = VALUE #(
-                        ( `${$parameters>/text}`   )
-                        ( `${$parameters>/format}` ) ) ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:ndc` v = `sap.ndc`
+
+            )->ele( `Page`
+                )->tag( n = `BarcodeScannerButton` ns = `ndc`
+                    )->a( n = `dialogTitle` v = `Barcode Scanner`
+                    )->a( n = `scanSuccess` v = client->_event(
+                                                   val   = `SCAN_SUCCESS`
+                                                   t_arg = VALUE #(
+                                                       ( `${$parameters>/text}`   )
+                                                       ( `${$parameters>/format}` ) ) ) ).
 
     client->view_display( view->stringify( ) ).
 
@@ -77,21 +71,29 @@ CLASS z2ui5_cl_sample_focus IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(page) = z2ui5_cl_xml_view=>factory( )->page( ).
-      page->simple_form(
-         )->content( ns = `form`
-         )->label( `One`
-         )->input(
-              id     = `id1`
-              value  = client->_bind( one )
-              submit = client->_event( `ONE_ENTER` )
-         )->label( `Two`
-         )->input(
-              id     = `id2`
-              value  = client->_bind( two )
-              submit = client->_event( `TWO_ENTER` ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`      v = `sap.m`
+              )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+              )->a( n = `xmlns:form` v = `sap.ui.layout.form`
 
-      client->view_display( page->stringify( ) ).
+              )->ele( `Page`
+                  )->ele( n = `SimpleForm` ns = `form`
+                      )->ele( n = `content` ns = `form`
+                          )->tag( `Label`
+                              )->a( n = `text` v = `One`
+                          )->tag( `Input`
+                              )->a( n = `id`     v = `id1`
+                              )->a( n = `value`  v = client->_bind( one )
+                              )->a( n = `submit` v = client->_event( `ONE_ENTER` )
+                          )->tag( `Label`
+                              )->a( n = `text` v = `Two`
+                          )->tag( `Input`
+                              )->a( n = `id`     v = `id2`
+                              )->a( n = `value`  v = client->_bind( two )
+                              )->a( n = `submit` v = client->_event( `TWO_ENTER` ) ).
+
+      client->view_display( view->stringify( ) ).
       RETURN.
     ENDIF.
 
@@ -126,17 +128,25 @@ CLASS z2ui5_cl_sample_sound IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(vbox) = view->page( )->vbox( ).
-      vbox->input( id          = `inputApp`
-                   value       = client->_bind( company_code )
-                   type        = `Number`
-                   placeholder = `Company Code`
-                   submit      = client->_event( `CHECK_INPUT` ) ).
-      vbox->button( text  = `check`
-                    press = client->_event( `CHECK_INPUT` ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->ele( `VBox`
+                      )->tag( `Input`
+                          )->a( n = `id`          v = `inputApp`
+                          )->a( n = `value`       v = client->_bind( company_code )
+                          )->a( n = `type`        v = `Number`
+                          )->a( n = `placeholder` v = `Company Code`
+                          )->a( n = `submit`      v = client->_event( `CHECK_INPUT` )
+                      )->tag( `Button`
+                          )->a( n = `text`  v = `check`
+                          )->a( n = `press` v = client->_event( `CHECK_INPUT` ) ).
 
       client->view_display( view->stringify( ) ).
+
       RETURN.
     ENDIF.
 
@@ -148,7 +158,6 @@ CLASS z2ui5_cl_sample_sound IMPLEMENTATION.
       ELSE.
         CLEAR company_code.
       ENDIF.
-      client->view_model_update( ).
     ENDIF.
 
   ENDMETHOD.

--- a/docs/cookbook/device_capabilities/barcode_scanning.md
+++ b/docs/cookbook/device_capabilities/barcode_scanning.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Barcode Scanning
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Barcode scanning is common in enterprise apps. With abap2UI5, you can:
 - Scan barcodes
 - Handle focus transitions

--- a/docs/cookbook/device_capabilities/camera.md
+++ b/docs/cookbook/device_capabilities/camera.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Camera
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 abap2UI5 offers a custom control for taking photos directly from the device's camera. The control returns the image as a base64-encoded string, ready for backend processing.
 
 A minimal example based on sample `Z2UI5_CL_SMP_APP_306`:

--- a/docs/cookbook/device_capabilities/camera.md
+++ b/docs/cookbook/device_capabilities/camera.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Camera
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 abap2UI5 offers a custom control for taking photos directly from the device's camera. The control returns the image as a base64-encoded string, ready for backend processing.
 
 A minimal example based on sample `Z2UI5_CL_SMP_APP_306`:
@@ -30,11 +19,22 @@ CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_init( ).
-      DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( `abap2UI5 - Device Camera Picture`
-                )->_z2ui5( )->camera_picture(
-                    value    = client->_bind( mv_picture_base )
-                    onphoto  = client->_event( `CAPTURE` ) ).
-      client->view_display( page->stringify( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`       v = `sap.m`
+              )->a( n = `xmlns:mvc`   v = `sap.ui.core.mvc`
+              )->a( n = `xmlns:z2ui5` v = `z2ui5.cc`
+
+              )->ele( `Shell`
+                  )->ele( `Page`
+                      )->a( n = `title` v = `abap2UI5 - Device Camera Picture`
+
+                      )->tag( n = `CameraPicture` ns = `z2ui5`
+                          )->a( n = `value`   v = client->_bind( mv_picture_base )
+                          )->a( n = `OnPhoto` v = client->_event( `CAPTURE` ) ).
+
+      client->view_display( view->stringify( ) ).
+
     ENDIF.
 
     IF client->get( )-event = `CAPTURE`.

--- a/docs/cookbook/device_capabilities/geolocation.md
+++ b/docs/cookbook/device_capabilities/geolocation.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Geolocation
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 abap2UI5 offers a custom control for reading geolocation data from the user's device — longitude, latitude, altitude, speed, and accuracy values. This is handy for logistics apps, field service tools, or any scenario where location matters.
 
 The control fires a `finished` event once the browser resolves the device position, and the binding writes every value back into your ABAP attributes. See also `Z2UI5_CL_SMP_APP_120`.

--- a/docs/cookbook/device_capabilities/geolocation.md
+++ b/docs/cookbook/device_capabilities/geolocation.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Geolocation
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 abap2UI5 offers a custom control for reading geolocation data from the user's device — longitude, latitude, altitude, speed, and accuracy values. This is handy for logistics apps, field service tools, or any scenario where location matters.
 
 The control fires a `finished` event once the browser resolves the device position, and the binding writes every value back into your ABAP attributes. See also `Z2UI5_CL_SMP_APP_120`.
@@ -36,18 +25,25 @@ CLASS z2ui5_cl_sample_geolocation IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    client->view_display( view->shell(
-        )->page( )->_z2ui5(
-            )->geolocation(
-                finished         = client->_event( `POST` )
-                longitude        = client->_bind( longitude )
-                latitude         = client->_bind( latitude )
-                altitude         = client->_bind( altitude )
-                altitudeaccuracy = client->_bind( altitudeaccuracy )
-                accuracy         = client->_bind( accuracy )
-                speed            = client->_bind( speed )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`       v = `sap.m`
+            )->a( n = `xmlns:mvc`   v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:z2ui5` v = `z2ui5.cc`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->tag( n = `Geolocation` ns = `z2ui5`
+                        )->a( n = `finished`         v = client->_event( `POST` )
+                        )->a( n = `longitude`        v = client->_bind( longitude )
+                        )->a( n = `latitude`         v = client->_bind( latitude )
+                        )->a( n = `altitude`         v = client->_bind( altitude )
+                        )->a( n = `altitudeAccuracy` v = client->_bind( altitudeaccuracy )
+                        )->a( n = `accuracy`         v = client->_bind( accuracy )
+                        )->a( n = `speed`            v = client->_bind( speed ) ).
+
+    client->view_display( view->stringify( ) ).
+
 
     CASE client->get( )-event.
       WHEN `POST`.

--- a/docs/cookbook/device_capabilities/pdf.md
+++ b/docs/cookbook/device_capabilities/pdf.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # PDF
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Render a PDF directly in your app — for printouts from Adobe Forms, SmartForms, archived documents from the Content Server, or anything else that produces an `xstring`.
 
 #### Built-In Popup
@@ -26,12 +15,18 @@ METHOD z2ui5_if_app~main.
   CASE abap_true.
 
     WHEN client->check_on_init( ).
-      client->view_display( z2ui5_cl_xml_view=>factory(
-          )->page(
-              )->button(
-                  text  = `show PDF`
-                  press = client->_event( `SHOW_PDF` )
-          )->stringify( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->tag( `Button`
+                      )->a( n = `text`  v = `show PDF`
+                      )->a( n = `press` v = client->_event( `SHOW_PDF` ) ).
+
+      client->view_display( view->stringify( ) ).
+
 
     WHEN client->check_on_event( `SHOW_PDF` ).
       "lv_xstring contains the binary PDF — e.g. from cl_fp_function_module=>get_pdf, SmartForm OTF

--- a/docs/cookbook/device_capabilities/pdf.md
+++ b/docs/cookbook/device_capabilities/pdf.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # PDF
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Render a PDF directly in your app — for printouts from Adobe Forms, SmartForms, archived documents from the Content Server, or anything else that produces an `xstring`.
 
 #### Built-In Popup

--- a/docs/cookbook/device_capabilities/spreadsheet.md
+++ b/docs/cookbook/device_capabilities/spreadsheet.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Spreadsheet
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 abap2UI5 works with the XLSX APIs on your ABAP system to upload and download spreadsheets, converting between XLSX files and internal tables as needed.
 
 #### Upload
@@ -35,14 +24,20 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_upload IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->page(
-            )->_z2ui5( )->file_uploader(
-                value       = client->_bind( mv_value )
-                path        = client->_bind( mv_path )
-                placeholder = `filepath here...`
-                upload      = client->_event( `UPLOAD` )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`       v = `sap.m`
+            )->a( n = `xmlns:mvc`   v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:z2ui5` v = `z2ui5.cc`
+
+            )->ele( `Page`
+                )->tag( n = `FileUploader` ns = `z2ui5`
+                    )->a( n = `value`       v = client->_bind( mv_value )
+                    )->a( n = `path`        v = client->_bind( mv_path )
+                    )->a( n = `placeholder` v = `filepath here...`
+                    )->a( n = `upload`      v = client->_event( `UPLOAD` ) ).
+
+    client->view_display( view->stringify( ) ).
 
     IF client->get( )-event = `UPLOAD`.
 
@@ -106,12 +101,17 @@ Convert an internal table to an XLSX file and download it to the frontend:
 ```abap
   METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->page(
-            )->button(
-                text = `Open Download Popup`
-                press = client->_event( `DOWNLOAD` )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->tag( `Button`
+                    )->a( n = `text`  v = `Open Download Popup`
+                    )->a( n = `press` v = client->_event( `DOWNLOAD` ) ).
+
+    client->view_display( view->stringify( ) ).
 
     IF client->get( )-event = `DOWNLOAD`.
 
@@ -208,12 +208,18 @@ Instead of the XLSX API above (which can change between releases), consider the 
 ```abap
   METHOD z2ui5_if_app~main.
 
-  client->view_display( z2ui5_cl_xml_view=>factory(
-    )->page(
-      )->button(
-        text = `Open Download Popup`
-        press = client->_event( `DOWNLOAD` )
-    )->stringify( ) ).
+  DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+      )->ele( n = `View` ns = `mvc`
+          )->a( n = `xmlns`     v = `sap.m`
+          )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+          )->ele( `Page`
+              )->tag( `Button`
+                  )->a( n = `text`  v = `Open Download Popup`
+                  )->a( n = `press` v = client->_event( `DOWNLOAD` ) ).
+
+  client->view_display( view->stringify( ) ).
+
 
   IF client->get( )-event = `DOWNLOAD`.
 

--- a/docs/cookbook/device_capabilities/spreadsheet.md
+++ b/docs/cookbook/device_capabilities/spreadsheet.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Spreadsheet
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 abap2UI5 works with the XLSX APIs on your ABAP system to upload and download spreadsheets, converting between XLSX files and internal tables as needed.
 
 #### Upload

--- a/docs/cookbook/device_capabilities/upload_download.md
+++ b/docs/cookbook/device_capabilities/upload_download.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Upload, Download
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 abap2UI5 handles file uploads and downloads by sending base64-encoded data over the binding.
 
 #### Upload

--- a/docs/cookbook/device_capabilities/upload_download.md
+++ b/docs/cookbook/device_capabilities/upload_download.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Upload, Download
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 abap2UI5 handles file uploads and downloads by sending base64-encoded data over the binding.
 
 #### Upload
@@ -30,14 +19,20 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_upload IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->page(
-            )->_z2ui5( )->file_uploader(
-                value       = client->_bind( mv_value )
-                path        = client->_bind( mv_path )
-                placeholder = `filepath here...`
-                upload      = client->_event( `UPLOAD` )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`       v = `sap.m`
+            )->a( n = `xmlns:mvc`   v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:z2ui5` v = `z2ui5.cc`
+
+            )->ele( `Page`
+                )->tag( n = `FileUploader` ns = `z2ui5`
+                    )->a( n = `value`       v = client->_bind( mv_value )
+                    )->a( n = `path`        v = client->_bind( mv_path )
+                    )->a( n = `placeholder` v = `filepath here...`
+                    )->a( n = `upload`      v = client->_event( `UPLOAD` ) ).
+
+    client->view_display( view->stringify( ) ).
 
     CASE client->get( )-event.
       WHEN `UPLOAD`.
@@ -54,12 +49,18 @@ See also `Z2UI5_CL_SMP_APP_186`:
 ```abap
   METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->page(
-            )->button(
-                text = `Open Download Popup`
-                press = client->_event( `BUTTON_DOWNLOAD` )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->tag( `Button`
+                    )->a( n = `text`  v = `Open Download Popup`
+                    )->a( n = `press` v = client->_event( `BUTTON_DOWNLOAD` ) ).
+
+    client->view_display( view->stringify( ) ).
+
 
     CASE client->get( )-event.
       WHEN `BUTTON_DOWNLOAD`.

--- a/docs/cookbook/eml_cds_sql/abap_sql.md
+++ b/docs/cookbook/eml_cds_sql/abap_sql.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # ABAP SQL
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 ABAP SQL is the standard way to read and change data in the database directly from ABAP. In an abap2UI5 controller you can issue `SELECT`, `INSERT`, `UPDATE`, `DELETE`, and `MODIFY` statements the same way as in any ABAP program, and bind the result straight to a UI5 view.
 
 ### Read Data
@@ -39,20 +28,47 @@ CLASS z2ui5_cl_sample_sql IMPLEMENTATION.
         INTO TABLE @mt_flights
         UP TO 50 ROWS.
 
-      DATA(view)  = z2ui5_cl_xml_view=>factory( )->shell( )->page( ).
-      DATA(table) = view->table( client->_bind( mt_flights ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-      table->columns(
-           )->column( )->text( `Carrier` )->get_parent(
-           )->column( )->text( `Connection` )->get_parent(
-           )->column( )->text( `Date` )->get_parent(
-           )->column( )->text( `Price` ).
+              )->ele( `Shell`
+                  )->ele( `Page`
+                      )->ele( `Table`
+                          )->a( n = `items` v = client->_bind( mt_flights )
 
-      table->items( )->column_list_item( )->cells(
-         )->text( `{CARRID}`
-         )->text( `{CONNID}`
-         )->text( `{FLDATE}`
-         )->text( `{PRICE} {CURRENCY}` ).
+                          )->ele( `columns`
+                              )->ele( `Column`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `Carrier`
+                              )->end(
+                              )->ele( `Column`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `Connection`
+                              )->end(
+                              )->ele( `Column`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `Date`
+                              )->end(
+                              )->ele( `Column`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `Price`
+                              )->end(
+
+                          )->end(
+
+                          )->ele( `items`
+                              )->ele( `ColumnListItem`
+                                  )->ele( `cells`
+                                      )->tag( `Text`
+                                          )->a( n = `text` v = `{CARRID}`
+                                      )->tag( `Text`
+                                          )->a( n = `text` v = `{CONNID}`
+                                      )->tag( `Text`
+                                          )->a( n = `text` v = `{FLDATE}`
+                                      )->tag( `Text`
+                                          )->a( n = `text` v = `{PRICE} {CURRENCY}` ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/eml_cds_sql/abap_sql.md
+++ b/docs/cookbook/eml_cds_sql/abap_sql.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # ABAP SQL
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 ABAP SQL is the standard way to read and change data in the database directly from ABAP. In an abap2UI5 controller you can issue `SELECT`, `INSERT`, `UPDATE`, `DELETE`, and `MODIFY` statements the same way as in any ABAP program, and bind the result straight to a UI5 view.
 
 ### Read Data

--- a/docs/cookbook/eml_cds_sql/cds.md
+++ b/docs/cookbook/eml_cds_sql/cds.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # CDS
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 All examples in these docs work without CDS. On a recent ABAP release, you can also read data through CDS views in your abap2UI5 apps.
 
 ### ABAP CDS
@@ -37,17 +26,40 @@ CLASS z2ui5_cl_sample_cds IMPLEMENTATION.
        INTO TABLE @mt_salesorder
        UP TO 10 ROWS.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( )->page( ).
-      DATA(table) = view->table( client->_bind( mt_salesorder ) ).
-      table->columns(
-           )->column( )->text( `SalesOrder` )->get_parent(
-           )->column( )->text( `SalesOrderType` )->get_parent(
-           )->column( )->text( `SalesOrganization` ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-      table->items( )->column_list_item( )->cells(
-         )->text( `{SALESORDER}`
-         )->text( `{SALESORDERTYPE}`
-         )->text( `{SALESORGANIZATION}` ).
+              )->ele( `Page`
+                  )->ele( `Table`
+                      )->a( n = `items` v = client->_bind( mt_salesorder )
+
+                      )->ele( `columns`
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `SalesOrder`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `SalesOrderType`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `SalesOrganization`
+                          )->end(
+
+                      )->end(
+
+                      )->ele( `items`
+                          )->ele( `ColumnListItem`
+                              )->ele( `cells`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{SALESORDER}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{SALESORDERTYPE}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{SALESORGANIZATION}` ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/eml_cds_sql/cds.md
+++ b/docs/cookbook/eml_cds_sql/cds.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # CDS
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 All examples in these docs work without CDS. On a recent ABAP release, you can also read data through CDS views in your abap2UI5 apps.
 
 ### ABAP CDS

--- a/docs/cookbook/eml_cds_sql/draft_handling.md
+++ b/docs/cookbook/eml_cds_sql/draft_handling.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Draft Handling
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 ## Drafts Are a RAP Feature — and You Can Use Them with abap2UI5
 
 Draft handling is one of the headline features of the **ABAP RESTful Application Programming Model (RAP)**. If you have built RAP business objects before, you know the drill: add `with draft` to the behavior definition, define a draft table, and the RAP framework takes care of the rest — the shadow table, the pessimistic lock, and the standard draft actions `Edit`, `Resume`, `Activate`, and `Discard`.

--- a/docs/cookbook/eml_cds_sql/draft_handling.md
+++ b/docs/cookbook/eml_cds_sql/draft_handling.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Draft Handling
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 ## Drafts Are a RAP Feature — and You Can Use Them with abap2UI5
 
 Draft handling is one of the headline features of the **ABAP RESTful Application Programming Model (RAP)**. If you have built RAP business objects before, you know the drill: add `with draft` to the behavior definition, define a draft table, and the RAP framework takes care of the rest — the shadow table, the pessimistic lock, and the standard draft actions `Edit`, `Resume`, `Activate`, and `Discard`.
@@ -212,19 +201,33 @@ CLASS z2ui5_cl_sample_draft_min IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD view_display.
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page( `Edit Bank (minimal draft)`
-            )->simple_form( editable = abap_true
-                )->content( `form`
-                )->label( `Bank Name`
-                )->input( client->_bind( long_bank_name )
-                )->label( `SWIFT Code`
-                )->input( client->_bind( swift_code )
-                )->button(
-                    text  = `Save`
-                    type  = `Emphasized`
-                    press = client->_event( `SAVE` ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title` v = `Edit Bank (minimal draft)`
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `editable` b = abap_true
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Bank Name`
+                            )->tag( `Input`
+                                )->a( n = `value` v = client->_bind( long_bank_name )
+                            )->tag( `Label`
+                                )->a( n = `text` v = `SWIFT Code`
+                            )->tag( `Input`
+                                )->a( n = `value` v = client->_bind( swift_code )
+                            )->tag( `Button`
+                                )->a( n = `text`  v = `Save`
+                                )->a( n = `type`  v = `Emphasized`
+                                )->a( n = `press` v = client->_event( `SAVE` ) ).
+
     client->view_display( view->stringify( ) ).
   ENDMETHOD.
 ENDCLASS.
@@ -925,51 +928,66 @@ CLASS z2ui5_cl_sample_draft IMPLEMENTATION.
         WHEN mode = `EDIT` THEN `Bank header (draft)`
         ELSE `Bank header (view)` ).
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page(
-            title          = `Edit Bank — Standard BO Draft via EML`
-            shownavbutton  = client->check_app_prev_stack( )
-            navbuttonpress = client->_event( `LEAVE_APP` )
-            )->simple_form(
-                title    = lv_form_title
-                editable = draft_open
-                )->content( `form`
-                )->label( `Bank Country`
-                )->input(
-                    value   = bank_country
-                    enabled = abap_false
-                )->label( `Bank Key`
-                )->input(
-                    value   = bank_internal_id
-                    enabled = abap_false
-                )->label( `Bank Name`
-                )->input(
-                    value   = client->_bind( long_bank_name )
-                    enabled = draft_open
-                )->label( `SWIFT Code`
-                )->input(
-                    value   = client->_bind( swift_code )
-                    enabled = draft_open
-                )->label( `Status`
-                )->input(
-                    value   = status_text
-                    enabled = abap_false
-                )->label( `Messages`
-                )->text_area(
-                    value    = messages
-                    rows     = `6`
-                    editable = abap_false
-                )->button(
-                    text  = lv_edit_button_text
-                    type  = lv_edit_button_type
-                    press = client->_event( `EDIT_TOGGLE` )
-                )->button(
-                    text    = `Activate`
-                    type    = `Emphasized`
-                    press   = client->_event( `ACTIVATE` )
-                    enabled = draft_open ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `Edit Bank — Standard BO Draft via EML`
+                    )->a( n = `navButtonPress` v = client->_event( `LEAVE_APP` )
+                    )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = lv_form_title
+                        )->a( n = `editable` b = draft_open
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Bank Country`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = bank_country
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Bank Key`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = bank_internal_id
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Bank Name`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = client->_bind( long_bank_name )
+                                )->a( n = `enabled` b = draft_open
+                            )->tag( `Label`
+                                )->a( n = `text` v = `SWIFT Code`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = client->_bind( swift_code )
+                                )->a( n = `enabled` b = draft_open
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Status`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = status_text
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Messages`
+                            )->tag( `TextArea`
+                                )->a( n = `value`    v = messages
+                                )->a( n = `rows`     v = `6`
+                                )->a( n = `editable` b = abap_false
+                            )->tag( `Button`
+                                )->a( n = `text`  v = lv_edit_button_text
+                                )->a( n = `type`  v = lv_edit_button_type
+                                )->a( n = `press` v = client->_event( `EDIT_TOGGLE` )
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Activate`
+                                )->a( n = `type`    v = `Emphasized`
+                                )->a( n = `press`   v = client->_event( `ACTIVATE` )
+                                )->a( n = `enabled` b = draft_open ).
+
     client->view_display( view->stringify( ) ).
+
   ENDMETHOD.
 ENDCLASS.
 ```

--- a/docs/cookbook/eml_cds_sql/eml.md
+++ b/docs/cookbook/eml_cds_sql/eml.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # EML
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 All examples in these docs work without EML. But on a recent ABAP release, you can also use this feature in abap2UI5 apps.
 
 ### EML
@@ -41,17 +30,40 @@ CLASS z2ui5_cl_sample_eml_read IMPLEMENTATION.
         VALUE #( ( SalesOrder = `0000000001` ) )
         RESULT mt_salesorder.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( )->page( ).
-      DATA(table) = view->table( client->_bind( mt_salesorder ) ).
-      table->columns(
-           )->column( )->text( `SalesOrder` )->get_parent(
-           )->column( )->text( `SalesOrderType` )->get_parent(
-           )->column( )->text( `SalesOrganization` ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-      table->items( )->column_list_item( )->cells(
-         )->text( `{SALESORDER}`
-         )->text( `{SALESORDERTYPE}`
-         )->text( `{SALESORGANIZATION}` ).
+              )->ele( `Page`
+                  )->ele( `Table`
+                      )->a( n = `items` v = client->_bind( mt_salesorder )
+
+                      )->ele( `columns`
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `SalesOrder`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `SalesOrderType`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `SalesOrganization`
+                          )->end(
+
+                      )->end(
+
+                      )->ele( `items`
+                          )->ele( `ColumnListItem`
+                              )->ele( `cells`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{SALESORDER}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{SALESORDERTYPE}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{SALESORGANIZATION}` ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/eml_cds_sql/eml.md
+++ b/docs/cookbook/eml_cds_sql/eml.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # EML
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 All examples in these docs work without EML. But on a recent ABAP release, you can also use this feature in abap2UI5 apps.
 
 ### EML

--- a/docs/cookbook/eml_cds_sql/fuzzy_search.md
+++ b/docs/cookbook/eml_cds_sql/fuzzy_search.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Fuzzy Search
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 On SAP HANA you can match strings tolerantly — typos, missing letters, transposed characters — with the `CONTAINS` SQL function in fuzzy mode. The score is a value between `0.0` (no match) and `1.0` (exact match); pass a threshold to `FUZZY( )` and HANA filters out rows below it.
 
 Wire it to a UI5 `search_field` in the table toolbar and you get an ALV-style search that forgives the user's typing.

--- a/docs/cookbook/eml_cds_sql/fuzzy_search.md
+++ b/docs/cookbook/eml_cds_sql/fuzzy_search.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Fuzzy Search
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 On SAP HANA you can match strings tolerantly — typos, missing letters, transposed characters — with the `CONTAINS` SQL function in fuzzy mode. The score is a value between `0.0` (no match) and `1.0` (exact match); pass a threshold to `FUZZY( )` and HANA filters out rows below it.
 
 Wire it to a UI5 `search_field` in the table toolbar and you get an ALV-style search that forgives the user's typing.
@@ -68,23 +57,58 @@ CLASS z2ui5_cl_sample_fuzzy IMPLEMENTATION.
 
   METHOD render.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( )->page( `Customers` ).
-    DATA(tab)  = view->table( client->_bind( mt_customers ) growing = abap_true ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-    tab->header_toolbar( )->overflow_toolbar(
-        )->title( `Customer List`
-        )->toolbar_spacer( )
-        )->search_field(
-            value       = client->_bind( mv_search )
-            width       = `20rem`
-            placeholder = `try a misspelled name…`
-            search      = client->_event( `SEARCH` ) ).
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title` v = `Customers`
 
-    tab->columns( )->column( )->text( `Customer` )->get_parent(
-                  )->column( )->text( `Name` )->get_parent(
-                  )->column( )->text( `City` ).
-    tab->items( )->column_list_item( )->cells(
-       )->text( `{KUNNR}` )->text( `{NAME1}` )->text( `{ORT01}` ).
+                    )->ele( `Table`
+                        )->a( n = `items`   v = client->_bind( mt_customers )
+                        )->a( n = `growing` b = abap_true
+
+                        )->ele( `headerToolbar`
+                            )->ele( `OverflowToolbar`
+                                )->tag( `Title`
+                                    )->a( n = `text` v = `Customer List`
+                                )->tag( `ToolbarSpacer`
+                                )->tag( `SearchField`
+                                    )->a( n = `value`       v = client->_bind( mv_search )
+                                    )->a( n = `width`       v = `20rem`
+                                    )->a( n = `placeholder` v = `try a misspelled name…`
+                                    )->a( n = `search`      v = client->_event( `SEARCH` )
+
+                        )->end(
+                        )->end(
+
+                        )->ele( `columns`
+                            )->ele( `Column`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `Customer`
+                            )->end(
+                            )->ele( `Column`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `Name`
+                            )->end(
+                            )->ele( `Column`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `City`
+                            )->end(
+
+                        )->end(
+
+                        )->ele( `items`
+                            )->ele( `ColumnListItem`
+                                )->ele( `cells`
+                                    )->tag( `Text`
+                                        )->a( n = `text` v = `{KUNNR}`
+                                    )->tag( `Text`
+                                        )->a( n = `text` v = `{NAME1}`
+                                    )->tag( `Text`
+                                        )->a( n = `text` v = `{ORT01}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/event_navigation/backend.md
+++ b/docs/cookbook/event_navigation/backend.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Backend
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 UI5 control properties can both display data and fire events. To run backend logic when an event fires, use the `client->_event` method.
 
 ## Basic

--- a/docs/cookbook/event_navigation/backend.md
+++ b/docs/cookbook/event_navigation/backend.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Backend
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 UI5 control properties can both display data and fire events. To run backend logic when an event fires, use the `client->_event` method.
 
 ## Basic
@@ -22,11 +11,17 @@ As an example, we use the `press` property of a button. To fire events to the ba
 ```abap
 METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->button(
-            text  = `post`
-            press = client->_event( `BUTTON_POST` )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->tag( `Button`
+                    )->a( n = `text`  v = `post`
+                    )->a( n = `press` v = client->_event( `BUTTON_POST` ) ).
+
+    client->view_display( view->stringify( ) ).
 
     CASE client->get( )-event.
         WHEN `BUTTON_POST`.
@@ -49,12 +44,20 @@ Send properties of the event source control to the backend. The syntax `${$sourc
 ```abap
 METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->button( text = `post` press = client->_event(
-            val = `BUTTON_POST`
-            "reads button text → result: "post"
-            t_arg = VALUE #( ( `${$source>/text}` ) ) )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->tag( `Button`
+                    )->a( n = `text`  v = `post`
+                    )->a( n = `press` v = client->_event(
+                                          val   = `BUTTON_POST`
+                                          " reads the button text → result: "post"
+                                          t_arg = VALUE #( ( `${$source>/text}` ) ) ) ).
+
+    client->view_display( view->stringify( ) ).
 
     CASE client->get( )-event.
       WHEN `BUTTON_POST`.
@@ -69,12 +72,21 @@ Read parameters of the event. The syntax `${$parameters>/id}` reads the `id` par
 ```abap
 METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->button( text = `post` id = `button_id` press = client->_event(
-            val = `BUTTON_POST`
-            "reads event parameter 'id' → result: "mainView--button_id"
-            t_arg = VALUE #( ( `${$parameters>/id}` ) ) )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->tag( `Button`
+                    )->a( n = `id`    v = `button_id`
+                    )->a( n = `text`  v = `post`
+                    )->a( n = `press` v = client->_event(
+                                          val   = `BUTTON_POST`
+                                          " reads the event parameter 'id' → result: "mainView--button_id"
+                                          t_arg = VALUE #( ( `${$parameters>/id}` ) ) ) ).
+
+    client->view_display( view->stringify( ) ).
 
     CASE client->get( )-event.
         WHEN `BUTTON_POST`.
@@ -89,12 +101,20 @@ Read specific properties of the event object. The syntax `$event>sId` reads the 
 ```abap
 METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->button( text = `post` press = client->_event(
-            val = `BUTTON_POST`
-            "reads event object attribute → result: "press"
-            t_arg = VALUE #( ( `$event>sId` ) ) )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->tag( `Button`
+                    )->a( n = `text`  v = `post`
+                    )->a( n = `press` v = client->_event(
+                                          val   = `BUTTON_POST`
+                                          " reads an event-object attribute → result: "press"
+                                          t_arg = VALUE #( ( `$event>sId` ) ) ) ).
+
+    client->view_display( view->stringify( ) ).
 
     CASE client->get( )-event.
         WHEN `BUTTON_POST`.
@@ -121,12 +141,21 @@ ENDCLASS.
 CLASS z2ui5_cl_app_hello_world IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-         )->input( client->_bind( name )
-        )->button( text = `post` press = client->_event(
-            val   = `BUTTON_POST`
-            t_arg = VALUE #( ( `$` && client->_bind( name ) ) ) )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->tag( `Input`
+                    )->a( n = `value` v = client->_bind( name )
+                )->tag( `Button`
+                    )->a( n = `text`  v = `post`
+                    )->a( n = `press` v = client->_event(
+                                          val   = `BUTTON_POST`
+                                          t_arg = VALUE #( ( `$` && client->_bind( name ) ) ) ) ).
+
+    client->view_display( view->stringify( ) ).
 
     CASE client->get( )-event.
         WHEN `BUTTON_POST`.

--- a/docs/cookbook/event_navigation/frontend.md
+++ b/docs/cookbook/event_navigation/frontend.md
@@ -3,23 +3,26 @@ outline: [2, 4]
 ---
 # Frontend
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 If you don't want to handle the event in the backend, fire actions directly on the frontend. The difference between the two event styles:
 
 - **`client->_event( )`** — causes a backend roundtrip; the event runs in the `main` method
-- **`client->_event_client( )`** — runs an action directly in the browser; no backend call
+- **`client->follow_up_action( )`** — runs an action in the browser; no backend call
 
-Use `_event_client` on a UI5 control property (like `press`) when the response should happen entirely in the browser. To fire a frontend event **after** backend processing has finished, use [`client->follow_up_action`](/cookbook/expert_more/follow_up_action) instead — it schedules the same frontend event but is called from the backend.
+`follow_up_action( )` is **one method in two positions**, and the position is
+what decides when it happens:
+
+- **in a view attribute** (`press = client->follow_up_action( … )`) its result
+  is consumed, and the action is wired to the control — the browser runs it
+  when the user presses, with no roundtrip at all;
+- **as a statement** in your `main` method it is scheduled, and the browser
+  runs it after the response arrives — i.e. after your backend work.
+
+::: tip `_event_client( )` is the older name for the first form
+It is obsolete: in the view-attribute position the two produce the identical
+wire, byte for byte. It stays in the interface so existing apps keep compiling
+— rename the calls at your leisure.
+:::
+
 
 The following frontend events are available:
 ```abap
@@ -73,13 +76,20 @@ For example, to open a new tab directly from a button press (no backend involved
 ```abap
 METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-        )->button(
-            text  = `open new tab`
-            press = client->_event_client(
-                val   = client->cs_event-open_new_tab
-                t_arg = VALUE #( ( `https://github.com/abap2UI5` ) ) )
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->tag( `Button`
+                    )->a( n = `text`  v = `open new tab`
+                    )->a( n = `press` v = client->follow_up_action(
+                                             val   = client->cs_event-open_new_tab
+                                             t_arg = VALUE #( ( `https://github.com/abap2UI5` ) ) ) ).
+
+    client->view_display( view->stringify( ) ).
+
 
 ENDMETHOD.
 ```
@@ -99,12 +109,13 @@ For `control_by_id`, any public control method is callable as long as it is not 
 
 ```abap
 " toggle a MessagePopover open, anchored to the pressing button, no roundtrip
-press = client->_event_client(
+press = client->follow_up_action(
     val   = client->cs_event-control_by_id
     t_arg = VALUE #( ( `msgPopover` ) ( `toggleBy` ) ( `${$source>/id}` ) ) )
 ```
 
-The same events also work from the backend with `client->follow_up_action( )` using the identical `t_arg`.
+The same events also work as a **statement** in your `main` method, with the identical `t_arg` — then the browser runs them after the response arrives.
+
 
 ### Element-binding a view slot: `bind_element`
 
@@ -122,15 +133,16 @@ The `view` parameter selects the slot to bind; `t_arg` carries the row index and
 
 ### The `view` parameter
 
-For `control_by_id`, the control is looked up by id. Both `_event_client( )` and `follow_up_action( )` take a separate `view` parameter (default `cs_view-main`) that scopes this lookup:
+For `control_by_id`, the control is looked up by id. `follow_up_action( )` (and the obsolete `_event_client( )`) takes a separate `view` parameter (default `cs_view-main`) that scopes this lookup:
 
 - omit it (or pass `cs_view-main`) — the id is resolved across all open views;
 - pass `cs_view-popup` / `cs_view-popover` / `cs_view-nested` / … — the lookup is scoped to a control hosted in that view (e.g. a control living inside a popup).
 
 ```abap
 " call a method on a control that lives inside the popup view
-press = client->_event_client(
+press = client->follow_up_action(
     val   = client->cs_event-control_by_id
+
     view  = client->cs_view-popup
     t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
 ```

--- a/docs/cookbook/event_navigation/frontend.md
+++ b/docs/cookbook/event_navigation/frontend.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Frontend
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 If you don't want to handle the event in the backend, fire actions directly on the frontend. The difference between the two event styles:
 
 - **`client->_event( )`** — causes a backend roundtrip; the event runs in the `main` method

--- a/docs/cookbook/expert_more/app_state_share.md
+++ b/docs/cookbook/expert_more/app_state_share.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # App State, Share
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 abap2UI5 saves the current app state so you can return to it later — like how standard UI5 apps manage state. This opens up several useful options, like sharing and bookmarking the current state of your app.
 
 ### Usage
@@ -37,14 +26,22 @@ CLASS z2ui5_cl_sample_app_state IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_navigated( ).
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      client->view_display(
-        view->label( `quantity`
-            )->input( client->_bind( mv_quantity )
-            )->button(
-                text  = `post with state`
-                press = client->_event( `BUTTON_POST` )
-              )->stringify( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->tag( `Label`
+                      )->a( n = `text` v = `quantity`
+                  )->tag( `Input`
+                      )->a( n = `value` v = client->_bind( mv_quantity )
+                  )->tag( `Button`
+                      )->a( n = `text`  v = `post with state`
+                      )->a( n = `press` v = client->_event( `BUTTON_POST` ) ).
+
+      client->view_display( view->stringify( ) ).
+
     ENDIF.
 
     CASE client->get( )-event.

--- a/docs/cookbook/expert_more/app_state_share.md
+++ b/docs/cookbook/expert_more/app_state_share.md
@@ -74,10 +74,22 @@ CLASS z2ui5_cl_sample_share IMPLEMENTATION.
 
       WHEN client->check_on_navigated( ).
 
-        DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( )->page(
-          )->label( `quantity`
-          )->input( client->_bind( mv_quantity )
-          )->button( text  = `share` press = client->_event( `BUTTON_POST` ) ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+                )->ele( `Shell`
+                    )->ele( `Page`
+
+                        )->tag( `Label`
+                            )->a( n = `text` v = `quantity`
+                        )->tag( `Input`
+                            )->a( n = `value` v = client->_bind( mv_quantity )
+                        )->tag( `Button`
+                            )->a( n = `text`  v = `share`
+                            )->a( n = `press` v = client->_event( `BUTTON_POST` ) ).
+
         client->view_display( view->stringify( ) ).
 
       WHEN client->check_on_event( `BUTTON_POST` ).

--- a/docs/cookbook/expert_more/app_state_share.md
+++ b/docs/cookbook/expert_more/app_state_share.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # App State, Share
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 abap2UI5 saves the current app state so you can return to it later — like how standard UI5 apps manage state. This opens up several useful options, like sharing and bookmarking the current state of your app.
 
 ### Usage

--- a/docs/cookbook/expert_more/demo_output.md
+++ b/docs/cookbook/expert_more/demo_output.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Demo Output
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Familiar with `CL_DEMO_OUTPUT` from classic ABAP? You can show its HTML output inside an abap2UI5 app too. This is handy for quick data visualization or when porting existing demos.
 
 The approach: build the HTML with `cl_demo_output=>get( )`, inject CSS styles via `_cc_plain_xml` (which inserts raw XML/HTML into the view), and render the result with the UI5 `html` control. The CSS block is needed because `CL_DEMO_OUTPUT` produces HTML with specific class names (e.g., `heading1`, `header`, `body`) that need matching style definitions to render correctly.
@@ -95,13 +84,19 @@ METHOD z2ui5_if_app~main.
     DATA(lv_html) = `<h2 title="I'm a header">The title Attribute</h2>` && |\n|  &&
                     `<p title="I'm a tooltip">Mouse over this paragraph, to display the title attribute as a tooltip.</p>`.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-           )->page(
-          )->_cc_plain_xml( lv_style
-          )->html( lv_html ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:core` v = `sap.ui.core`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->tag( n = `HTML` ns = `core`
+                        )->a( n = `content` v = lv_style && lv_html ).
 
     client->view_display( view->stringify( ) ).
+
 
 ENDMETHOD.
 ```

--- a/docs/cookbook/expert_more/demo_output.md
+++ b/docs/cookbook/expert_more/demo_output.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Demo Output
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Familiar with `CL_DEMO_OUTPUT` from classic ABAP? You can show its HTML output inside an abap2UI5 app too. This is handy for quick data visualization or when porting existing demos.
 
 The approach: build the HTML with `cl_demo_output=>get( )`, inject CSS styles via `_cc_plain_xml` (which inserts raw XML/HTML into the view), and render the result with the UI5 `html` control. The CSS block is needed because `CL_DEMO_OUTPUT` produces HTML with specific class names (e.g., `heading1`, `header`, `body`) that need matching style definitions to render correctly.

--- a/docs/cookbook/expert_more/email.md
+++ b/docs/cookbook/expert_more/email.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # E-Mail
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 abap2UI5 has no e-mail control of its own — sending mail is plain ABAP via `cl_bcs_message` (or `cl_bcs` on older releases). The UI part is a normal event handler that gathers the form fields and calls the BCS API.
 
 #### Plain Text Mail
@@ -35,17 +24,37 @@ CLASS z2ui5_cl_sample_email IMPLEMENTATION.
     CASE abap_true.
 
       WHEN client->check_on_init( ).
-        client->view_display( z2ui5_cl_xml_view=>factory(
-            )->page( `Send E-Mail`
-                )->simple_form( editable = abap_true
-                    )->content( `form`
-                        )->label( `To`      )->input( client->_bind( mv_to )
-                        )->label( `Subject` )->input( client->_bind( mv_subject )
-                        )->label( `Body`    )->text_area( client->_bind( mv_body )
-                        )->button(
-                            text  = `send`
-                            press = client->_event( `SEND` )
-            )->stringify( ) ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`      v = `sap.m`
+                )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+                )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+                )->ele( `Page`
+                    )->a( n = `title` v = `Send E-Mail`
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `editable` b = abap_true
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `To`
+                            )->tag( `Input`
+                                )->a( n = `value` v = client->_bind( mv_to )
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Subject`
+                            )->tag( `Input`
+                                )->a( n = `value` v = client->_bind( mv_subject )
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Body`
+                            )->tag( `TextArea`
+                                )->a( n = `value` v = client->_bind( mv_body )
+                            )->tag( `Button`
+                                )->a( n = `text`  v = `send`
+                                )->a( n = `press` v = client->_event( `SEND` ) ).
+
+        client->view_display( view->stringify( ) ).
+
 
       WHEN client->check_on_event( `SEND` ).
         TRY.

--- a/docs/cookbook/expert_more/email.md
+++ b/docs/cookbook/expert_more/email.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # E-Mail
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 abap2UI5 has no e-mail control of its own — sending mail is plain ABAP via `cl_bcs_message` (or `cl_bcs` on older releases). The UI part is a normal event handler that gathers the form fields and calls the BCS API.
 
 #### Plain Text Mail

--- a/docs/cookbook/expert_more/follow_up_action.md
+++ b/docs/cookbook/expert_more/follow_up_action.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Follow-up Action
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Sometimes, once your backend event handler has finished, you want to trigger an
 action that runs on the frontend — set the browser title, move focus, scroll,
 copy to the clipboard, and so on. `client->follow_up_action( )` schedules such a
@@ -149,15 +138,25 @@ The `_generic` method creates a custom XML/HTML element — here an HTML `<scrip
   METHOD z2ui5_if_app~main.
 
   IF client->check_on_init( ).
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      view->_generic( name = `script` ns = `html`
-        )->_cc_plain_xml(
-          |function myFunction() \{ console.log( `Hello World` ); \}|
-        ).
-      view->page(
-        )->button( text  = `call custom JS`
-                   press = client->_event( `CUSTOM_JS` ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`      v = `sap.m`
+              )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+              )->a( n = `xmlns:core` v = `sap.ui.core`
+
+              " the script travels as the CONTENT of a core:HTML control - the
+              " builder re-escapes it on stringify, so the literal markup is
+              " written here
+              )->tag( n = `HTML` ns = `core`
+                  )->a( n = `content` v = |<script>function myFunction() \{ console.log( `Hello World` ); \}</script>|
+
+              )->ele( `Page`
+                  )->tag( `Button`
+                      )->a( n = `text`  v = `call custom JS`
+                      )->a( n = `press` v = client->_event( `CUSTOM_JS` ) ).
+
       client->view_display( view->stringify( ) ).
+
   ENDIF.
 
   IF client->get( )-event = `CUSTOM_JS`.

--- a/docs/cookbook/expert_more/follow_up_action.md
+++ b/docs/cookbook/expert_more/follow_up_action.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Follow-up Action
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Sometimes, once your backend event handler has finished, you want to trigger an
 action that runs on the frontend — set the browser title, move focus, scroll,
 copy to the clipboard, and so on. `client->follow_up_action( )` schedules such a
@@ -101,7 +112,7 @@ alternative.
 
 ::: tip `cs_event-z2ui5` is the older form of the same thing
 The constant calls a function you registered as a `z2ui5.*` global
-(`follow_up_action( val = cs_event-z2ui5 t_arg = VALUE #( ( `myFunction` ) ) )`).
+(``follow_up_action( val = cs_event-z2ui5 t_arg = VALUE #( ( `myFunction` ) ) )``).
 It still works and is still dispatched, but it sits with the obsolete constants
 in `z2ui5_if_client`: passing the expression directly, as above, is the same
 call without the indirection. If the global is missing the frontend logs

--- a/docs/cookbook/expert_more/follow_up_action.md
+++ b/docs/cookbook/expert_more/follow_up_action.md
@@ -176,7 +176,7 @@ If you must use this, ensure the JavaScript content is **entirely static and har
 The same security considerations apply: any `<script>` element embedded in an XML view runs with full app privileges and bypasses UI5's output encoding. Prefer a [Custom Control](/advanced/extensibility/custom_control) or one of the built-in events instead.
 :::
 
-If you want to look at — or hand-craft — the raw XML view that abap2UI5 produces, a `<script>` tag is placed in the `html` namespace alongside the regular UI5 controls. The view stringified by `z2ui5_cl_xml_view=>factory( )` ends up looking like this:
+If you want to look at — or hand-craft — the raw XML view that abap2UI5 produces, a `<script>` tag is placed in the `html` namespace alongside the regular UI5 controls. The view stringified by `z2ui5_cl_ui5_view_builder=>factory( )` ends up looking like this:
 
 ```xml
 <mvc:View

--- a/docs/cookbook/expert_more/lock.md
+++ b/docs/cookbook/expert_more/lock.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Lock
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 In classic SAP GUI, a transaction like `VA02` calls `ENQUEUE_EVVBAK` and the lock lives as long as the dialog session. Web apps are different: each roundtrip is a fresh ABAP session by default, so a lock set in one roundtrip is gone by the next. Locking in abap2UI5 means picking a deliberate strategy for two questions:
 
 | Phase | Question |
@@ -106,33 +95,46 @@ CLASS z2ui5_cl_sample_lock_1 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page(
-            title          = `Edit Sales Order — No Locking`
-            shownavbutton  = client->check_app_prev_stack( )
-            navbuttonpress = client->_event_nav_app_leave( )
-            )->simple_form(
-                title    = `Header`
-                editable = abap_true
-                )->content( `form`
-                )->label( `Sales Order`
-                )->input(
-                    value   = vbeln
-                    enabled = abap_false
-                )->label( `Type`
-                )->input( client->_bind( auart )
-                )->label( `Created by`
-                )->input(
-                    value   = ernam
-                    enabled = abap_false
-                )->label( `Created on`
-                )->input(
-                    value   = CONV string( erdat )
-                    enabled = abap_false
-                )->button(
-                    text  = `Save`
-                    press = client->_event( `SAVE` ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `Edit Sales Order — No Locking`
+                    )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+                    )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `Header`
+                        )->a( n = `editable` b = abap_true
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Sales Order`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = vbeln
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Type`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = client->_bind( auart )
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Created by`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = ernam
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Created on`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = CONV string( erdat )
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Save`
+                                )->a( n = `press`   v = client->_event( `SAVE` ) ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
@@ -275,25 +277,36 @@ CLASS z2ui5_cl_sample_lock_2 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page(
-            title          = `Edit Sales Order — Enqueue at Save`
-            shownavbutton  = client->check_app_prev_stack( )
-            navbuttonpress = client->_event_nav_app_leave( )
-            )->simple_form(
-                title    = `Header`
-                editable = abap_true
-                )->content( `form`
-                )->label( `Sales Order`
-                )->input(
-                    value   = vbeln
-                    enabled = abap_false
-                )->label( `Type`
-                )->input( client->_bind( auart )
-                )->button(
-                    text  = `Save`
-                    press = client->_event( `SAVE` ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `Edit Sales Order — Enqueue at Save`
+                    )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+                    )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `Header`
+                        )->a( n = `editable` b = abap_true
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Sales Order`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = vbeln
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Type`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = client->_bind( auart )
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Save`
+                                )->a( n = `press`   v = client->_event( `SAVE` ) ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
@@ -418,7 +431,7 @@ CLASS z2ui5_cl_sample_lock_3 IMPLEMENTATION.
     ENDIF.
 
     "don't do that, just for demo
-    "DATA(now) = z2ui5_cl_util=>time_get_timestampl( ).
+    "GET TIME STAMP FIELD now.
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,
@@ -427,7 +440,6 @@ CLASS z2ui5_cl_sample_lock_3 IMPLEMENTATION.
     "COMMIT WORK.
 
     data_read( ).
-    client->view_model_update( ).
     client->message_toast_display( `Saved.` ).
 
   ENDMETHOD.
@@ -435,25 +447,36 @@ CLASS z2ui5_cl_sample_lock_3 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page(
-            title          = `Edit Sales Order — Optimistic Locking`
-            shownavbutton  = client->check_app_prev_stack( )
-            navbuttonpress = client->_event_nav_app_leave( )
-            )->simple_form(
-                title    = `Header`
-                editable = abap_true
-                )->content( `form`
-                )->label( `Sales Order`
-                )->input(
-                    value   = vbeln
-                    enabled = abap_false
-                )->label( `Type`
-                )->input( client->_bind( auart )
-                )->button(
-                    text  = `Save`
-                    press = client->_event( `SAVE` ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `Edit Sales Order — Optimistic Locking`
+                    )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+                    )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `Header`
+                        )->a( n = `editable` b = abap_true
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Sales Order`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = vbeln
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Type`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = client->_bind( auart )
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Save`
+                                )->a( n = `press`   v = client->_event( `SAVE` ) ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
@@ -575,7 +598,7 @@ CLASS z2ui5_cl_sample_lock_4 IMPLEMENTATION.
     ENDIF.
 
     "don't do that, just for demo
-    "DATA(now) = z2ui5_cl_util=>time_get_timestampl( ).
+    "GET TIME STAMP FIELD now.
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,
@@ -590,7 +613,6 @@ CLASS z2ui5_cl_sample_lock_4 IMPLEMENTATION.
         vbeln     = vbeln.
 
     data_read( ).
-    client->view_model_update( ).
     client->message_toast_display( `Saved.` ).
 
   ENDMETHOD.
@@ -598,25 +620,36 @@ CLASS z2ui5_cl_sample_lock_4 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page(
-            title          = `Edit Sales Order — Enqueue + Optimistic`
-            shownavbutton  = client->check_app_prev_stack( )
-            navbuttonpress = client->_event_nav_app_leave( )
-            )->simple_form(
-                title    = `Header`
-                editable = abap_true
-                )->content( `form`
-                )->label( `Sales Order`
-                )->input(
-                    value   = vbeln
-                    enabled = abap_false
-                )->label( `Type`
-                )->input( client->_bind( auart )
-                )->button(
-                    text  = `Save`
-                    press = client->_event( `SAVE` ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `Edit Sales Order — Enqueue + Optimistic`
+                    )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+                    )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `Header`
+                        )->a( n = `editable` b = abap_true
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Sales Order`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = vbeln
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Type`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = client->_bind( auart )
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Save`
+                                )->a( n = `press`   v = client->_event( `SAVE` ) ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
@@ -782,7 +815,7 @@ CLASS z2ui5_cl_sample_lock_5 IMPLEMENTATION.
   METHOD on_event_save.
 
     "don't do that, just demo
-    "DATA(now) = z2ui5_cl_util=>time_get_timestampl( ).
+    "GET TIME STAMP FIELD now.
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,
@@ -807,28 +840,39 @@ CLASS z2ui5_cl_sample_lock_5 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page(
-            title          = `Edit Sales Order — Stateful Lock`
-            shownavbutton  = client->check_app_prev_stack( )
-            navbuttonpress = client->_event( `CANCEL` )
-            )->simple_form(
-                title    = `Header`
-                editable = abap_true
-                )->content( `form`
-                )->label( `Sales Order`
-                )->input(
-                    value   = vbeln
-                    enabled = abap_false
-                )->label( `Type`
-                )->input( client->_bind( auart )
-                )->button(
-                    text  = `Save`
-                    press = client->_event( `SAVE` )
-                )->button(
-                    text  = `Cancel`
-                    press = client->_event( `CANCEL` ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `Edit Sales Order — Stateful Lock`
+                    )->a( n = `navButtonPress` v = client->_event( `CANCEL` )
+                    )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `Header`
+                        )->a( n = `editable` b = abap_true
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Sales Order`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = vbeln
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Type`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = client->_bind( auart )
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Save`
+                                )->a( n = `press`   v = client->_event( `SAVE` )
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Cancel`
+                                )->a( n = `press`   v = client->_event( `CANCEL` ) ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
@@ -943,7 +987,7 @@ CLASS z2ui5_cl_sample_lock_6 IMPLEMENTATION.
     DATA s_new TYPE z2ui5_sample_01.
     s_new-vbeln    = vbeln.
     s_new-username = sy-uname.
-    s_new-locked_at = z2ui5_cl_util=>time_get_timestampl( ).
+    GET TIME STAMP FIELD s_new-locked_at.
 
     MODIFY z2ui5_sample_01 FROM @s_new.
     COMMIT WORK.
@@ -1013,7 +1057,7 @@ CLASS z2ui5_cl_sample_lock_6 IMPLEMENTATION.
     ENDIF.
 
     "don't do that, just demo
-    "DATA(now) = z2ui5_cl_util=>time_get_timestampl( ).
+    "GET TIME STAMP FIELD now.
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,
@@ -1046,33 +1090,45 @@ CLASS z2ui5_cl_sample_lock_6 IMPLEMENTATION.
 
     DATA(editable) = COND abap_bool( WHEN locked_by IS INITIAL THEN abap_true ELSE abap_false ).
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page(
-            title          = `Edit Sales Order — Soft Lock + Save Guard`
-            shownavbutton  = client->check_app_prev_stack( )
-            navbuttonpress = client->_event_nav_app_leave( )
-            )->simple_form(
-                title    = `Header`
-                editable = editable
-                )->content( `form`
-                )->label( `Sales Order`
-                )->input(
-                    value   = vbeln
-                    enabled = abap_false
-                )->label( `Type`
-                )->input( client->_bind( auart )
-                )->label( `Status`
-                )->input(
-                    value   = locked_by
-                    enabled = abap_false
-                )->button(
-                    text    = `Save`
-                    press   = client->_event( `SAVE` )
-                    enabled = editable
-                )->button(
-                    text  = `Release & Exit`
-                    press = client->_event( `RELEASE` ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `Edit Sales Order — Soft Lock + Save Guard`
+                    )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+                    )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `Header`
+                        )->a( n = `editable` b = editable
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Sales Order`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = vbeln
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Type`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = client->_bind( auart )
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Status`
+                            )->tag( `Input`
+                                )->a( n = `value`   v = locked_by
+                                )->a( n = `enabled` b = abap_false
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Save`
+                                )->a( n = `press`   v = client->_event( `SAVE` )
+                                )->a( n = `enabled` b = editable
+                            )->tag( `Button`
+                                )->a( n = `text`    v = `Release & Exit`
+                                )->a( n = `press`   v = client->_event( `RELEASE` ) ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.

--- a/docs/cookbook/expert_more/lock.md
+++ b/docs/cookbook/expert_more/lock.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Lock
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 In classic SAP GUI, a transaction like `VA02` calls `ENQUEUE_EVVBAK` and the lock lives as long as the dialog session. Web apps are different: each roundtrip is a fresh ABAP session by default, so a lock set in one roundtrip is gone by the next. Locking in abap2UI5 means picking a deliberate strategy for two questions:
 
 | Phase | Question |

--- a/docs/cookbook/expert_more/odata.md
+++ b/docs/cookbook/expert_more/odata.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # OData
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 By default, you bind public attributes of your class to UI5 properties with `_bind`. For cases where you need access to large datasets, you can also use existing OData services. OData offers features like pagination and growing that improve performance with large amounts of data.
 
 #### Define Additional Model
@@ -28,21 +17,47 @@ client->follow_up_action(
 #### Bind Data
 Next, bind the OData model to your view definition. Since we use a non-default model, name the model explicitly for each binding:
 ```abap
-DATA(tab) = z2ui5_cl_xml_view=>factory( )->page( )->table(
-    items = `{FLIGHT>/Airport}`
-    growing = abap_true ).
+DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`     v = `sap.m`
+        )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-tab->columns(
-    )->column( )->text( `AirportID` )->get_parent(
-    )->column( )->text( `Name` )->get_parent(
-    )->column( )->text( `City` )->get_parent(
-    )->column( )->text( `CountryCode` ).
+        )->ele( `Page`
+            )->ele( `Table`
+                )->a( n = `items`   v = `{FLIGHT>/Airport}`
+                )->a( n = `growing` b = abap_true
 
-tab->items( )->column_list_item( )->cells(
-    )->text( `{FLIGHT>AirportID}`
-    )->text( `{FLIGHT>Name}`
-    )->text( `{FLIGHT>City}`
-    )->text( `{FLIGHT>CountryCode}` ).
+                )->ele( `columns`
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `AirportID`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `Name`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `City`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `CountryCode`
+                    )->end(
+
+                )->end(
+
+                )->ele( `items`
+                    )->ele( `ColumnListItem`
+                        )->ele( `cells`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{FLIGHT>AirportID}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{FLIGHT>Name}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{FLIGHT>City}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{FLIGHT>CountryCode}` ).
 ```
 The `growing` property loads data in batches instead of all at once, boosting performance.
 
@@ -51,23 +66,49 @@ The full source code:
 ```abap
   METHOD z2ui5_if_app~main.
 
-    DATA(tab) = z2ui5_cl_xml_view=>factory( )->page( )->table(
-        items   = `{FLIGHT>/Airport}`
-        growing = abap_true ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-    tab->columns(
-        )->column( )->text( `AirportID` )->get_parent(
-        )->column( )->text( `Name` )->get_parent(
-        )->column( )->text( `City` )->get_parent(
-        )->column( )->text( `CountryCode` ).
+            )->ele( `Page`
+                )->ele( `Table`
+                    )->a( n = `items`   v = `{FLIGHT>/Airport}`
+                    )->a( n = `growing` b = abap_true
 
-    tab->items( )->column_list_item( )->cells(
-        )->text( `{FLIGHT>AirportID}`
-        )->text( `{FLIGHT>Name}`
-        )->text( `{FLIGHT>City}`
-        )->text( `{FLIGHT>CountryCode}` ).
+                    )->ele( `columns`
+                        )->ele( `Column`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `AirportID`
+                        )->end(
+                        )->ele( `Column`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `Name`
+                        )->end(
+                        )->ele( `Column`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `City`
+                        )->end(
+                        )->ele( `Column`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `CountryCode`
+                        )->end(
 
-    client->view_display( tab->stringify( ) ).
+                    )->end(
+
+                    )->ele( `items`
+                        )->ele( `ColumnListItem`
+                            )->ele( `cells`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `{FLIGHT>AirportID}`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `{FLIGHT>Name}`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `{FLIGHT>City}`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `{FLIGHT>CountryCode}` ).
+
+    client->view_display( view->stringify( ) ).
 
     client->follow_up_action(
         val   = z2ui5_if_client=>cs_event-set_odata_model
@@ -81,23 +122,49 @@ ENDMETHOD.
 #### Multiple OData Models
 You can also bind multiple OData models at once. For example, to bind an extra OData model under the name `TRAVEL`:
 ```abap
-DATA(tab) = z2ui5_cl_xml_view=>factory( )->page( )->table(
-    items   = `{TRAVEL>/BookingSupplement}`
-    growing = abap_true ).
+DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`     v = `sap.m`
+        )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-tab->columns(
-    )->column( )->text( `TravelID` )->get_parent(
-    )->column( )->text( `BookingID` )->get_parent(
-    )->column( )->text( `BookingSupplementID` )->get_parent(
-    )->column( )->text( `SupplementID` )->get_parent( ).
+        )->ele( `Page`
+            )->ele( `Table`
+                )->a( n = `items`   v = `{TRAVEL>/BookingSupplement}`
+                )->a( n = `growing` b = abap_true
 
-tab->items( )->column_list_item( )->cells(
-    )->text( `{TRAVEL>TravelID}`
-    )->text( `{TRAVEL>BookingID}`
-    )->text( `{TRAVEL>BookingSupplementID}`
-    )->text( `{TRAVEL>SupplementID}` ).
+                )->ele( `columns`
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `TravelID`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `BookingID`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `BookingSupplementID`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `SupplementID`
+                    )->end(
 
-client->view_display( tab->stringify( ) ).
+                )->end(
+
+                )->ele( `items`
+                    )->ele( `ColumnListItem`
+                        )->ele( `cells`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{TRAVEL>TravelID}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{TRAVEL>BookingID}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{TRAVEL>BookingSupplementID}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{TRAVEL>SupplementID}` ).
+
+client->view_display( view->stringify( ) ).
 
 client->follow_up_action(
     val   = z2ui5_if_client=>cs_event-set_odata_model

--- a/docs/cookbook/expert_more/odata.md
+++ b/docs/cookbook/expert_more/odata.md
@@ -204,23 +204,48 @@ So `{TRAVEL>/#Currency/Currency/@sap:label}` resolves to the value of `sap:label
 
 ```abap
 
-DATA(tab) = page->table(
-    items   = `{TRAVEL>/Currency}`
-    growing = abap_true ).
+DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`     v = `sap.m`
+        )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-tab->columns(
-    )->column( )->text( `{TRAVEL>/#Currency/Currency/@sap:label}` )->get_parent(
-    )->column( )->text( `{TRAVEL>/#Currency/Currency_Text/@sap:label}` )->get_parent(
-    )->column( )->text( `{TRAVEL>/#Currency/Decimals/@sap:label}` )->get_parent(
-    )->column( )->text( `{TRAVEL>/#Currency/CurrencyISOCode/@sap:label}` ).
+        )->ele( `Page`
+            )->ele( `Table`
+                )->a( n = `items`   v = `{TRAVEL>/Currency}`
+                )->a( n = `growing` b = abap_true
 
-tab->items( )->column_list_item( )->cells(
-    )->text( `{TRAVEL>Currency}`
-    )->text( `{TRAVEL>Currency_Text}`
-    )->text( `{TRAVEL>Decimals}`
-    )->text( `{TRAVEL>CurrencyISOCode}` ).
+                )->ele( `columns`
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `{TRAVEL>/#Currency/Currency/@sap:label}`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `{TRAVEL>/#Currency/Currency_Text/@sap:label}`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `{TRAVEL>/#Currency/Decimals/@sap:label}`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `{TRAVEL>/#Currency/CurrencyISOCode/@sap:label}`
+                    )->end(
+                )->end(
 
-client->view_display( tab->stringify( ) ).
+                )->ele( `items`
+                    )->ele( `ColumnListItem`
+                        )->ele( `cells`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{TRAVEL>Currency}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{TRAVEL>Currency_Text}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{TRAVEL>Decimals}`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{TRAVEL>CurrencyISOCode}` ).
+
+client->view_display( view->stringify( ) ).
 
 client->follow_up_action(
     val   = z2ui5_if_client=>cs_event-set_odata_model

--- a/docs/cookbook/expert_more/odata.md
+++ b/docs/cookbook/expert_more/odata.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # OData
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 By default, you bind public attributes of your class to UI5 properties with `_bind`. For cases where you need access to large datasets, you can also use existing OData services. OData offers features like pagination and growing that improve performance with large amounts of data.
 
 #### Define Additional Model

--- a/docs/cookbook/expert_more/snippets.md
+++ b/docs/cookbook/expert_more/snippets.md
@@ -280,24 +280,24 @@ CLASS z2ui5_cl_app_table_sort IMPLEMENTATION.
                   )->a( n = `title` v = `Sortable Table`
                   )->ele( `Table`
                       )->a( n = `items` v = client->_bind( rows )
-                    )->a( n = `growingThreshold` v = `10`
-                    )->a( n = `sticky`           v = `ColumnHeaders`
-                    )->a( n = `growing`          b = abap_true
+                      )->a( n = `growingThreshold` v = `10`
+                      )->a( n = `sticky`           v = `ColumnHeaders`
+                      )->a( n = `growing`          b = abap_true
 
-                    )->ele( `headerToolbar`
-                        )->ele( `Toolbar`
-                            )->tag( `Title`
-                                )->a( n = `text` v = `Orders`
-                            )->tag( `ToolbarSpacer`
-                            )->tag( `Button`
-                                )->a( n = `text`  v = `Sort by Name`
-                                )->a( n = `press` v = client->_event( `SORT_NAME` )
-                            )->tag( `Button`
-                                )->a( n = `text`  v = `Sort by Status`
-                                )->a( n = `press` v = client->_event( `SORT_STATUS` )
+                      )->ele( `headerToolbar`
+                          )->ele( `Toolbar`
+                              )->tag( `Title`
+                                  )->a( n = `text` v = `Orders`
+                              )->tag( `ToolbarSpacer`
+                              )->tag( `Button`
+                                  )->a( n = `text`  v = `Sort by Name`
+                                  )->a( n = `press` v = client->_event( `SORT_NAME` )
+                              )->tag( `Button`
+                                  )->a( n = `text`  v = `Sort by Status`
+                                  )->a( n = `press` v = client->_event( `SORT_STATUS` )
 
-                    )->end(
-                    )->end(
+                          )->end(
+                      )->end(
 
                       )->ele( `columns`
                           )->ele( `Column`

--- a/docs/cookbook/expert_more/snippets.md
+++ b/docs/cookbook/expert_more/snippets.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Snippets
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Copy-paste starting points for the most common app shapes. Each snippet is a complete, self-contained class — drop it in, activate it, and launch it by its name from the abap2UI5 landing page.
 
 ## Basic App Structure
@@ -34,11 +23,20 @@ CLASS z2ui5_cl_app_skeleton IMPLEMENTATION.
     CASE abap_true.
 
       WHEN client->check_on_init( ).
-        DATA(view) = z2ui5_cl_xml_view=>factory(
-          )->page( `My App`
-          )->text( `Hello World`
-          )->button( text  = `Go`
-                     press = client->_event( `GO` ) ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+                )->ele( `Page`
+                    )->a( n = `title` v = `My App`
+
+                )->tag( `Text`
+                    )->a( n = `text` v = `Hello World`
+                )->tag( `Button`
+                    )->a( n = `text`  v = `Go`
+                    )->a( n = `press` v = client->_event( `GO` ) ).
+
         client->view_display( view->stringify( ) ).
 
       WHEN client->check_on_event( `GO` ).
@@ -71,24 +69,45 @@ CLASS z2ui5_cl_app_selection IMPLEMENTATION.
     CASE abap_true.
 
       WHEN client->check_on_init( ).
-        DATA(page) = z2ui5_cl_xml_view=>factory( )->page( `Selection Screen` ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+                )->a( n = `xmlns:form` v = `sap.ui.layout.form`
 
-        page->simple_form( title = `Selection Criteria` editable = abap_true
-            )->content( ns = `form`
-                )->label( `Carrier ID`
-                )->input( client->_bind( carrid )
-                )->label( `Connection ID`
-                )->input( client->_bind( connid )
-                )->label( `Flight Date`
-                )->date_picker( client->_bind( fldate ) ).
+                )->ele( `Page`
+                    )->a( n = `title` v = `Selection Screen`
 
-        page->footer( )->overflow_toolbar(
-            )->toolbar_spacer(
-            )->button( text  = `Execute`
-                       type  = `Emphasized`
-                       press = client->_event( `EXECUTE` ) ).
+                )->ele( n = `SimpleForm` ns = `form`
+                    )->a( n = `title`    v = `Selection Criteria`
+                    )->a( n = `editable` b = abap_true
 
-        client->view_display( page->stringify( ) ).
+                    )->ele( n = `content` ns = `form`
+                        )->tag( `Label`
+                            )->a( n = `text` v = `Carrier ID`
+                        )->tag( `Input`
+                            )->a( n = `value` v = client->_bind( carrid )
+                        )->tag( `Label`
+                            )->a( n = `text` v = `Connection ID`
+                        )->tag( `Input`
+                            )->a( n = `value` v = client->_bind( connid )
+                        )->tag( `Label`
+                            )->a( n = `text` v = `Flight Date`
+                        )->tag( `DatePicker`
+                            )->a( n = `value` v = client->_bind( fldate )
+
+                )->end(
+                )->end(
+
+                )->ele( `footer`
+                    )->ele( `OverflowToolbar`
+                        )->tag( `ToolbarSpacer`
+                        )->tag( `Button`
+                            )->a( n = `text`  v = `Execute`
+                            )->a( n = `type`  v = `Emphasized`
+                            )->a( n = `press` v = client->_event( `EXECUTE` ) ).
+
+        client->view_display( view->stringify( ) ).
 
       WHEN client->check_on_event( `EXECUTE` ).
         " run the search with carrid / connid / fldate
@@ -126,8 +145,18 @@ CLASS z2ui5_cl_app_write_output IMPLEMENTATION.
       cl_demo_output=>write_data( sy-datum ).
       html = cl_demo_output=>get( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( )->page( `Write Output` ).
-      view->html( content = client->_bind( html ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+              )->a( n = `xmlns:core` v = `sap.ui.core`
+
+              )->ele( `Page`
+                  )->a( n = `title` v = `Write Output`
+
+              )->tag( n = `HTML` ns = `core`
+                  )->a( n = `content` v = client->_bind( html ) ).
+
       client->view_display( view->stringify( ) ).
 
     ENDIF.
@@ -166,16 +195,41 @@ CLASS z2ui5_cl_app_table_basic IMPLEMENTATION.
                         descr = `Sample row` ) INTO TABLE rows.
       ENDDO.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( )->page( `Basic Table` ).
-      DATA(tab)  = view->table( client->_bind( rows ) ).
-      tab->columns(
-          )->column( )->text( `ID` )->get_parent(
-          )->column( )->text( `Name` )->get_parent(
-          )->column( )->text( `Description` ).
-      tab->items( )->column_list_item( )->cells(
-          )->text( `{ID}`
-          )->text( `{NAME}`
-          )->text( `{DESCR}` ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->a( n = `title` v = `Basic Table`
+                  )->ele( `Table`
+                      )->a( n = `items` v = client->_bind( rows )
+
+                      )->ele( `columns`
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `ID`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Name`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Description`
+                          )->end(
+
+                      )->end(
+
+                      )->ele( `items`
+                          )->ele( `ColumnListItem`
+                              )->ele( `cells`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{ID}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{NAME}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{DESCR}` ).
 
       client->view_display( view->stringify( ) ).
 
@@ -187,7 +241,7 @@ ENDCLASS.
 
 ## Table with Sorting
 
-`sap.m.Table` has no built-in column sorting — in abap2UI5, sorting (and filtering) is backend work: react to an event, `SORT` the internal table in ABAP, and push the new order to the rendered view with `view_model_update`. No re-render needed:
+`sap.m.Table` has no built-in column sorting — in abap2UI5, sorting (and filtering) is backend work: react to an event and `SORT` the internal table in ABAP. The new order reaches the rendered view with the response — no re-render, and nothing else to call:
 
 ```abap
 CLASS z2ui5_cl_app_table_sort DEFINITION PUBLIC.
@@ -217,45 +271,69 @@ CLASS z2ui5_cl_app_table_sort IMPLEMENTATION.
           ) INTO TABLE rows.
       ENDDO.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( )->page( `Sortable Table` ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-      DATA(tab) = view->table(
-          items            = client->_bind( rows )
-          growing          = abap_true
-          growingthreshold = `10`
-          sticky           = `ColumnHeaders` ).
+              )->ele( `Page`
+                  )->a( n = `title` v = `Sortable Table`
+                  )->ele( `Table`
+                      )->a( n = `items` v = client->_bind( rows )
+                    )->a( n = `growingThreshold` v = `10`
+                    )->a( n = `sticky`           v = `ColumnHeaders`
+                    )->a( n = `growing`          b = abap_true
 
-      tab->header_toolbar( )->toolbar(
-          )->title( `Orders`
-          )->toolbar_spacer(
-          )->button(
-              text  = `Sort by Name`
-              press = client->_event( `SORT_NAME` )
-          )->button(
-              text  = `Sort by Status`
-              press = client->_event( `SORT_STATUS` ) ).
+                    )->ele( `headerToolbar`
+                        )->ele( `Toolbar`
+                            )->tag( `Title`
+                                )->a( n = `text` v = `Orders`
+                            )->tag( `ToolbarSpacer`
+                            )->tag( `Button`
+                                )->a( n = `text`  v = `Sort by Name`
+                                )->a( n = `press` v = client->_event( `SORT_NAME` )
+                            )->tag( `Button`
+                                )->a( n = `text`  v = `Sort by Status`
+                                )->a( n = `press` v = client->_event( `SORT_STATUS` )
 
-      tab->columns(
-          )->column( )->text( `ID` )->get_parent(
-          )->column( )->text( `Name` )->get_parent(
-          )->column( )->text( `Status` ).
+                    )->end(
+                    )->end(
 
-      tab->items( )->column_list_item( )->cells(
-          )->text( `{ID}`
-          )->text( `{NAME}`
-          )->text( `{STATUS}` ).
+                      )->ele( `columns`
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `ID`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Name`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Status`
+                          )->end(
+
+                      )->end(
+
+                      )->ele( `items`
+                          )->ele( `ColumnListItem`
+                              )->ele( `cells`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{ID}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{NAME}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{STATUS}` ).
 
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `SORT_NAME` ).
 
       SORT rows BY name.
-      client->view_model_update( ).
 
     ELSEIF client->check_on_event( `SORT_STATUS` ).
 
       SORT rows BY status.
-      client->view_model_update( ).
 
     ENDIF.
 

--- a/docs/cookbook/expert_more/snippets.md
+++ b/docs/cookbook/expert_more/snippets.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Snippets
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Copy-paste starting points for the most common app shapes. Each snippet is a complete, self-contained class — drop it in, activate it, and launch it by its name from the abap2UI5 landing page.
 
 ## Basic App Structure

--- a/docs/cookbook/expert_more/value_help.md
+++ b/docs/cookbook/expert_more/value_help.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Value Help
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Value help (the classic ABAP **F4** input help) lets users pick a value from a list instead of typing it. abap2UI5 covers the basics with two built-in popups and lets you build anything custom on top.
 
 #### Suggestions on the Input
@@ -32,20 +21,40 @@ mt_countries = VALUE #( ( code = `DE` name = `Germany` )
                         ( code = `FR` name = `France`  )
                         ( code = `IT` name = `Italy`   ) ).
 
-client->view_display( z2ui5_cl_xml_view=>factory(
-    )->page(
-        )->input(
-            value             = client->_bind( mv_country )
-            showsuggestion    = abap_true
-            suggestionitems   = client->_bind( mt_countries )
-            )->suggestion_items(
-                )->list_item( text = `{CODE}` additionaltext = `{NAME}`
-    )->stringify( ) ).
+DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+
+        )->ele( `Page`
+            )->ele( `Input`
+                )->a( n = `value`           v = client->_bind( mv_country )
+                )->a( n = `suggestionItems` v = client->_bind( mt_countries )
+                )->a( n = `showSuggestion`  b = abap_true
+
+                )->ele( `suggestionItems`
+                    )->tag( n = `ListItem` ns = `core`
+                        )->a( n = `text`           v = `{CODE}`
+                        )->a( n = `additionalText` v = `{NAME}` ).
+
+client->view_display( view->stringify( ) ).
 ```
 
 #### Selection Popup
 
-For a *"pick from this list"* dialog use the built-in `Z2UI5_CL_POP_TO_SELECT`. Pass any internal table, navigate to it as a sub-app, and read the result on return:
+For a *"pick from this list"* dialog, navigate to a picker as a sub-app, pass
+any internal table, and read the result on return.
+
+::: warning The built-in popups are frozen
+`Z2UI5_CL_POP_TO_SELECT` and its siblings live in the framework's frozen
+`src/99/02` package: they still run, so existing apps keep working, but they
+are not maintained and are on the removal list. Their successor is the separate
+[popups addon](https://github.com/abap2UI5-addons/popups), which is where new
+code should get its picker from. The example below is written with the built-in
+one because that is what existing code contains.
+:::
+
 
 ```abap
 CLASS z2ui5_cl_sample_f4 DEFINITION PUBLIC.
@@ -62,21 +71,29 @@ CLASS z2ui5_cl_sample_f4 IMPLEMENTATION.
     CASE abap_true.
 
       WHEN client->check_on_init( ).
-        client->view_display( z2ui5_cl_xml_view=>factory(
-            )->page(
-                )->input(
-                    value            = client->_bind( mv_carrid )
-                    showvaluehelp    = abap_true
-                    valuehelprequest = client->_event( `F4` )
-            )->stringify( ) ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+                )->ele( `Page`
+                    )->tag( `Input`
+                        )->a( n = `value`            v = client->_bind( mv_carrid )
+                        )->a( n = `valueHelpRequest` v = client->_event( `F4` )
+                        )->a( n = `showValueHelp`    b = abap_true ).
+
+        client->view_display( view->stringify( ) ).
+
 
       WHEN client->check_on_event( `F4` ).
         SELECT carrid, carrname, url FROM scarr INTO TABLE @DATA(lt_carriers).
+        " abap2ui5lint-disable-next-line non-released-api -- frozen built-in picker, see the note above
         client->nav_app_call( z2ui5_cl_pop_to_select=>factory(
             i_tab   = lt_carriers
             i_title = `Choose airline` ) ).
 
       WHEN client->check_on_navigated( ).
+        " abap2ui5lint-disable-next-line non-released-api -- frozen built-in picker, see the note above
         DATA(lo_prev) = CAST z2ui5_cl_pop_to_select( client->get_app_prev( ) ).
         DATA(ls_res)  = lo_prev->result( ).
         IF ls_res-check_confirmed = abap_true.

--- a/docs/cookbook/expert_more/value_help.md
+++ b/docs/cookbook/expert_more/value_help.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Value Help
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Value help (the classic ABAP **F4** input help) lets users pick a value from a list instead of typing it. abap2UI5 covers the basics with two built-in popups and lets you build anything custom on top.
 
 #### Suggestions on the Input

--- a/docs/cookbook/model/binding.md
+++ b/docs/cookbook/model/binding.md
@@ -109,9 +109,12 @@ DATA edit_row TYPE ts_order.
 
 ...
 
-)->input( client->_bind( edit_row-customer ) )  " resolves to {/EDIT_ROW/CUSTOMER}
-)->input( client->_bind( edit_row-material ) )
-)->input( client->_bind( edit_row-quantity ) )
+)->tag( `Input`
+    )->a( n = `value` v = client->_bind( edit_row-customer )   " resolves to {/EDIT_ROW/CUSTOMER}
+)->tag( `Input`
+    )->a( n = `value` v = client->_bind( edit_row-material )
+)->tag( `Input`
+    )->a( n = `value` v = client->_bind( edit_row-quantity )
 ```
 
 Nested structures follow the same rule recursively (`edit_row-address-city` → `/EDIT_ROW/ADDRESS/CITY`). Internal tables of structures use one row context per item — see [Tables](/cookbook/model/tables).
@@ -138,10 +141,10 @@ ABAP and UI5 do not share a type system. When ABAP values cross to the frontend 
 When a value looks wrong, the fix is almost always a UI5-side `type` (e.g. `sap.ui.model.type.Date`, `sap.ui.model.type.Float`) or an abap2UI5 [Formatter](/cookbook/model/formatter). The shape is always the same — build a JSON binding string with `parts` and `type`, using `path = abap_true` on `_bind` to inject the raw model path:
 
 ```abap
-)->input(
-    |\{ parts: [ `{ client->_bind( val = amount   path = abap_true ) }`,
-                 `{ client->_bind( val = currency path = abap_true ) }` ],
-        type: 'sap.ui.model.type.Currency' \}| )
+)->tag( `Input`
+    )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val = amount   path = abap_true ) }`,
+                                       `{ client->_bind( val = currency path = abap_true ) }` ],
+                              type: 'sap.ui.model.type.Currency' \}|
 ```
 
 See [Formatter](/cookbook/model/formatter) for the full example with `formatOptions`, `constraints`, and read-only display variants.

--- a/docs/cookbook/model/binding.md
+++ b/docs/cookbook/model/binding.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Binding
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 In abap2UI5 you share data between your ABAP code and the UI5 frontend with `client->_bind( )`. There is only one binding, and it works **in both directions**: when the value is changed in an editable control, the framework writes it back to your ABAP attribute before the next event handler runs. Only the paths the user actually edited are transported back (a delta), so read-only data costs nothing on the way back.
 
 #### Displaying Data
@@ -31,11 +20,20 @@ ENDCLASS.
 CLASS zcl_app_hello_world IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-      )->page( `abap2UI5 - Hello World`
-          )->text( `My Text`
-          )->text( client->_bind( name )
-      )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->a( n = `title` v = `abap2UI5 - Hello World`
+
+                )->tag( `Text`
+                    )->a( n = `text` v = `My Text`
+                )->tag( `Text`
+                    )->a( n = `text` v = client->_bind( name ) ).
+
+    client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 ENDCLASS.
@@ -57,12 +55,24 @@ ENDCLASS.
 CLASS zcl_app_hello_world IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    client->view_display( z2ui5_cl_xml_view=>factory(
-      )->page( `abap2UI5 - Hello World`
-          )->text( `Enter your name`
-          )->input( client->_bind( name )
-          )->button( text = `post` press = client->_event( `POST` )
-      )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Page`
+                )->a( n = `title` v = `abap2UI5 - Hello World`
+
+                )->tag( `Text`
+                    )->a( n = `text` v = `Enter your name`
+                )->tag( `Input`
+                    )->a( n = `value` v = client->_bind( name )
+                )->tag( `Button`
+                    )->a( n = `text`  v = `post`
+                    )->a( n = `press` v = client->_event( `POST` ) ).
+
+    client->view_display( view->stringify( ) ).
+
 
     CASE client->get( )-event.
       WHEN `POST`.

--- a/docs/cookbook/model/binding.md
+++ b/docs/cookbook/model/binding.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Binding
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 In abap2UI5 you share data between your ABAP code and the UI5 frontend with `client->_bind( )`. There is only one binding, and it works **in both directions**: when the value is changed in an editable control, the framework writes it back to your ABAP attribute before the next event handler runs. Only the paths the user actually edited are transported back (a delta), so read-only data costs nothing on the way back.
 
 #### Displaying Data

--- a/docs/cookbook/model/expression_binding.md
+++ b/docs/cookbook/model/expression_binding.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Expression Binding
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Expression Binding lets you compute values directly in XML views with JavaScript-like expressions. This is especially handy in abap2UI5, since it cuts server roundtrips by moving calculations, logical conditions, and string operations to the frontend.
 
 The syntax `{= ... }` marks a UI5 expression binding. Inside the expression, you can use JavaScript operators (like `===` for strict equality or `Math.max`) and reference model properties with `$` followed by a binding path. Note: `===` is the JavaScript strict equality operator (not an ABAP operator) — UI5 needs it because these expressions evaluate in the browser.

--- a/docs/cookbook/model/expression_binding.md
+++ b/docs/cookbook/model/expression_binding.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Expression Binding
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Expression Binding lets you compute values directly in XML views with JavaScript-like expressions. This is especially handy in abap2UI5, since it cuts server roundtrips by moving calculations, logical conditions, and string operations to the frontend.
 
 The syntax `{= ... }` marks a UI5 expression binding. Inside the expression, you can use JavaScript operators (like `===` for strict equality or `Math.max`) and reference model properties with `$` followed by a binding path. Note: `===` is the JavaScript strict equality operator (not an ABAP operator) — UI5 needs it because these expressions evaluate in the browser.
@@ -41,22 +30,33 @@ ENDCLASS.
 CLASS z2ui5_cl_demo_app_max_val IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell( )->page(
-      )->label( `max value of the first two inputs`
-                "UI5 type binding — validates integer input
-                "resolves to: { type: "sap.ui.model.type.Integer", path: "/INPUT31" }
-                )->input( `{ type : "sap.ui.model.type.Integer",` &&
-                          `  path:"` && client->_bind( val  = input31
-                                                       path = abap_true ) && `" }`
-                )->input( `{ type : "sap.ui.model.type.Integer",` && |\n| &&
-                          `  path:"` && client->_bind( val  = input32
-                                                       path = abap_true ) && `" }`
-                "Expression binding — computed in the browser
-                "resolves to: {= Math.max(${/INPUT31}, ${/INPUT32}) }
-                )->input(
-                    value   = `{= Math.max($` && client->_bind( input31 ) &&`, $` && client->_bind( input32 ) && `) }`
-                    enabled = abap_false ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->tag( `Label`
+                        )->a( n = `text` v = `max value of the first two inputs`
+
+                    " UI5 type binding — validates integer input
+                    " resolves to: { type: "sap.ui.model.type.Integer", path: "/INPUT31" }
+                    )->tag( `Input`
+                        )->a( n = `value` v = `{ type : "sap.ui.model.type.Integer",` &&
+                                              `  path:"` && client->_bind( val  = input31
+                                                                           path = abap_true ) && `" }`
+                    )->tag( `Input`
+                        )->a( n = `value` v = `{ type : "sap.ui.model.type.Integer",` && |\n| &&
+                                              `  path:"` && client->_bind( val  = input32
+                                                                           path = abap_true ) && `" }`
+
+                    " Expression binding — computed in the browser
+                    " resolves to: {= Math.max(${/INPUT31}, ${/INPUT32}) }
+                    )->tag( `Input`
+                        )->a( n = `value`   v = `{= Math.max($` && client->_bind( input31 ) && `, $` && client->_bind( input32 ) && `) }`
+                        )->a( n = `enabled` b = abap_false ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
@@ -80,17 +80,28 @@ ENDCLASS.
 CLASS z2ui5_cl_demo_editable IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell( )->page(
-      )->label( `only enabled when the quantity equals 500`
-                )->input( `{ type : "sap.ui.model.type.Integer",` &&
-                          `  path:"` && client->_bind( val  = quantity
-                                                       path = abap_true ) && `"  }`
-                "enabled resolves to: {= 500===${/QUANTITY} }
-                )->input(
-                    value   = client->_bind( product )
-                    enabled = `{= 500===$` && client->_bind( quantity ) && ` }` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->tag( `Label`
+                        )->a( n = `text` v = `only enabled when the quantity equals 500`
+
+                    )->tag( `Input`
+                        )->a( n = `value` v = `{ type : "sap.ui.model.type.Integer",` &&
+                                              `  path:"` && client->_bind( val  = quantity
+                                                                           path = abap_true ) && `"  }`
+
+                    " enabled resolves to: {= 500===${/QUANTITY} }
+                    )->tag( `Input`
+                        )->a( n = `value`   v = client->_bind( product )
+                        )->a( n = `enabled` v = `{= 500===$` && client->_bind( quantity ) && ` }` ).
+
     client->view_display( view->stringify( ) ).
+
 
   ENDMETHOD.
 ENDCLASS.

--- a/docs/cookbook/model/formatter.md
+++ b/docs/cookbook/model/formatter.md
@@ -161,6 +161,11 @@ CLASS z2ui5_cl_smp_app_067 IMPLEMENTATION.
     CASE client->get( )-event.
       WHEN |BACK|.
         client->nav_app_leave( client->get_app( client->get( )-s_draft-id_prev_app_stack ) ).
+      WHEN |BUTTON|.
+        " the roundtrip is the point of this button: the edited values travel
+        " to the server and come back, and every formatter above renders them
+        " again from the model
+        client->message_toast_display( |Amount { amount }, currency { currency }| ).
     ENDCASE.
 
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory(

--- a/docs/cookbook/model/formatter.md
+++ b/docs/cookbook/model/formatter.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Formatter
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 You can format values like currencies, numerics, dates, or booleans directly on the frontend with UI5 type formatters.
 
 UI5 formatter types use a special JSON-based binding syntax with these key elements:

--- a/docs/cookbook/model/formatter.md
+++ b/docs/cookbook/model/formatter.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Formatter
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 You can format values like currencies, numerics, dates, or booleans directly on the frontend with UI5 type formatters.
 
 UI5 formatter types use a special JSON-based binding syntax with these key elements:
@@ -174,105 +163,117 @@ CLASS z2ui5_cl_smp_app_067 IMPLEMENTATION.
         client->nav_app_leave( client->get_app( client->get( )-s_draft-id_prev_app_stack ) ).
     ENDCASE.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-         )->page( title          = `abap2UI5 - Currency Format`
-                  navbuttonpress = client->_event( |BACK| )
-                  shownavbutton  = xsdbool( client->get( )-s_draft-id_prev_app_stack IS NOT INITIAL  ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
 
-    page->simple_form( title    = `Currency`
-                       editable = abap_true
-     )->content( `form`
-         )->title( `Input`
-         )->label( `Documentation`
-         )->link( text = `https://sapui5.hana.ondemand.com/#/entity/sap.ui.model.type.Currency`
-                  href = `https://sapui5.hana.ondemand.com/#/entity/sap.ui.model.type.Currency`
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `abap2UI5 - Currency Format`
+                    )->a( n = `navButtonPress` v = client->_event( |BACK| )
+                    )->a( n = `showNavButton`  b = xsdbool( client->get( )-s_draft-id_prev_app_stack IS NOT INITIAL )
 
-         "Currency in one field — shows amount and currency symbol together
-         "resolves to: { parts: ["/AMOUNT", "/CURRENCY"], type: 'sap.ui.model.type.Currency' }
-         )->label( `One field`
-         )->input(
-             |\{ parts: [ `{ client->_bind( val  = amount
-                                                 path = abap_true ) }`, `{ client->_bind(
-                                                                               val  = currency
-                                                                               path = abap_true ) }`],  type: 'sap.ui.model.type.Currency' \}|
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `Currency`
+                        )->a( n = `editable` b = abap_true
 
-         "Split into two fields — first shows only the number, second only the currency
-         "showMeasure: false → hides the currency symbol
-         "showNumber: false  → hides the numeric value
-         )->label( `Two fields`
-         )->input(
-             |\{ parts: [ `{ client->_bind( val  = amount
-                                                 path = abap_true ) }`, `{ client->_bind(
-                                                                               val  = currency
-                                                                               path = abap_true ) }`],  type: 'sap.ui.model.type.Currency' , formatOptions: \{showMeasure: false\}  \}|
-         )->input(
-             |\{ parts: [ `{ client->_bind( val  = amount
-                                                 path = abap_true ) }`, `{ client->_bind(
-                                                                               val  = currency
-                                                                               path = abap_true ) }`],  type: 'sap.ui.model.type.Currency' , formatOptions: \{showNumber: false\} \}|
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Title`
+                                )->a( n = `text` v = `Input`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Documentation`
+                            )->tag( `Link`
+                                )->a( n = `text` v = `https://sdk.openui5.org/api/sap.ui.model.type.Currency`
+                                )->a( n = `href` v = `https://sdk.openui5.org/api/sap.ui.model.type.Currency`
 
-         "Read-only display variants with different formatOptions
-         )->label( `Default`
-         )->text(
-             |\{ parts: [ `{ client->_bind( val  = amount
-                                                 path = abap_true ) }`, `{ client->_bind(
-                                                                               val  = currency
-                                                                               path = abap_true ) }`],  type: 'sap.ui.model.type.Currency' \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `One field`
+                            )->tag( `Input`
+                                )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val  = amount
+                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency' \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Two fields`
+                            )->tag( `Input`
+                                )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val  = amount
+                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{showMeasure: false\} \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Two fields`
+                            )->tag( `Input`
+                                )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val  = amount
+                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{showNumber: false\} \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Default`
+                            )->tag( `Text`
+                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
+                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency' \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `preserveDecimals:false`
+                            )->tag( `Text`
+                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
+                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{ preserveDecimals : false \} \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `currencyCode:false`
+                            )->tag( `Text`
+                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
+                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{ currencyCode : false \} \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `style:'short'`
+                            )->tag( `Text`
+                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
+                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{ style : 'short' \} \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `style:'long'`
+                            )->tag( `Text`
+                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
+                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{   style : 'long' \} \}|
 
-         "preserveDecimals: false → trims trailing zeros (e.g. 123,456,789.12 USD)
-         )->label( `preserveDecimals:false`
-         )->text( |\{ parts: [ `{ client->_bind( val  = amount
-                                                      path = abap_true ) }`, `| && client->_bind(
-                                                                                       val  = currency
-                                                                                       path = abap_true ) &&
-                     |`],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ preserveDecimals : false \} \}|
+                            )->tag( `Label`
+                                )->a( n = `text` v = `event`
+                            )->tag( `Button`
+                                )->a( n = `text`  v = `send`
+                                )->a( n = `press` v = client->_event( `BUTTON` )
 
-         "currencyCode: false → hides the ISO code, shows only the number
-         )->label( `currencyCode:false`
-         )->text( |\{ parts: [ `{ client->_bind( val  = amount
-                                                      path = abap_true ) }`, `| && client->_bind(
-                                                                                       val  = currency
-                                                                                       path = abap_true ) &&
-                         |`],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ currencyCode : false \} \}|
+                    )->end(
+                    )->end(
 
-         "style: 'short' → compact notation (e.g. 123M USD)
-         )->label( `style:'short'`
-         )->text(
-             |\{ parts: [ `{ client->_bind( val  = amount
-                                                 path = abap_true ) }`, `{ client->_bind(
-                                                                               val  = currency
-                                                                               path = abap_true ) }`],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ style : 'short' \} \}|
+                    " Remove leading zeros from a numeric string with OData type formatting.
+                    " isDigitSequence: true tells the formatter to treat the value as a digit
+                    " sequence — resolves to: { path: "/NUMERIC",
+                    " type: 'sap.ui.model.odata.type.String',
+                    " constraints: { isDigitSequence: true } }
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `No Zeros`
+                        )->a( n = `editable` b = abap_true
 
-         "style: 'long' → full text notation (e.g. 123 million US dollars)
-         )->label( `style:'long'`
-         )->text(
-             |\{ parts: [ `{ client->_bind( val  = amount
-                                                 path = abap_true ) }`, `{ client->_bind(
-                                                                               val  = currency
-                                                                               path = abap_true ) }`],  type: 'sap.ui.model.type.Currency' , formatOptions: \{   style : 'long' \} \}|
-         )->label( `event`
-         )->button( text  = `send`
-                    press = client->_event( `BUTTON` ) ).
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Title`
+                                )->a( n = `text` v = `Input`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Documentation`
+                            )->tag( `Link`
+                                )->a( n = `text` v = `https://sdk.openui5.org/api/sap.ui.model.odata.type.String%23methods/formatValue`
+                                )->a( n = `href` v = `https://sdk.openui5.org/api/sap.ui.model.odata.type.String%23methods/formatValue`
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Numeric`
+                            )->tag( `Input`
+                                )->a( n = `value` v = client->_bind( val = numeric )
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Without leading Zeros`
+                            )->tag( `Text`
+                                )->a( n = `text` v = |\{ path : `{ client->_bind( val  = numeric
+                                                                                  path = abap_true ) }`, type : 'sap.ui.model.odata.type.String', constraints : \{ isDigitSequence : true \} \}| ).
 
-    "Remove leading zeros from a numeric string with OData type formatting
-    "isDigitSequence: true tells the formatter to treat the value as a digit sequence
-    "resolves to: { path: "/NUMERIC", type: 'sap.ui.model.odata.type.String', constraints: { isDigitSequence: true } }
-    page->simple_form( title    = `No Zeros`
-                       editable = abap_true
-        )->content( `form`
-        )->title( `Input`
-        )->label( `Documentation`
-        )->link( text = `https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.odata.type.String%23methods/formatValue`
-                 href = `https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.odata.type.String%23methods/formatValue`
-        )->label( `Numeric`
-        )->input( value = client->_bind( val = numeric )
-        )->label( `Without leading Zeros`
-        )->text(
-    text = |\{path : `{ client->_bind(
-                            val  = numeric
-                            path = abap_true ) }`, type : 'sap.ui.model.odata.type.String', constraints : \{  isDigitSequence : true \} \}| ).
-
-    client->view_display( page->stringify( ) ).
+    client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 

--- a/docs/cookbook/model/formatter.md
+++ b/docs/cookbook/model/formatter.md
@@ -31,10 +31,10 @@ The sections below show the binding-string pattern for each ABAP type that needs
 ABAP `p LENGTH n DECIMALS m` + a `c LENGTH 3` currency code (a plain `string` also works, as in the worked example below) → UI5 `Currency` formatter. Two `parts` entries; the type combines them into a locale-aware amount string:
 
 ```abap
-)->input(
-    |\{ parts: [ `{ client->_bind( val = amount   path = abap_true ) }`,
-                 `{ client->_bind( val = currency path = abap_true ) }` ],
-        type: 'sap.ui.model.type.Currency' \}| )
+)->tag( `Input`
+    )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val = amount   path = abap_true ) }`,
+                                       `{ client->_bind( val = currency path = abap_true ) }` ],
+                              type: 'sap.ui.model.type.Currency' \}|
 ```
 
 Common `formatOptions`:
@@ -51,24 +51,24 @@ The [Full Worked Example](#full-worked-example) below demonstrates each of these
 ABAP `n LENGTH n` is sent as a digit string, leading zeros included. Without a type the zeros render literally. Use the OData `String` type with `isDigitSequence: true`:
 
 ```abap
-)->text(
-    |\{ path: `{ client->_bind( val = numeric path = abap_true ) }`,
-        type: 'sap.ui.model.odata.type.String',
-        constraints: \{ isDigitSequence: true \} \}| )
+)->tag( `Text`
+    )->a( n = `text` v = |\{ path: `{ client->_bind( val = numeric path = abap_true ) }`,
+                             type: 'sap.ui.model.odata.type.String',
+                             constraints: \{ isDigitSequence: true \} \}|
 ```
 
 This strips the leading zeros for display and re-pads them on write-back.
 
 ## Date
 
-ABAP `d` is an 8-character string `YYYYMMDD`. `date_picker` accepts it directly via `client->_bind( mv_date )` for the default case. For explicit locale or pattern control, use `sap.ui.model.type.Date` with a `source` pattern that matches the wire format:
+ABAP `d` is an 8-character string `YYYYMMDD`. `DatePicker` accepts it directly via `client->_bind( mv_date )` for the default case. For explicit locale or pattern control, use `sap.ui.model.type.Date` with a `source` pattern that matches the wire format:
 
 ```abap
-)->date_picker(
-    value = |\{ path: `{ client->_bind( val = mv_date path = abap_true ) }`,
-                type: 'sap.ui.model.type.Date',
-                formatOptions: \{ pattern: 'yyyy-MM-dd',
-                                  source: \{ pattern: 'yyyyMMdd' \} \} \}| )
+)->tag( `DatePicker`
+    )->a( n = `value` v = |\{ path: `{ client->_bind( val = mv_date path = abap_true ) }`,
+                              type: 'sap.ui.model.type.Date',
+                              formatOptions: \{ pattern: 'yyyy-MM-dd',
+                                                source: \{ pattern: 'yyyyMMdd' \} \} \}|
 ```
 
 `source.pattern` is the wire format (ABAP side); the outer `pattern` is what the user sees.
@@ -78,11 +78,11 @@ ABAP `d` is an 8-character string `YYYYMMDD`. `date_picker` accepts it directly 
 ABAP `t` is a 6-character string `HHMMSS`. Same pattern as Date, with `sap.ui.model.type.Time`:
 
 ```abap
-)->time_picker(
-    value = |\{ path: `{ client->_bind( val = mv_time path = abap_true ) }`,
-                type: 'sap.ui.model.type.Time',
-                formatOptions: \{ pattern: 'HH:mm:ss',
-                                  source: \{ pattern: 'HHmmss' \} \} \}| )
+)->tag( `TimePicker`
+    )->a( n = `value` v = |\{ path: `{ client->_bind( val = mv_time path = abap_true ) }`,
+                              type: 'sap.ui.model.type.Time',
+                              formatOptions: \{ pattern: 'HH:mm:ss',
+                                                source: \{ pattern: 'HHmmss' \} \} \}|
 ```
 
 ## Boolean
@@ -91,7 +91,8 @@ ABAP `abap_bool` is `"X"` or `""`. UI5's `CheckBox` expects `true` / `false`. Tw
 
 **Expression binding** — compare the bound value to `'X'` inline. Read-only:
 ```abap
-)->checkbox( selected = `{= $` && client->_bind( mv_flag ) && ` === 'X' }` )
+)->tag( `CheckBox`
+    )->a( n = `selected` v = `{= $` && client->_bind( mv_flag ) && ` === 'X' }`
 ```
 This resolves to `{= ${/MV_FLAG} === 'X' }`. Note that expression bindings cannot write back — checking the box will not flip the ABAP attribute.
 
@@ -106,7 +107,7 @@ flag_str = COND #( WHEN flag_bool = abap_true THEN 'true' ELSE 'false' ).
 " after the event:
 flag_bool = COND #( WHEN flag_str = 'true' THEN abap_true ELSE abap_false ).
 ```
-Then `)->checkbox( selected = client->_bind( flag_str ) )` works both directions. More boilerplate in the controller, simpler view.
+Then a `CheckBox` whose `selected` attribute is `client->_bind( flag_str )` works both directions. More boilerplate in the controller, simpler view.
 
 A custom JS formatter wired through `sap.ui.model.SimpleType` is the third option — see the [samples repository](https://github.com/abap2UI5/samples).
 
@@ -118,11 +119,11 @@ A custom JS formatter wired through `sap.ui.model.SimpleType` is the third optio
 
 **Send as string with a source pattern** — convert to a string in `yyyyMMddHHmmss` format on the ABAP side, then bind with `sap.ui.model.type.DateTime`:
 ```abap
-)->date_time_picker(
-    value = |\{ path: `{ client->_bind( val = mv_ts_string path = abap_true ) }`,
-                type: 'sap.ui.model.type.DateTime',
-                formatOptions: \{ pattern: 'yyyy-MM-dd HH:mm:ss',
-                                  source: \{ pattern: 'yyyyMMddHHmmss' \} \} \}| )
+)->tag( `DateTimePicker`
+    )->a( n = `value` v = |\{ path: `{ client->_bind( val = mv_ts_string path = abap_true ) }`,
+                              type: 'sap.ui.model.type.DateTime',
+                              formatOptions: \{ pattern: 'yyyy-MM-dd HH:mm:ss',
+                                                source: \{ pattern: 'yyyyMMddHHmmss' \} \} \}|
 ```
 Conversion happens in ABAP (`WRITE timestamp TO ts_string …` or a helper); the framework moves the string verbatim.
 

--- a/docs/cookbook/model/size_limit.md
+++ b/docs/cookbook/model/size_limit.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Size Limit
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 Every UI5 JSON model has a built-in upper limit on the number of items it will expose to a list binding. By default this limit is `100`. If you bind a `ComboBox`, `Table` or any other aggregation to a table that contains more than 100 entries, only the first 100 are rendered — the rest are silently dropped. This is a UI5 design decision, documented under [`sap.ui.model.Model#setSizeLimit`](https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.Model%23methods/setSizeLimit).
 
 abap2UI5 exposes this setting through the built-in client event `SET_SIZE_LIMIT`, so you can raise (or reset) the limit per view directly from ABAP.
@@ -74,7 +63,6 @@ CLASS z2ui5_cl_sample_size_limit IMPLEMENTATION.
         DO mv_combo_number TIMES.
           INSERT VALUE #( key = sy-index text = sy-index ) INTO TABLE t_combo.
         ENDDO.
-        client->view_model_update( ).
         RETURN.
     ENDCASE.
 
@@ -82,23 +70,44 @@ CLASS z2ui5_cl_sample_size_limit IMPLEMENTATION.
       INSERT VALUE #( key = sy-index text = sy-index ) INTO TABLE t_combo.
     ENDDO.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->page( `Size Limit Demo`
-        )->simple_form( title = `Settings` editable = abap_true
-            )->content( `form`
-                )->label( `setSizeLimit`
-                )->input( value = client->_bind( mv_size_limit )
-                )->button(
-                    text  = `update size limit`
-                    press = client->_event( `UPDATE_LIMIT` )
-                )->label( `Number of Entries`
-                )->input( value = client->_bind( mv_combo_number )
-                )->button(
-                    text  = `update number of entries`
-                    press = client->_event( `UPDATE_MODEL` )
-                )->label( `ComboBox`
-                )->combobox( items = client->_bind( t_combo )
-                    )->item( key = `{KEY}` text = `{TEXT}` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:core` v = `sap.ui.core`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form`
+
+            )->ele( `Page`
+                )->a( n = `title` v = `Size Limit Demo`
+
+                )->ele( n = `SimpleForm` ns = `form`
+                    )->a( n = `title`    v = `Settings`
+                    )->a( n = `editable` b = abap_true
+
+                    )->ele( n = `content` ns = `form`
+                        )->tag( `Label`
+                            )->a( n = `text` v = `setSizeLimit`
+                        )->tag( `Input`
+                            )->a( n = `value` v = client->_bind( mv_size_limit )
+                        )->tag( `Button`
+                            )->a( n = `text`  v = `update size limit`
+                            )->a( n = `press` v = client->_event( `UPDATE_LIMIT` )
+                        )->tag( `Label`
+                            )->a( n = `text` v = `Number of Entries`
+                        )->tag( `Input`
+                            )->a( n = `value` v = client->_bind( mv_combo_number )
+                        )->tag( `Button`
+                            )->a( n = `text`  v = `update number of entries`
+                            )->a( n = `press` v = client->_event( `UPDATE_MODEL` )
+                        )->tag( `Label`
+                            )->a( n = `text` v = `ComboBox`
+                        )->ele( `ComboBox`
+                            )->a( n = `items` v = client->_bind( t_combo )
+
+                            )->tag( n = `Item` ns = `core`
+                                )->a( n = `key`  v = `{KEY}`
+                                )->a( n = `text` v = `{TEXT}` ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.

--- a/docs/cookbook/model/size_limit.md
+++ b/docs/cookbook/model/size_limit.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Size Limit
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 Every UI5 JSON model has a built-in upper limit on the number of items it will expose to a list binding. By default this limit is `100`. If you bind a `ComboBox`, `Table` or any other aggregation to a table that contains more than 100 entries, only the first 100 are rendered — the rest are silently dropped. This is a UI5 design decision, documented under [`sap.ui.model.Model#setSizeLimit`](https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.Model%23methods/setSizeLimit).
 
 abap2UI5 exposes this setting through the built-in client event `SET_SIZE_LIMIT`, so you can raise (or reset) the limit per view directly from ABAP.

--- a/docs/cookbook/model/tables.md
+++ b/docs/cookbook/model/tables.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Tables
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 This section walks through rendering tabular and nested data in views.
 
 ### Basic Table
@@ -45,17 +34,42 @@ CLASS z2ui5_cl_sample_tab IMPLEMENTATION.
           descr = `this is a description` ) INTO TABLE mt_itab.
       ENDDO.
 
-      DATA(tab) = z2ui5_cl_xml_view=>factory( )->page(
-          )->table( client->_bind( mt_itab ) ).
-      tab->columns(
-          )->column( )->text( `Count` )->get_parent(
-          )->column( )->text( `Value` )->get_parent(
-          )->column( )->text( `Description` ).
-      tab->items( )->column_list_item( )->cells(
-         )->text( `{COUNT}`
-         )->text( `{VALUE}`
-         )->text( `{DESCR}` ).
-      client->view_display( tab->stringify( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->ele( `Table`
+                      )->a( n = `items` v = client->_bind( mt_itab )
+
+                      )->ele( `columns`
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Count`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Value`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Description`
+                          )->end(
+
+                      )->end(
+
+                      )->ele( `items`
+                          )->ele( `ColumnListItem`
+                              )->ele( `cells`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{COUNT}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{VALUE}`
+                                  )->tag( `Text`
+                                      )->a( n = `text` v = `{DESCR}` ).
+
+      client->view_display( view->stringify( ) ).
 
     ENDIF.
 
@@ -77,17 +91,42 @@ To make a table editable, use editable cell controls (e.g. `input`) — the bind
           descr = `this is a description` ) INTO TABLE mt_itab.
       ENDDO.
 
-      DATA(tab) = z2ui5_cl_xml_view=>factory( )->page(
-          )->table( client->_bind( mt_itab ) ).
-      tab->columns(
-          )->column( )->text( `Count` )->get_parent(
-          )->column( )->text( `Value` )->get_parent(
-          )->column( )->text( `Description` ).
-      tab->items( )->column_list_item( )->cells(
-         )->input( `{COUNT}`
-         )->input( `{VALUE}`
-         )->input( `{DESCR}` ).
-      client->view_display( tab->stringify( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->ele( `Table`
+                      )->a( n = `items` v = client->_bind( mt_itab )
+
+                      )->ele( `columns`
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Count`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Value`
+                          )->end(
+                          )->ele( `Column`
+                              )->tag( `Text`
+                                  )->a( n = `text` v = `Description`
+                          )->end(
+
+                      )->end(
+
+                      )->ele( `items`
+                          )->ele( `ColumnListItem`
+                              )->ele( `cells`
+                                  )->tag( `Input`
+                                      )->a( n = `value` v = `{COUNT}`
+                                  )->tag( `Input`
+                                      )->a( n = `value` v = `{VALUE}`
+                                  )->tag( `Input`
+                                      )->a( n = `value` v = `{DESCR}` ).
+
+      client->view_display( view->stringify( ) ).
 
     ENDIF.
 
@@ -121,19 +160,43 @@ CLASS z2ui5_cl_sample_nested_structures IMPLEMENTATION.
         ( product = `chair` s_details = VALUE #( create_date = `25.10.2022` create_by = `Frank`  ) )
         ( product = `sofa`  s_details = VALUE #( create_date = `12.03.2024` create_by = `George` ) ) ).
 
-    DATA(tab) = z2ui5_cl_xml_view=>factory( )->table( client->_bind( mt_itab ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-    DATA(columns) = tab->columns( ).
-    columns->column( )->text( text = `Product` ).
-    columns->column( )->text( text = `Created at` ).
-    columns->column( )->text( text = `By` ).
+            )->ele( `Table`
+                )->a( n = `items` v = client->_bind( mt_itab )
 
-    DATA(cells) = tab->items( )->column_list_item( ).
-    cells->text( `{PRODUCT}` ).
-    cells->text( `{S_DETAILS/CREATE_DATE}` ).
-    cells->text( `{S_DETAILS/CREATE_BY}` ).
+                )->ele( `columns`
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `Product`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `Created at`
+                    )->end(
+                    )->ele( `Column`
+                        )->tag( `Text`
+                            )->a( n = `text` v = `By`
+                    )->end(
 
-    client->view_display( tab->stringify( ) ).
+                )->end(
+
+                )->ele( `items`
+                    )->ele( `ColumnListItem`
+                        )->ele( `cells`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `{PRODUCT}`
+                            )->tag( `Text`
+                                " abap2ui5lint-disable-next-line unknown-binding-path -- the linter does not resolve a nested BEGIN OF inside a row type; the path is correct
+                                )->a( n = `text` v = `{S_DETAILS/CREATE_DATE}`
+                            )->tag( `Text`
+                                " abap2ui5lint-disable-next-line unknown-binding-path -- same
+                                )->a( n = `text` v = `{S_DETAILS/CREATE_BY}` ).
+
+    client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/docs/cookbook/model/tables.md
+++ b/docs/cookbook/model/tables.md
@@ -2,6 +2,18 @@
 outline: [2, 4]
 ---
 # Tables
+
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 This section walks through rendering tabular and nested data in views.
 
 ### Basic Table

--- a/docs/cookbook/model/tables.md
+++ b/docs/cookbook/model/tables.md
@@ -190,10 +190,10 @@ CLASS z2ui5_cl_sample_nested_structures IMPLEMENTATION.
                             )->tag( `Text`
                                 )->a( n = `text` v = `{PRODUCT}`
                             )->tag( `Text`
-                                " abap2ui5lint-disable-next-line unknown-binding-path -- the linter does not resolve a nested BEGIN OF inside a row type; the path is correct
+                                " abap2ui5lint-disable-next-line unknown-binding-path -- linter defect, fixed in @abap2ui5/linter 0.2.0: a nested BEGIN OF inside a row type was dropped. Delete this line with the pin bump; the path is correct
                                 )->a( n = `text` v = `{S_DETAILS/CREATE_DATE}`
                             )->tag( `Text`
-                                " abap2ui5lint-disable-next-line unknown-binding-path -- same
+                                " abap2ui5lint-disable-next-line unknown-binding-path -- same, and it goes with the same pin bump
                                 )->a( n = `text` v = `{S_DETAILS/CREATE_BY}` ).
 
     client->view_display( view->stringify( ) ).

--- a/docs/cookbook/model/trees.md
+++ b/docs/cookbook/model/trees.md
@@ -2,6 +2,18 @@
 outline: [2, 4]
 ---
 # Trees
+
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 For hierarchical data, abap2UI5 uses nested ABAP structures to represent tree levels. Each level holds a table of child nodes, which UI5 traverses to build the expandable tree control.
 
 ### Tree

--- a/docs/cookbook/model/trees.md
+++ b/docs/cookbook/model/trees.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Trees
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 For hierarchical data, abap2UI5 uses nested ABAP structures to represent tree levels. Each level holds a table of child nodes, which UI5 traverses to build the expandable tree control.
 
 ### Tree
@@ -73,13 +62,22 @@ CLASS z2ui5_cl_sample_tree IMPLEMENTATION.
                 prodh = `001100010500000105` )
     ) ) ) ) ).
 
-    DATA(tree) = z2ui5_cl_xml_view=>factory( )->page(
-        )->tree( items = client->_bind( prodh_nodes )
-            )->items( )->standard_tree_item(
-                selected = `{IS_SELECTED}`
-                title    = `{TEXT}` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-    client->view_display( tree->stringify( ) ).
+            )->ele( `Page`
+                )->ele( `Tree`
+                    )->a( n = `items` v = client->_bind( prodh_nodes )
+
+                    )->ele( `items`
+                        )->tag( `StandardTreeItem`
+                            )->a( n = `selected` v = `{IS_SELECTED}`
+                            )->a( n = `title`    v = `{TEXT}` ).
+
+    client->view_display( view->stringify( ) ).
+
 
   ENDMETHOD.
 ENDCLASS.

--- a/docs/cookbook/overview.md
+++ b/docs/cookbook/overview.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Overview
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 The Cookbook collects task-oriented recipes for everyday abap2UI5 development. Each section focuses on one area of the framework and shows the patterns you reach for most often. Use this page as a map — pick the topic that matches the problem in front of you and jump straight in.
 
 ### Sections
@@ -53,6 +42,7 @@ EML/CDS/SQL integration with RAP, recurring patterns and helpers, troubleshootin
 - Each recipe stands on its own — read only the section you need.
 - Code snippets are copy-paste ready. Drop them into a class that implements `z2ui5_if_app`.
 - For full sample apps, browse the hundreds of examples in the [samples repository](https://github.com/abap2UI5/samples).
-- For the API surface (`z2ui5_if_client`, `z2ui5_cl_xml_view`, …), read the source in the [main repository](https://github.com/abap2UI5/abap2UI5).
+- For the API surface (`z2ui5_if_client`, `z2ui5_cl_ui5_view_builder`, …), read the source in the [main repository](https://github.com/abap2UI5/abap2UI5).
+
 
 → New to abap2UI5? Start with the [Getting Started Guide](/get_started/quickstart).

--- a/docs/cookbook/overview.md
+++ b/docs/cookbook/overview.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Overview
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 The Cookbook collects task-oriented recipes for everyday abap2UI5 development. Each section focuses on one area of the framework and shows the patterns you reach for most often. Use this page as a map — pick the topic that matches the problem in front of you and jump straight in.
 
 ### Sections

--- a/docs/cookbook/popup_popover/popover.md
+++ b/docs/cookbook/popup_popover/popover.md
@@ -3,29 +3,25 @@ outline: [2, 4]
 ---
 # Popover
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 To show a popover, call `client->popover_display` and pass the ID of the control the popover should attach to:
 ```abap
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_init( ).
-      DATA(view) = z2ui5_cl_xml_view=>factory(
-        )->shell(
-            )->page( `Popover Example`
-                )->button(
-                    text  = `display popover`
-                    press = client->_event( `POPOVER_OPEN` )
-                    id    = `TEST` ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Shell`
+                  )->ele( `Page`
+                      )->a( n = `title` v = `Popover Example`
+
+                      )->tag( `Button`
+                          )->a( n = `id`    v = `TEST`
+                          )->a( n = `text`  v = `display popover`
+                          )->a( n = `press` v = client->_event( `POPOVER_OPEN` ) ).
+
       client->view_display( view->stringify( ) ).
 
     ENDIF.
@@ -33,13 +29,21 @@ To show a popover, call `client->popover_display` and pass the ID of the control
     CASE client->get( )-event.
 
       WHEN `POPOVER_OPEN`.
-        DATA(popover) = z2ui5_cl_xml_view=>factory_popup(
-            )->popover( placement = `Left`
-                )->text( `this is a popover`
-                )->button(
-                    id    = `my_id`
-                    text  = `close`
-                    press = client->_event( `POPOVER_CLOSE` ) ).
+        DATA(popover) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `FragmentDefinition` ns = `core`
+                )->a( n = `xmlns`      v = `sap.m`
+                )->a( n = `xmlns:core` v = `sap.ui.core`
+
+                )->ele( `Popover`
+                    )->a( n = `placement` v = `Left`
+
+                    )->tag( `Text`
+                        )->a( n = `text` v = `this is a popover`
+                    )->tag( `Button`
+                        )->a( n = `id`    v = `my_id`
+                        )->a( n = `text`  v = `close`
+                        )->a( n = `press` v = client->_event( `POPOVER_CLOSE` ) ).
+
         client->popover_display(
             xml   = popover->stringify( )
             by_id = `TEST` ).

--- a/docs/cookbook/popup_popover/popover.md
+++ b/docs/cookbook/popup_popover/popover.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Popover
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 To show a popover, call `client->popover_display` and pass the ID of the control the popover should attach to:
 ```abap
   METHOD z2ui5_if_app~main.

--- a/docs/cookbook/popup_popover/popup.md
+++ b/docs/cookbook/popup_popover/popup.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Popup
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 UI5 offers popups that overlay specific parts of the view. This section walks through building them in abap2UI5.
 
 ## General

--- a/docs/cookbook/popup_popover/popup.md
+++ b/docs/cookbook/popup_popover/popup.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Popup
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 UI5 offers popups that overlay specific parts of the view. This section walks through building them in abap2UI5.
 
 ## General
@@ -22,9 +11,17 @@ To show a popup, call `client->popup_display` instead of `client->view_display`:
 ```abap
   METHOD z2ui5_if_app~main.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup(
-        )->dialog( `Popup - Info`
-          )->text( `this is information shown in a popup` ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `FragmentDefinition` ns = `core`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:core` v = `sap.ui.core`
+
+            )->ele( `Dialog`
+                )->a( n = `title` v = `Popup - Info`
+
+                )->tag( `Text`
+                    )->a( n = `text` v = `this is information shown in a popup` ).
+
     client->popup_display( popup->stringify( ) ).
 
   ENDMETHOD.
@@ -36,11 +33,18 @@ A typical popup flow shows a normal view, opens a popup, and finally closes it. 
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_init( ).
-        DATA(view) = z2ui5_cl_xml_view=>factory(
-            )->page( `abap2UI5 - Popups`
-                )->button(
-                    text  = `popup rendering, no background rendering`
-                    press = client->_event( `POPUP_OPEN` ) ).
+        DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+                )->ele( `Page`
+                    )->a( n = `title` v = `abap2UI5 - Popups`
+
+                    )->tag( `Button`
+                        )->a( n = `text`  v = `popup rendering, no background rendering`
+                        )->a( n = `press` v = client->_event( `POPUP_OPEN` ) ).
+
         client->view_display( view->stringify( ) ).
 
     ENDIF.
@@ -48,13 +52,22 @@ A typical popup flow shows a normal view, opens a popup, and finally closes it. 
     CASE client->get( )-event.
 
       WHEN `POPUP_OPEN`.
-        DATA(popup) = z2ui5_cl_xml_view=>factory_popup(
-            )->dialog( `Popup`
-                )->text( `this is a text in a popup`
-                )->button(
-                    text  = `close`
-                    press = client->_event( `POPUP_CLOSE` ) ).
+        DATA(popup) = z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `FragmentDefinition` ns = `core`
+                )->a( n = `xmlns`      v = `sap.m`
+                )->a( n = `xmlns:core` v = `sap.ui.core`
+
+                )->ele( `Dialog`
+                    )->a( n = `title` v = `Popup`
+
+                    )->tag( `Text`
+                        )->a( n = `text` v = `this is a text in a popup`
+                    )->tag( `Button`
+                        )->a( n = `text`  v = `close`
+                        )->a( n = `press` v = client->_event( `POPUP_CLOSE` ) ).
+
         client->popup_display( popup->stringify( ) ).
+
 
       WHEN `POPUP_CLOSE`.
         client->popup_destroy( ).
@@ -64,7 +77,8 @@ A typical popup flow shows a normal view, opens a popup, and finally closes it. 
   ENDMETHOD.
 ```
 
-The popup has the same lifecycle trio as the main view: `popup_display( )` renders the XML, `popup_model_update( )` pushes changed ABAP data into the **already-rendered** popup without re-rendering it, and `popup_destroy( )` closes it.
+The popup has the same lifecycle as the main view: `popup_display( )` renders the XML and `popup_destroy( )` closes it. Changed ABAP data needs neither — the framework pushes the delta into the already-rendered popup with the response. (`popup_model_update( )` used to be how you asked for that; it is a no-op now and is on the removal list.)
+
 
 ## Separated App
 For a cleaner source layout, encapsulate popups in separate classes and call them via [navigation](/cookbook/event_navigation/navigation).

--- a/docs/cookbook/view/definition.md
+++ b/docs/cookbook/view/definition.md
@@ -29,40 +29,106 @@ ENDMETHOD.
 
 Swap `<Text>` for any other control from the SDK; the framework doesn't care.
 
-#### Helper Class
+#### The View Builder
 
-Writing raw XML by hand quickly turns cumbersome. abap2UI5 ships the helper class `z2ui5_cl_xml_view` with a fluent API that mirrors the XML structure and gives you code completion. The `stringify( )` method at the end converts the view tree into an XML string that the framework sends to the frontend:
+Writing raw XML by hand quickly turns cumbersome. abap2UI5 ships
+`z2ui5_cl_ui5_view_builder`, which produces the same XML by method chaining —
+one call per control, so the shape of the chain is the shape of the view.
+`stringify( )` renders the tree into the XML string the framework sends to the
+frontend:
 
 ```abap
   METHOD z2ui5_if_app~main.
 
-    client->view_display(
-        z2ui5_cl_xml_view=>factory(
-            )->shell(
-                )->page( `My title`
-                    )->text( `My text`
-        )->stringify( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:core` v = `sap.ui.core`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title` v = `My title`
+
+                    )->tag( `Text`
+                        )->a( n = `text` v = `My text` ) ).
+
+    client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 ```
 
-Both snippets produce the exact same view. Use whichever you prefer — raw strings are fine for a handful of lines, the fluent API scales better for real apps.
+Both snippets produce the exact same view. Use whichever you prefer — raw
+strings are fine for a handful of lines, the builder scales better for real
+apps.
+
+Four verbs, and no catalogue of controls behind them:
+
+| | |
+| --- | --- |
+| `ele( )` | add a control and **descend** into it — for a container |
+| `tag( )` | add a control and **stay** — for a leaf |
+| `a( )` | set **one** attribute on the control the chain is pointing at |
+| `end( )` | ascend to the parent |
+
+There is exactly one rule: `a( )` applies to the control the chain is
+**pointing at** — the child just added by `ele( )` or `tag( )` — so an
+attribute always follows its own control, and a control has to receive its
+attributes *before* its first child. `ele( )` descends and is closed by an
+`end( )`; `tag( )` stays, so a run of leaves needs none. The final `end( )`s
+may be left out entirely: `stringify( )` always renders from the root, no
+matter where the chain stopped.
+
+The root `mvc:View` and its `xmlns` declarations are written by hand, exactly
+as in a real UI5 view — the builder does not invent them for you.
+
+Because the builder knows no control names, **it can express every control,
+property and aggregation UI5 has**, including those released after this page
+was written. Whatever name and namespace you pass is written into the XML
+verbatim, in the SDK's own camelCase. An aggregation is an element like any
+other and carries its parent's namespace — `<m:content>` under a Page is
+``ele( n = `content` ns = `m` )``, a default-namespace `<columns>` inside an
+`sap.ui.table.Table` is ``ele( `columns` )``.
+
+For an ABAP boolean pass `b` instead of `v`; it renders `true`/`false`, so a
+flag reaches the view without a conversion of its own:
+
+```abap
+    )->a( n = `editable` b = mv_edit_mode
+    )->a( n = `visible`  b = xsdbool( lines( mt_item ) > 0 ) )
+```
 
 Tips for working with views:
-- Use code completion on `Z2UI5_CL_XML_VIEW` to find controls and properties
-- See the [samples repository](/get_started/next#sample-apps) for ready-made XML examples to copy and adapt
+- The [VS Code extension](https://github.com/abap2UI5/vscode-extension) gives
+  the chain completion and hover for the whole UI5 API, and checks the view
+  while you type.
+- The [abap2UI5-linter](https://github.com/abap2UI5/linter) rebuilds the view
+  from your chain and reports unknown controls, properties, enum values and
+  `@since` violations — no SAP system involved.
+- See the [samples repository](/get_started/next#sample-apps) for ready-made
+  examples to copy and adapt.
 
 ::: warning Respect the UI5 Control Aggregation Rules
-`Z2UI5_CL_XML_VIEW` is intentionally permissive — its fluent API lets you nest **any** control inside **any** other control. UI5 itself is not. Every UI5 control defines specific aggregations (e.g. `sap.m.Page` has `content`, `headerContent`, `footer`) and each aggregation accepts only certain child control types (often a particular interface or base class).
+The builder is intentionally permissive — it lets you nest **any** control
+inside **any** other control, because it never knew what either of them is.
+UI5 itself is not permissive. Every UI5 control defines specific aggregations
+(e.g. `sap.m.Page` has `content`, `headerContent`, `footer`) and each
+aggregation accepts only certain child control types (often a particular
+interface or base class).
 
-Combining controls in a way that violates these rules can lead to broken rendering, missing controls, layout glitches, runtime errors in the browser console, or subtle bugs that only show up on certain devices or themes.
+Combining controls in a way that violates these rules can lead to broken
+rendering, missing controls, layout glitches, runtime errors in the browser
+console, or subtle bugs that only show up on certain devices or themes.
 
-**Always check the [UI5 SDK](https://sapui5.hana.ondemand.com) for each control** to confirm:
+**Always check the [UI5 SDK](https://sapui5.hana.ondemand.com) for each
+control** to confirm:
 - which aggregations it exposes,
 - which child types those aggregations accept, and
 - which parent controls are valid for the control you want to use.
 
-The ABAP compiler cannot catch these mistakes — they are pure UI5 concerns and must be verified against the SDK documentation.
+The ABAP compiler cannot catch these mistakes — they are pure UI5 concerns.
+The [abap2UI5-linter](https://github.com/abap2UI5/linter) catches a large part
+of them before you deploy, and the rest have to be verified against the SDK.
 :::
 
 #### Where to Look for Controls
@@ -96,45 +162,9 @@ The UI5 SDK is large. The table below covers the choices that come up in almost 
 | Multi-select dropdown             | `sap.m.MultiComboBox`                                 | Pills appear inside the field.                                                     |
 | Date / time input                 | `sap.m.DatePicker` / `sap.m.TimePicker` / `sap.m.DateTimePicker` | Needs a formatter — see [Binding → Data-Type Mapping](/cookbook/model/binding#data-type-mapping). |
 | Status indicator                  | `sap.m.ObjectStatus`                                  | Colored text + icon for state.                                                     |
-| Modal dialog                      | `sap.m.Dialog` (built with `factory_popup`)           | See [Popup](/cookbook/popup_popover/popup).                                        |
+| Modal dialog                      | `sap.m.Dialog` (inside a `core:FragmentDefinition`)           | See [Popup](/cookbook/popup_popover/popup).                                        |
 
 When two controls fit, prefer the simpler one: `Table` over `TreeTable`, `SimpleForm` over `Form`, `Select` over `ComboBox`. Switch to the richer variant only when a concrete requirement justifies it.
-
-## Mapping UI5 XML ↔ ABAP Fluent API
-
-`Z2UI5_CL_XML_VIEW` is a hand-curated wrapper around UI5 controls. It does not cover every UI5 control, and the naming is not always a strict 1:1 mapping of the UI5 SDK:
-
-- Control names follow snake_case of the UI5 control class — `sap.m.MultiComboBox` becomes `->multi_combo_box( )`, `sap.m.Text` becomes `->text( )`.
-- Properties are passed as named parameters, lowercased without underscores (`enabled`, `placeholder`, `selectedkey`, `growingthreshold`). Only the *method* names use snake_case (e.g. `multi_combo_box`).
-- Aggregations are exposed as methods named after the aggregation itself (`->items( )`, `->content( )`, `->custom_data( )`) — not as `add_item( )` / `add_content( )`. Calling the aggregation method returns the parent builder so you can chain children inside it.
-- Coverage is incomplete and occasionally inconsistent: some controls or properties are missing, some method signatures don't match the SDK exactly. When in doubt, check the source of `Z2UI5_CL_XML_VIEW` or fall back to the generic builder below.
-
-### The Fully Generic Builder
-
-Every fluent helper ultimately produces an XML element. The lowest-level method `_generic( name = ... ns = ... )` lets you emit **any** XML element with **any** attributes, regardless of whether `Z2UI5_CL_XML_VIEW` knows the control:
-
-```abap
-  DATA(view) = z2ui5_cl_xml_view=>factory( ).
-
-  view->_generic( name = `Page` ns = `sap.m`
-    )->_generic( name = `MultiComboBox` ns = `sap.m`
-        t_prop = VALUE #(
-          ( n = `selectedKeys` v = `{/keys}` )
-          ( n = `placeholder`  v = `Pick one` )
-        )
-      )->_generic( name = `items` ns = `sap.m`
-        )->_generic( name = `core:Item` ns = `sap.ui.core`
-            t_prop = VALUE #(
-              ( n = `key`  v = `{key}` )
-              ( n = `text` v = `{text}` )
-            ) ).
-
-  client->view_display( view->stringify( ) ).
-```
-
-This maps **1:1** to the UI5 XML/SDK API — control names, property names, and aggregation names are written exactly as they appear in the [UI5 SDK](https://sapui5.hana.ondemand.com), in their original camelCase. There is no abstraction layer guessing what to call things.
-
-The rest of this documentation uses the higher-level fluent API (`->page( )`, `->button( )`, `->multi_combo_box( )`) because it reads better in examples. Both styles can be mixed freely in the same view.
 
 #### Next Steps
 This produces a static view. The next section walks through binding and sharing data between the view and the app logic.

--- a/docs/cookbook/view/definition.md
+++ b/docs/cookbook/view/definition.md
@@ -51,7 +51,7 @@ frontend:
                     )->a( n = `title` v = `My title`
 
                     )->tag( `Text`
-                        )->a( n = `text` v = `My text` ) ).
+                        )->a( n = `text` v = `My text` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/view/deprecated_controls.md
+++ b/docs/cookbook/view/deprecated_controls.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Deprecated Controls
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 abap2UI5 sends plain UI5 XML to the browser, so **every** control the UI5 runtime knows will render — including the ones SAP has deprecated. Nothing in the framework stops you from using them.
 
 That makes deprecation a question you have to answer yourself while building the view. A deprecated control still works today, but it receives no new features, may behave inconsistently with newer themes, and disappears without replacement once SAP removes it — which has already happened (the Belize themes were removed in 1.136).

--- a/docs/cookbook/view/deprecated_controls.md
+++ b/docs/cookbook/view/deprecated_controls.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Deprecated Controls
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 abap2UI5 sends plain UI5 XML to the browser, so **every** control the UI5 runtime knows will render — including the ones SAP has deprecated. Nothing in the framework stops you from using them.
 
 That makes deprecation a question you have to answer yourself while building the view. A deprecated control still works today, but it receives no new features, may behave inconsistently with newer themes, and disappears without replacement once SAP removes it — which has already happened (the Belize themes were removed in 1.136).
@@ -67,16 +56,22 @@ These show up as *property values* rather than as controls, which makes them eas
 - Belize, Blue Crystal, and Blue Crystal HCB themes — **removed** in 1.136, use Horizon → [Theme](/configuration/setup/theme)
 
 ::: warning Avatar — mind the namespace
-`z2ui5_cl_xml_view->avatar( )` passes the `ns` parameter straight through to the XML element. Leave it empty so the element resolves to `sap.m.Avatar` via the view's default `xmlns`:
+Write `Avatar` with no `ns`, so the element resolves to `sap.m.Avatar` through
+the view's default `xmlns`:
 
 ```abap
-view->avatar( src = `sap-icon://person-placeholder` ).   " → <Avatar> = sap.m.Avatar
+)->tag( `Avatar`
+    )->a( n = `src` v = `sap-icon://person-placeholder`   " → <Avatar> = sap.m.Avatar
 ```
 
-**Never pass `ns = 'f'`** — that produces `<f:Avatar>`, which is the deprecated `sap.f.Avatar`.
+**Never write `ns = `f``** — that produces `<f:Avatar>`, the deprecated
+`sap.f.Avatar`.
 
-`avatar_group( )` and `avatar_group_item( )` are different: they hardcode `ns = 'f'` internally and are correct that way, because those controls still live in `sap.f`.
+`AvatarGroup` and `AvatarGroupItem` are the other way round: those controls do
+still live in `sap.f`, so they need `ns = `f`` and the `sap.f` namespace
+declared on the view.
 :::
+
 
 #### Next Steps
 

--- a/docs/cookbook/view/nested_views.md
+++ b/docs/cookbook/view/nested_views.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Nested Views
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 A **nested view** in abap2UI5 is a separate XML view fragment that you inject into a *placeholder* inside another view. The main view stays on screen; only the nested fragment is rendered (and later re-rendered or refreshed) independently. This is the standard pattern for master-detail screens, side panels, tab content, and anywhere you want one part of the UI to update without rebuilding the whole page.
 
 If you know SAPUI5's [nested views](https://sapui5.hana.ondemand.com/sdk/#/topic/df8c9c3d6f2a4d728ba7d6f4cb6c6d35) (`<mvc:XMLView viewName="..."/>`), the goal is the same — split the UI into independently managed pieces. In abap2UI5 the wiring is done from ABAP at runtime: instead of referencing a static view file, you build the nested view's XML in ABAP and tell the client to plug it into a named slot.
@@ -27,30 +16,44 @@ Two ingredients are needed:
 
 ```abap
 " 1) Main view with an anchor
-DATA(lo_view) = z2ui5_cl_xml_view=>factory( ).
-DATA(page)    = lo_view->shell(
-    )->page( title = `Main View`
-             id    = `test` ).        " <-- the anchor id
+DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`     v = `sap.m`
+        )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-page->content(
-  )->button( text  = `Re-render only the nested view`
-             press = client->_event( `NEST` ) ).
+        )->ele( `Shell`
+            )->ele( `Page`
+                )->a( n = `title` v = `Main View`
+                )->a( n = `id`    v = `test`        " <-- the anchor id
+
+                )->ele( `content`
+                    )->tag( `Button`
+                        )->a( n = `text`  v = `Re-render only the nested view`
+                        )->a( n = `press` v = client->_event( `NEST` ) ).
 
 " 2) Nested view, built like any other view
-DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory(
-  )->page( `Nested View`
-    )->input( client->_bind( mv_input_nest )
-    )->button( text  = `event`
-               press = client->_event( `TEST` ) ).
+DATA(nested) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`     v = `sap.m`
+        )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+        )->ele( `Page`
+            )->a( n = `title` v = `Nested View`
+
+            )->tag( `Input`
+                )->a( n = `value` v = client->_bind( mv_input_nest )
+            )->tag( `Button`
+                )->a( n = `text`  v = `event`
+                )->a( n = `press` v = client->_event( `TEST` ) ).
 
 IF client->check_on_init( ).
-  client->view_display( lo_view->stringify( ) ).
+  client->view_display( view->stringify( ) ).
 ENDIF.
 
 CASE client->get( )-event.
   WHEN `NEST`.
     client->nest_view_display(
-        val           = lo_view_nested->stringify( )
+        val           = nested->stringify( )
         id            = `test`               " target the anchor
         method_insert = `addContent` ).      " UI5 mutator on that control
 ENDCASE.
@@ -106,34 +109,51 @@ The most common real-world use: a master list on the left, detail content on the
 
 ```abap
 " Master view — built once
-DATA(page) = z2ui5_cl_xml_view=>factory(
-  )->page( title = `abap2UI5 - Master Detail` ).
+DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`     v = `sap.m`
+        )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:f`   v = `sap.f`
 
-DATA(lr_master) = page->flexible_column_layout(
-                       layout = client->_bind( mv_layout )
-                       id     = `test`                            " anchor
-                     )->begin_column_pages( ).
+        )->ele( `Page`
+            )->a( n = `title` v = `abap2UI5 - Master Detail`
 
-lr_master->list( items = client->_bind( t_tab )
-                 selectionchange = client->_event( `SELCHANGE` )
-  )->standard_list_item( title    = `{TITLE}`
-                         selected = `{SELECTED}` ).
+            )->ele( n = `FlexibleColumnLayout` ns = `f`
+                )->a( n = `layout` v = client->_bind( mv_layout )
+                )->a( n = `id`     v = `test`                     " anchor
 
-client->view_display( page->stringify( ) ).
+                )->ele( n = `beginColumnPages` ns = `f`
+                    )->ele( `List`
+                        )->a( n = `items`           v = client->_bind( t_tab )
+                        )->a( n = `selectionChange` v = client->_event( `SELCHANGE` )
+
+                        )->ele( `items`
+                            )->tag( `StandardListItem`
+                                )->a( n = `title`    v = `{TITLE}`
+                                )->a( n = `selected` v = `{SELECTED}` ).
+
+client->view_display( view->stringify( ) ).
 ```
 
 When the user picks a row, a detail view is rendered into the middle column:
 
 ```abap
 METHOD view_display_detail.
-  DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
-  DATA(page) = lo_view_nested->page( `Nested View` ).
+  DATA(nested) = z2ui5_cl_ui5_view_builder=>factory(
+      )->ele( n = `View` ns = `mvc`
+          )->a( n = `xmlns`     v = `sap.m`
+          )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:t`   v = `sap.ui.table`
 
-  page->ui_table( rows = client->_bind( t_tab2 ) ).
+          )->ele( `Page`
+              )->a( n = `title` v = `Nested View`
+
+              )->ele( n = `Table` ns = `t`
+                  )->a( n = `rows` v = client->_bind( t_tab2 ) ).
   " ...columns, toolbar, row actions...
 
   client->nest_view_display(
-    val            = lo_view_nested->stringify( )
+    val            = nested->stringify( )
     id             = `test`
     method_insert  = `addMidColumnPage`
     method_destroy = `removeAllMidColumnPages` ).
@@ -166,12 +186,20 @@ The middle column can itself host another nested view in the end column — usef
 
 ```abap
 METHOD view_display_detail_detail.
-  DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
-  lo_view_nested->page( `Nested View`
-    )->text( client->_bind( mv_title ) ).
+  DATA(nested) = z2ui5_cl_ui5_view_builder=>factory(
+      )->ele( n = `View` ns = `mvc`
+          )->a( n = `xmlns`     v = `sap.m`
+          )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+          )->ele( `Page`
+              )->a( n = `title` v = `Nested View`
+
+              )->tag( `Text`
+                  )->a( n = `text` v = client->_bind( mv_title ) ).
 
   client->nest2_view_display(
-    val            = lo_view_nested->stringify( )
+    val            = nested->stringify( )
+
     id             = `test`
     method_insert  = `addEndColumnPage`
     method_destroy = `removeAllEndColumnPages` ).

--- a/docs/cookbook/view/nested_views.md
+++ b/docs/cookbook/view/nested_views.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Nested Views
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 A **nested view** in abap2UI5 is a separate XML view fragment that you inject into a *placeholder* inside another view. The main view stays on screen; only the nested fragment is rendered (and later re-rendered or refreshed) independently. This is the standard pattern for master-detail screens, side panels, tab content, and anywhere you want one part of the UI to update without rebuilding the whole page.
 
 If you know SAPUI5's [nested views](https://sapui5.hana.ondemand.com/sdk/#/topic/df8c9c3d6f2a4d728ba7d6f4cb6c6d35) (`<mvc:XMLView viewName="..."/>`), the goal is the same — split the UI into independently managed pieces. In abap2UI5 the wiring is done from ABAP at runtime: instead of referencing a static view file, you build the nested view's XML in ABAP and tell the client to plug it into a named slot.

--- a/docs/cookbook/view/xml_templating.md
+++ b/docs/cookbook/view/xml_templating.md
@@ -38,25 +38,38 @@ mt_layout = VALUE #( ( fname = `NAME` merge = `false` visible = `true`  )
                      ( fname = `AGE`  merge = `false` visible = `false` ) ).
 client->_bind( mt_layout ).
 
-view->table( client->_bind( mt_data )
-  )->columns(
-    )->template_repeat( list = `{template>/MT_LAYOUT}`
-                        var  = `L0`
-      )->column( mergeduplicates = `{L0>MERGE}`
-                 visible         = `{L0>VISIBLE}`
-        )->text( `{L0>FNAME}` )->get_parent(
-    )->get_parent( )->get_parent(
-    )->items(
-      )->column_list_item(
-        )->cells(
-          )->template_repeat( list = `{template>/MT_LAYOUT}`
-                              var  = `L1`
-            )->object_identifier( text = `{= '{' + ${L1>FNAME} + '}' }` ).
+view->ele( `Table`
+    )->a( n = `items` v = client->_bind( mt_data )
+
+    )->ele( `columns`
+        )->ele( n = `repeat` ns = `template`
+            )->a( n = `list` v = `{template>/MT_LAYOUT}`
+            )->a( n = `var`  v = `L0`
+
+            )->ele( `Column`
+                )->a( n = `mergeDuplicates` v = `{L0>MERGE}`
+                )->a( n = `visible`         v = `{L0>VISIBLE}`
+
+                )->tag( `Text`
+                    )->a( n = `text` v = `{L0>FNAME}`
+            )->end(
+        )->end(
+    )->end(
+
+    )->ele( `items`
+        )->ele( `ColumnListItem`
+            )->ele( `cells`
+                )->ele( n = `repeat` ns = `template`
+                    )->a( n = `list` v = `{template>/MT_LAYOUT}`
+                    )->a( n = `var`  v = `L1`
+
+                    )->tag( `ObjectIdentifier`
+                        )->a( n = `text` v = `{= '{' + ${L1>FNAME} + '}' }` ).
 ```
 
 Notes on the snippet:
 
-- `list` is the binding path that drives the loop; `var` is the alias used inside the loop body (here `L0` for the column headers, `L1` for the cells).
+- `list` is the binding path that drives the loop; `var` is the alias used inside the loop body (here `L0` for the column headers, `L1` for the cells). `template` is an element namespace like any other, so the builder needs nothing beyond `ns = template` on the element — the prefix itself is declared once on the view's root.
 - Inside the loop, `{L0>FNAME}` is a templating-time read — it ends up as the literal string `NAME`/`DATE`/`AGE` in the expanded XML.
 - `{= '{' + ${L1>FNAME} + '}' }` is an [expression binding](https://sapui5.hana.ondemand.com/sdk/#/topic/daf6852a04b44d118963968a1239d2c0) that **constructs another binding string at templating time**. With `L1>FNAME = NAME` it expands to `text="{NAME}"`, which becomes a normal runtime binding against the row of `mt_data`. This is the standard pattern for templated tables: outer loop builds the columns, inner loop builds the cells, expression binding wires each cell to the right field of the row.
 - `template_repeat` accepts the same optional attributes as the UI5 instruction (`startIndex`, `length`) plus list-binding extras like sorters and filters.
@@ -70,18 +83,24 @@ The full sample is `Z2UI5_CL_SMP_APP_173`.
 ```abap
 client->_bind( mv_flag ).
 
-view->template_if( `{template>/MV_FLAG}`
-  )->template_then(
-    )->icon( src   = `sap-icon://accept`
-             color = `green` )->get_parent(
-  )->template_else(
-    )->icon( src   = `sap-icon://decline`
-             color = `red` ).
+view->ele( n = `if` ns = `template`
+    )->a( n = `test` v = `{template>/MV_FLAG}`
+
+    )->ele( n = `then` ns = `template`
+        )->tag( n = `Icon` ns = `core`
+            )->a( n = `src`   v = `sap-icon://accept`
+            )->a( n = `color` v = `green`
+    )->end(
+
+    )->ele( n = `else` ns = `template`
+        )->tag( n = `Icon` ns = `core`
+            )->a( n = `src`   v = `sap-icon://decline`
+            )->a( n = `color` v = `red` ).
 ```
 
 The test argument follows the same rules as in UI5: any binding expression is fine, and the string `"false"` is treated as boolean `false` (a UI5 convenience). For richer conditions use expression binding, e.g. `` `{= ${template>/MV_COUNT} > 0 }` ``.
 
-`template:elseif` is also supported by UI5; check `Z2UI5_CL_XML_VIEW` for the corresponding fluent method or fall back to the generic builder (see [Definition](/cookbook/view/definition#the-fully-generic-builder)).
+`template:elseif` is also supported by UI5, and needs nothing extra here: it is the same `ele` call with a different name, `ns = template` and a `test` attribute. That is the point of the builder — every templating instruction UI5 has is reachable the moment UI5 has it, without waiting for a method.
 
 #### Re-rendering
 

--- a/docs/cookbook/view/xml_templating.md
+++ b/docs/cookbook/view/xml_templating.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # XML Templating
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 XML Templating is a **UI5 preprocessor feature**, not an abap2UI5 invention. The UI5 runtime understands a small set of instructions in the `template` XML namespace — `template:repeat`, `template:if`, `template:then`, `template:else`, `template:with` — and expands them into plain XML *before* the control tree is created. abap2UI5 exposes these instructions through the fluent builder so you can drive the expansion from ABAP data.
 
 See the official UI5 references for the underlying mechanics:
@@ -113,21 +102,44 @@ This is the pattern used in `Z2UI5_CL_SMP_APP_173`: the switch fires `CHANGE_FLA
 
 ```abap
 " Main view: built once, stays on screen
-DATA(lo_view) = z2ui5_cl_xml_view=>factory( ).
-lo_view->shell( )->page( title = `Main View` id = `test` ... ).
-client->view_display( lo_view->stringify( ) ).
+DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`     v = `sap.m`
+        )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-" Nested templated view: inserted into the main view by id
-DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
-lo_view_nested->shell( )->page( `Nested View`
-  )->table( client->_bind( mt_data )
-  )->columns(
-    )->template_repeat( list = `{template>/MT_LAYOUT}` var = `L0`
-      )->column( ... ) " ...
+        )->ele( `Shell`
+            )->ele( `Page`
+                )->a( n = `title` v = `Main View`
+                )->a( n = `id`    v = `test` ).   " ...
 
-client->nest_view_display( val           = lo_view_nested->stringify( )
+client->view_display( view->stringify( ) ).
+
+" Nested templated view: inserted into the main view by id.
+" The template namespace has to be declared on the nested view's root.
+DATA(nested) = z2ui5_cl_ui5_view_builder=>factory(
+    )->ele( n = `View` ns = `mvc`
+        )->a( n = `xmlns`          v = `sap.m`
+        )->a( n = `xmlns:mvc`      v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:template` v = `http://schemas.sap.com/sapui5/extension/sap.ui.core.template/1`
+
+        )->ele( `Shell`
+            )->ele( `Page`
+                )->a( n = `title` v = `Nested View`
+
+                )->ele( `Table`
+                    )->a( n = `items` v = client->_bind( mt_data )
+
+                    )->ele( `columns`
+                        )->ele( n = `repeat` ns = `template`
+                            )->a( n = `list` v = `{template>/MT_LAYOUT}`
+                            )->a( n = `var`  v = `L0`
+
+                            )->ele( `Column` ).   " ...
+
+client->nest_view_display( val           = nested->stringify( )
                            id            = `test`
                            method_insert = `addContent` ).
+
 ```
 
 `nest_view_display` targets a control in the existing view by id (`test`) and appends/replaces the nested view there. To refresh the templated piece on a data change, call `nest_view_display` again from the event handler — the main view is left untouched.

--- a/docs/cookbook/view/xml_templating.md
+++ b/docs/cookbook/view/xml_templating.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # XML Templating
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 XML Templating is a **UI5 preprocessor feature**, not an abap2UI5 invention. The UI5 runtime understands a small set of instructions in the `template` XML namespace — `template:repeat`, `template:if`, `template:then`, `template:else`, `template:with` — and expands them into plain XML *before* the control tree is created. abap2UI5 exposes these instructions through the fluent builder so you can drive the expansion from ABAP data.
 
 See the official UI5 references for the underlying mechanics:

--- a/docs/get_started/full_example.md
+++ b/docs/get_started/full_example.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Full Example
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 This tutorial walks through a complete app that follows a typical ABAP flow: a small selection screen, reading data from the database, showing the result in a table, opening a popup to edit a row, and posting the changes back. It ties together everything from the [Hello World](/get_started/hello_world) page and shows how the pieces fit into a real screen.
 
 The example uses sales-order-like data but keeps the SELECTs and updates as plain ABAP so you can adapt them to your own tables. Drop the class into your system and launch it the same way as the Hello World app.

--- a/docs/get_started/full_example.md
+++ b/docs/get_started/full_example.md
@@ -3,16 +3,6 @@ outline: [2, 4]
 ---
 # Full Example
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
 
 This tutorial walks through a complete app that follows a typical ABAP flow: a small selection screen, reading data from the database, showing the result in a table, opening a popup to edit a row, and posting the changes back. It ties together everything from the [Hello World](/get_started/hello_world) page and shows how the pieces fit into a real screen.
 
@@ -95,48 +85,87 @@ The two date pickers and the customer input are bound with `_bind`, so whatever 
 ```abap
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - Full Example`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    page->simple_form(
-        title    = `Order Selection`
-        editable = abap_true
-        )->content( `form`
-        )->label( `Order Date From`
-        )->date_picker(
-            value       = client->_bind( s_search-date_from )
-            valueformat = `yyyy-MM-dd`
-        )->label( `Order Date To`
-        )->date_picker(
-            value       = client->_bind( s_search-date_to )
-            valueformat = `yyyy-MM-dd`
-        )->label( `Customer`
-        )->input( client->_bind( s_search-customer )
-        )->button(
-            text  = `Read Orders`
-            press = client->_event( `READ` ) ).
+    DATA(page) = view->ele( `Shell`
+        )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Full Example`
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( ) ).
 
-    DATA(tab) = page->table( client->_bind( t_orders ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Order Selection`
+        )->a( n = `editable` v = `true`
 
-    tab->columns(
-        )->column( )->text( `Order` )->get_parent(
-        )->column( )->text( `Customer` )->get_parent(
-        )->column( )->text( `Order Date` )->get_parent(
-        )->column( )->text( `Delivery Date` )->get_parent(
-        )->column( `10%` )->get_parent( ).
+        )->ele( n = `content` ns = `form`
 
-    tab->items( )->column_list_item(
-        )->cells(
-            )->text( `{ORDER_ID}`
-            )->text( `{CUSTOMER}`
-            )->text( `{ORDER_DATE}`
-            )->text( `{DELIVERY_DATE}`
-            )->button(
-                icon  = `sap-icon://edit`
-                press = client->_event( val = `EDIT` t_arg = VALUE #( ( `${ORDER_ID}` ) ) ) ).
+            )->tag( `Label`
+                )->a( n = `text` v = `Order Date From`
+            )->tag( `DatePicker`
+                )->a( n = `value`       v = client->_bind( s_search-date_from )
+                )->a( n = `valueFormat` v = `yyyy-MM-dd`
+            )->tag( `Label`
+                )->a( n = `text` v = `Order Date To`
+            )->tag( `DatePicker`
+                )->a( n = `value`       v = client->_bind( s_search-date_to )
+                )->a( n = `valueFormat` v = `yyyy-MM-dd`
+            )->tag( `Label`
+                )->a( n = `text` v = `Customer`
+            )->tag( `Input`
+                )->a( n = `value` v = client->_bind( s_search-customer )
+            )->tag( `Button`
+                )->a( n = `text`  v = `Read Orders`
+                )->a( n = `press` v = client->_event( `READ` ) ).
+
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_orders ) ).
+
+    tab->ele( `columns`
+
+        )->ele( `Column`
+            )->tag( `Text`
+                )->a( n = `text` v = `Order`
+
+        )->end(
+        )->ele( `Column`
+            )->tag( `Text`
+                )->a( n = `text` v = `Customer`
+
+        )->end(
+        )->ele( `Column`
+            )->tag( `Text`
+                )->a( n = `text` v = `Order Date`
+
+        )->end(
+        )->ele( `Column`
+            )->tag( `Text`
+                )->a( n = `text` v = `Delivery Date`
+
+        )->end(
+        )->ele( `Column`
+            )->a( n = `width` v = `10%` ).
+
+    tab->ele( `items`
+        )->ele( `ColumnListItem`
+            )->ele( `cells`
+
+                )->tag( `Text`
+                    )->a( n = `text` v = `{ORDER_ID}`
+                )->tag( `Text`
+                    )->a( n = `text` v = `{CUSTOMER}`
+                )->tag( `Text`
+                    )->a( n = `text` v = `{ORDER_DATE}`
+                )->tag( `Text`
+                    )->a( n = `text` v = `{DELIVERY_DATE}`
+                )->tag( `Button`
+                    )->a( n = `icon`    v = `sap-icon://edit`
+                    )->a( n = `tooltip` v = `Edit delivery date`
+                    )->a( n = `press`   v = client->_event( val   = `EDIT`
+                                                            t_arg = VALUE #( ( `${ORDER_ID}` ) ) ) ).
 
     client->view_display( view->stringify( ) ).
 
@@ -183,13 +212,22 @@ When the user presses **Read Orders**, the `READ` event arrives in `on_event`. R
   ENDMETHOD.
 ```
 
-Back in `on_event`, the crucial line is `view_model_update`. The view already exists in the browser — only the data changed — so instead of rebuilding it, the framework just sends the new model:
+Back in `on_event`, note what is **not** there: no second `view_display( )`.
+The view already exists in the browser and only the data changed, so the
+framework sends the new model by itself — every roundtrip that changed
+something bound pushes it. There is nothing to call:
 
 ```abap
       WHEN `READ`.
         data_read( ).
-        client->view_model_update( ).
 ```
+
+::: tip You may see `client->view_model_update( )` in older code
+It still compiles, and it still does nothing: the method is deliberately
+empty, because the model push is queued by the framework rather than asked
+for. Leaving it in is harmless; writing it in new code teaches a step that
+does not exist.
+:::
 
 ### Step 4 — The Edit Popup
 
@@ -201,29 +239,40 @@ Pressing the edit icon fires the `EDIT` event, and `client->get_event_arg( )` re
         popup_edit_display( ).
 ```
 
-A popup is built exactly like the main view — same fluent builder, just created with `factory_popup` and displayed with `popup_display`. The main view stays untouched in the background:
+A popup is built exactly like the main view — same builder, same verbs. The only differences are the root element (`core:FragmentDefinition` instead of `mvc:View`) and that it is handed to `popup_display( )`. The main view stays untouched in the background:
 
 ```abap
   METHOD popup_edit_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    DATA(dialog) = popup->dialog( |Order { s_edit-order_id } - { s_edit-customer }| ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `FragmentDefinition` ns = `core`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:core` v = `sap.ui.core`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    dialog->simple_form( editable = abap_true
-        )->content( `form`
-        )->label( `Delivery Date`
-        )->date_picker(
-            value       = client->_bind( s_edit-delivery_date )
-            valueformat = `yyyy-MM-dd` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title` v = |Order { s_edit-order_id } - { s_edit-customer }| ).
 
-    dialog->buttons(
-        )->button(
-            text  = `Cancel`
-            press = client->_event( `CANCEL` )
-        )->button(
-            text  = `Post`
-            press = client->_event( `POST` )
-            type  = `Emphasized` ).
+    dialog->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `editable` v = `true`
+
+        )->ele( n = `content` ns = `form`
+
+            )->tag( `Label`
+                )->a( n = `text` v = `Delivery Date`
+            )->tag( `DatePicker`
+                )->a( n = `value`       v = client->_bind( s_edit-delivery_date )
+                )->a( n = `valueFormat` v = `yyyy-MM-dd` ).
+
+    dialog->ele( `buttons`
+
+        )->tag( `Button`
+            )->a( n = `text`  v = `Cancel`
+            )->a( n = `press` v = client->_event( `CANCEL` )
+        )->tag( `Button`
+            )->a( n = `text`  v = `Post`
+            )->a( n = `press` v = client->_event( `POST` )
+            )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -240,7 +289,6 @@ The date picker in the dialog binds to `s_edit-delivery_date` with `_bind` — w
       WHEN `POST`.
         data_update( ).
         client->popup_destroy( ).
-        client->view_model_update( ).
         client->message_toast_display( |Delivery date of order { s_edit-order_id } updated.| ).
       WHEN `CANCEL`.
         client->popup_destroy( ).
@@ -322,14 +370,12 @@ CLASS zcl_app_full_example IMPLEMENTATION.
     CASE client->get( )-event.
       WHEN `READ`.
         data_read( ).
-        client->view_model_update( ).
       WHEN `EDIT`.
         s_edit = VALUE #( t_orders[ order_id = client->get_event_arg( ) ] OPTIONAL ).
         popup_edit_display( ).
       WHEN `POST`.
         data_update( ).
         client->popup_destroy( ).
-        client->view_model_update( ).
         client->message_toast_display( |Delivery date of order { s_edit-order_id } updated.| ).
       WHEN `CANCEL`.
         client->popup_destroy( ).
@@ -340,48 +386,87 @@ CLASS zcl_app_full_example IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - Full Example`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:mvc`  v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    page->simple_form(
-        title    = `Order Selection`
-        editable = abap_true
-        )->content( `form`
-        )->label( `Order Date From`
-        )->date_picker(
-            value       = client->_bind( s_search-date_from )
-            valueformat = `yyyy-MM-dd`
-        )->label( `Order Date To`
-        )->date_picker(
-            value       = client->_bind( s_search-date_to )
-            valueformat = `yyyy-MM-dd`
-        )->label( `Customer`
-        )->input( client->_bind( s_search-customer )
-        )->button(
-            text  = `Read Orders`
-            press = client->_event( `READ` ) ).
+    DATA(page) = view->ele( `Shell`
+        )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Full Example`
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( ) ).
 
-    DATA(tab) = page->table( client->_bind( t_orders ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Order Selection`
+        )->a( n = `editable` v = `true`
 
-    tab->columns(
-        )->column( )->text( `Order` )->get_parent(
-        )->column( )->text( `Customer` )->get_parent(
-        )->column( )->text( `Order Date` )->get_parent(
-        )->column( )->text( `Delivery Date` )->get_parent(
-        )->column( `10%` )->get_parent( ).
+        )->ele( n = `content` ns = `form`
 
-    tab->items( )->column_list_item(
-        )->cells(
-            )->text( `{ORDER_ID}`
-            )->text( `{CUSTOMER}`
-            )->text( `{ORDER_DATE}`
-            )->text( `{DELIVERY_DATE}`
-            )->button(
-                icon  = `sap-icon://edit`
-                press = client->_event( val = `EDIT` t_arg = VALUE #( ( `${ORDER_ID}` ) ) ) ).
+            )->tag( `Label`
+                )->a( n = `text` v = `Order Date From`
+            )->tag( `DatePicker`
+                )->a( n = `value`       v = client->_bind( s_search-date_from )
+                )->a( n = `valueFormat` v = `yyyy-MM-dd`
+            )->tag( `Label`
+                )->a( n = `text` v = `Order Date To`
+            )->tag( `DatePicker`
+                )->a( n = `value`       v = client->_bind( s_search-date_to )
+                )->a( n = `valueFormat` v = `yyyy-MM-dd`
+            )->tag( `Label`
+                )->a( n = `text` v = `Customer`
+            )->tag( `Input`
+                )->a( n = `value` v = client->_bind( s_search-customer )
+            )->tag( `Button`
+                )->a( n = `text`  v = `Read Orders`
+                )->a( n = `press` v = client->_event( `READ` ) ).
+
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_orders ) ).
+
+    tab->ele( `columns`
+
+        )->ele( `Column`
+            )->tag( `Text`
+                )->a( n = `text` v = `Order`
+
+        )->end(
+        )->ele( `Column`
+            )->tag( `Text`
+                )->a( n = `text` v = `Customer`
+
+        )->end(
+        )->ele( `Column`
+            )->tag( `Text`
+                )->a( n = `text` v = `Order Date`
+
+        )->end(
+        )->ele( `Column`
+            )->tag( `Text`
+                )->a( n = `text` v = `Delivery Date`
+
+        )->end(
+        )->ele( `Column`
+            )->a( n = `width` v = `10%` ).
+
+    tab->ele( `items`
+        )->ele( `ColumnListItem`
+            )->ele( `cells`
+
+                )->tag( `Text`
+                    )->a( n = `text` v = `{ORDER_ID}`
+                )->tag( `Text`
+                    )->a( n = `text` v = `{CUSTOMER}`
+                )->tag( `Text`
+                    )->a( n = `text` v = `{ORDER_DATE}`
+                )->tag( `Text`
+                    )->a( n = `text` v = `{DELIVERY_DATE}`
+                )->tag( `Button`
+                    )->a( n = `icon`    v = `sap-icon://edit`
+                    )->a( n = `tooltip` v = `Edit delivery date`
+                    )->a( n = `press`   v = client->_event( val   = `EDIT`
+                                                            t_arg = VALUE #( ( `${ORDER_ID}` ) ) ) ).
 
     client->view_display( view->stringify( ) ).
 
@@ -390,24 +475,35 @@ CLASS zcl_app_full_example IMPLEMENTATION.
 
   METHOD popup_edit_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    DATA(dialog) = popup->dialog( |Order { s_edit-order_id } - { s_edit-customer }| ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `FragmentDefinition` ns = `core`
+            )->a( n = `xmlns`      v = `sap.m`
+            )->a( n = `xmlns:core` v = `sap.ui.core`
+            )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    dialog->simple_form( editable = abap_true
-        )->content( `form`
-        )->label( `Delivery Date`
-        )->date_picker(
-            value       = client->_bind( s_edit-delivery_date )
-            valueformat = `yyyy-MM-dd` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title` v = |Order { s_edit-order_id } - { s_edit-customer }| ).
 
-    dialog->buttons(
-        )->button(
-            text  = `Cancel`
-            press = client->_event( `CANCEL` )
-        )->button(
-            text  = `Post`
-            press = client->_event( `POST` )
-            type  = `Emphasized` ).
+    dialog->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `editable` v = `true`
+
+        )->ele( n = `content` ns = `form`
+
+            )->tag( `Label`
+                )->a( n = `text` v = `Delivery Date`
+            )->tag( `DatePicker`
+                )->a( n = `value`       v = client->_bind( s_edit-delivery_date )
+                )->a( n = `valueFormat` v = `yyyy-MM-dd` ).
+
+    dialog->ele( `buttons`
+
+        )->tag( `Button`
+            )->a( n = `text`  v = `Cancel`
+            )->a( n = `press` v = client->_event( `CANCEL` )
+        )->tag( `Button`
+            )->a( n = `text`  v = `Post`
+            )->a( n = `press` v = client->_event( `POST` )
+            )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -460,7 +556,7 @@ ENDCLASS.
 
 - One controller class, one `main` method, all state in public attributes — that is the whole app
 - The view is rebuilt only when the structure changes. Edits, saves, and popup open/close do not need a fresh `view_display( )`
-- Popups are just a different factory (`factory_popup`) on the same `z2ui5_cl_xml_view`, displayed via `popup_display` / `popup_destroy` while the main view stays in place
+- Popups use the same builder as the view — a `core:FragmentDefinition` root instead of `mvc:View` — displayed via `popup_display` / `popup_destroy` while the main view stays in place
 - Reading and writing the database is plain ABAP — abap2UI5 does not abstract that layer, which is what makes it easy to plug into existing code
 
 From here, look at the [Cookbook](/cookbook/event_navigation/life_cycle) for value helps, navigation between apps, message handling, and other patterns you will need next.

--- a/docs/get_started/hello_world.md
+++ b/docs/get_started/hello_world.md
@@ -52,14 +52,41 @@ ENDCLASS.
 CLASS zcl_app_hello_world IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory(
-      )->page( `abap2UI5 - Hello World`
-      )->text( `My Text` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title` v = `abap2UI5 - Hello World`
+
+                    )->tag( `Text`
+                        )->a( n = `text` v = `My Text` ) ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 ENDCLASS.
 ```
+
+You are writing a UI5 XML view, one control per call. `z2ui5_cl_ui5_view_builder`
+has four verbs and no list of controls to look up — every UI5 control,
+property and aggregation is available because the builder never knew any of
+them by name:
+
+| | |
+| --- | --- |
+| `ele( )` | add a control and **descend** into it — for a container |
+| `tag( )` | add a control and **stay** — for a leaf |
+| `a( )` | set **one** attribute on the control the chain is pointing at |
+| `end( )` | ascend to the parent |
+
+The single rule: `a( )` applies to the control the chain currently points at,
+so attributes follow their control — and a control gets them *before* its
+first child. The root `mvc:View` and its `xmlns` declarations are written by
+hand, exactly as in a real UI5 view. A trailing `end( )` can be left out:
+`stringify( )` renders from the root wherever the chain stopped.
 
 ### Events
 Now add a button and react to its press event:
@@ -74,12 +101,21 @@ CLASS zcl_app_hello_world IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory(
-        )->page( `abap2UI5 - Hello World`
-        )->text( `My Text`
-        )->button(
-          text  = `post`
-          press = client->_event( `POST` ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Shell`
+                  )->ele( `Page`
+                      )->a( n = `title` v = `abap2UI5 - Hello World`
+
+                      )->tag( `Text`
+                          )->a( n = `text` v = `My Text`
+                      )->tag( `Button`
+                          )->a( n = `text`  v = `post`
+                          )->a( n = `press` v = client->_event( `POST` ) ) ).
+
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `POST` ).
@@ -127,13 +163,23 @@ CLASS zcl_app_hello_world IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory(
-        )->page( `abap2UI5 - Hello World`
-        )->text( `My Text`
-        )->button(
-          text  = `post`
-          press = client->_event( `POST` )
-        )->input( client->_bind( name ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Shell`
+                  )->ele( `Page`
+                      )->a( n = `title` v = `abap2UI5 - Hello World`
+
+                      )->tag( `Text`
+                          )->a( n = `text` v = `My Text`
+                      )->tag( `Input`
+                          )->a( n = `value` v = client->_bind( name )
+                      )->tag( `Button`
+                          )->a( n = `text`  v = `post`
+                          )->a( n = `press` v = client->_event( `POST` ) ) ).
+
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `POST` ).

--- a/docs/get_started/hello_world.md
+++ b/docs/get_started/hello_world.md
@@ -62,7 +62,7 @@ CLASS zcl_app_hello_world IMPLEMENTATION.
                     )->a( n = `title` v = `abap2UI5 - Hello World`
 
                     )->tag( `Text`
-                        )->a( n = `text` v = `My Text` ) ).
+                        )->a( n = `text` v = `My Text` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -114,7 +114,7 @@ CLASS zcl_app_hello_world IMPLEMENTATION.
                           )->a( n = `text` v = `My Text`
                       )->tag( `Button`
                           )->a( n = `text`  v = `post`
-                          )->a( n = `press` v = client->_event( `POST` ) ) ).
+                          )->a( n = `press` v = client->_event( `POST` ) ).
 
       client->view_display( view->stringify( ) ).
 
@@ -178,7 +178,7 @@ CLASS zcl_app_hello_world IMPLEMENTATION.
                           )->a( n = `value` v = client->_bind( name )
                       )->tag( `Button`
                           )->a( n = `text`  v = `post`
-                          )->a( n = `press` v = client->_event( `POST` ) ) ).
+                          )->a( n = `press` v = client->_event( `POST` ) ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/get_started/next.md
+++ b/docs/get_started/next.md
@@ -16,6 +16,9 @@ _No system at hand? Run the samples directly [in your browser](https://abap2ui5.
 The samples evolve all the time. Have one to share? Open a PR so others can learn from it.
 :::
 
+#### Tooling
+Optional, and worth the ten minutes: a project [template](https://github.com/abap2UI5/app-template) with the checks already wired up, a [linter](https://github.com/abap2UI5/linter) that finds broken views without a system, an [extension](https://github.com/abap2UI5/vscode-extension) that runs your app on `F9` next to the code, and an [MCP server](https://github.com/abap2UI5/ai-mcp) that lets an AI agent build and *look at* the app. See [Tooling](/get_started/tooling).
+
 #### Development
 Build views, handle events, share data, and work with tables. The [Cookbook](/cookbook/overview) walks through the patterns you need for everyday work — start with the [Life Cycle](/cookbook/event_navigation/life_cycle) page.
 

--- a/docs/get_started/quickstart.md
+++ b/docs/get_started/quickstart.md
@@ -26,7 +26,7 @@ ENDCLASS.
 
 CLASS zcl_my_abap2UI5_http_handler IMPLEMENTATION.
   METHOD if_http_extension~handle_request.
-    z2ui5_cl_http_handler=>run( server ).
+    z2ui5_cl_ui5_http_handler=>run( server ).
   ENDMETHOD.
 ENDCLASS.
 ```
@@ -39,7 +39,7 @@ ENDCLASS.
 
 CLASS zcl_my_abap2UI5_http_handler IMPLEMENTATION.
   METHOD if_http_service_extension~handle_request.
-    z2ui5_cl_http_handler=>run( req = request res = response ).
+    z2ui5_cl_ui5_http_handler=>run( req = request res = response ).
   ENDMETHOD.
 ENDCLASS.
 ```

--- a/docs/get_started/tooling.md
+++ b/docs/get_started/tooling.md
@@ -1,0 +1,94 @@
+---
+outline: [2, 4]
+---
+# Tooling
+
+Everything on this page is optional — abap2UI5 is one ABAP class and needs no
+tools at all. What these four add is the loop that ABAP does not give you by
+itself: catching a broken view **before** it reaches a system, and seeing the
+app without leaving the editor.
+
+They are independent of each other. Take the first one and stop, or take all
+four.
+
+#### Start a project from the template
+
+[**abap2UI5/app-template**](https://github.com/abap2UI5/app-template) — press
+*Use this template* on GitHub and you have an app repository that is already
+set up: one working app class, both gates configured, a CI workflow that runs
+them on every push, and a guide for AI agents.
+
+The alternative is creating a class by hand, which works fine — the template
+only saves you from assembling the checks below yourself, and from finding out
+half a year later that they were never running.
+
+```
+Use this template → clone → npm ci → npm run check
+```
+
+#### Check the view without a system
+
+[**abap2UI5/linter**](https://github.com/abap2UI5/linter) — the view your app
+builds only exists at runtime, so no UI5 tooling can see it and the ABAP
+compiler has no opinion about it. This one reconstructs the view from your
+builder chain and judges the two together:
+
+- controls, properties, aggregations and enum values that UI5 does not have,
+  or does not have **yet** on the release you target (the `@since` floor —
+  1.71 by default, which is what most systems serve),
+- bindings that point at nothing, events nothing handles, deprecated controls,
+- and then it loads every view in a headless browser, which is the only way to
+  find a view that does not merely render wrongly but fails to load at all.
+
+```sh
+npx @abap2ui5/linter src
+```
+
+No SAP system, no install beyond npm. It also ships as a GitHub Action, and
+the [app-template](https://github.com/abap2UI5/app-template) has it wired into
+CI already.
+
+#### Run the app from the editor
+
+[**abap2UI5/vscode-extension**](https://github.com/abap2UI5/vscode-extension) —
+press `F9` on an app class and it starts in a preview beside your code,
+against your real system. Plus completion and hover for the whole UI5 API
+inside the builder chain, the linter running as you type, a click-a-control →
+jump-to-the-line inspector, and a traffic log of every roundtrip.
+
+Install it from the VS Code Marketplace or Open VSX; it needs the
+[ABAP remote filesystem](https://marketplace.visualstudio.com/items?itemName=murbani.vscode-abap-remote-fs)
+extension for the system connection.
+
+#### Let an AI agent build and see the app
+
+[**abap2UI5/ai-mcp**](https://github.com/abap2UI5/ai-mcp) — an MCP server that
+gives a coding agent the whole loop *without* an SAP system: it validates the
+view, transpiles the framework and the app to Node, boots the app in a
+headless browser and hands the agent a **screenshot**. That last step is the
+difference between "the code compiles" and "the app works".
+
+Works with any MCP client (Claude Code, Cursor, VS Code). The full loop needs
+a few checkouts and a first build that takes a while — the README says which
+tools need what, and validating views alone needs almost nothing.
+
+::: tip Building with an AI agent?
+Point it at [`llms.txt`](https://github.com/abap2UI5/abap2UI5/blob/main/llms.txt)
+in the framework repository. It is a map of this documentation and the sample
+repositories written for agents, and the
+[app-template](https://github.com/abap2UI5/app-template) ships an `AGENTS.md`
+that states the conventions an agent should follow in your project.
+:::
+
+#### Where the samples live
+
+Three repositories, in the order they build on each other:
+
+| | |
+| --- | --- |
+| [samples](https://github.com/abap2UI5/samples) | the fundamentals — binding, events, popups, navigation, and complete little apps |
+| [samples-controls](https://github.com/abap2UI5/samples-controls) | the UI5 demo kit rebuilt in abap2UI5, one app per official sample |
+| [samples-stack](https://github.com/abap2UI5/samples-stack) | abap2UI5 together with OData, RAP, WebSockets and the Fiori Launchpad |
+
+All three install with abapGit and carry an overview app that lists everything
+they contain.

--- a/docs/technical/cloud.md
+++ b/docs/technical/cloud.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Cloud Readiness
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 _Ready for the Future — or Not?_
 
 Whether it's worth building apps with abap2UI5 comes down to future-proofing. In the ABAP ecosystem, this means cloud readiness, closely tied to the ABAP Cloud language version. So what does that mean? And are abap2UI5 apps truly cloud-ready?

--- a/docs/technical/cloud.md
+++ b/docs/technical/cloud.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Cloud Readiness
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 _Ready for the Future — or Not?_
 
 Whether it's worth building apps with abap2UI5 comes down to future-proofing. In the ABAP ecosystem, this means cloud readiness, closely tied to the ABAP Cloud language version. So what does that mean? And are abap2UI5 apps truly cloud-ready?
@@ -70,11 +59,20 @@ CLASS z2ui5_cl_demo_app_003 IMPLEMENTATION.
        INTO TABLE @mt_salesorder
        UP TO 10 ROWS.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory(
-          )->list( client->_bind( mt_salesorder )
-            )->standard_list_item(
-              title       = `{SALESORDER}`
-              description = `{SALESORGANIZATION}` ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->ele( `List`
+                      )->a( n = `items` v = client->_bind( mt_salesorder )
+
+                      )->ele( `items`
+                          )->tag( `StandardListItem`
+                              )->a( n = `title`       v = `{SALESORDER}`
+                              )->a( n = `description` v = `{SALESORGANIZATION}` ).
+
       client->view_display( view->stringify( ) ).
 
     ENDIF.
@@ -104,12 +102,22 @@ CLASS z2ui5_cl_demo_app_004 IMPLEMENTATION.
        INTO TABLE @mt_salesorder
        UP TO 10 ROWS.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory(
-        )->list( client->_bind( mt_salesorder )
-          )->standard_list_item(
-              title       = `{VBELN}`
-              description = `{VKORG}` ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->ele( `List`
+                      )->a( n = `items` v = client->_bind( mt_salesorder )
+
+                      )->ele( `items`
+                          )->tag( `StandardListItem`
+                              )->a( n = `title`       v = `{VBELN}`
+                              )->a( n = `description` v = `{VKORG}` ).
+
       client->view_display( view->stringify( ) ).
+
 
     ENDIF.
 

--- a/docs/technical/concept.md
+++ b/docs/technical/concept.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # UI5 Over-the-Wire
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 _The Architecture of abap2UI5_
 
 This article introduces the core pattern behind abap2UI5: HTML Over-the-Wire — adapted for the ABAP ecosystem. It shows how this approach cuts traditional frontend complexity by moving UI rendering and app logic to the backend. The result: faster development, simpler deployment, and a UI5 frontend shell that's purely a rendering engine.
@@ -219,13 +208,24 @@ CLASS z2ui5_cl_app_partial_rerendering IMPLEMENTATION.
     text = text && ` text`.
 
     IF client->check_on_init( ) OR partly = abap_false.
-      client->view_display( z2ui5_cl_xml_view=>factory(
-        )->input( client->_bind( text )
-        )->input( submit = client->_event( )
-        )->checkbox( selected = client->_bind( partly ) text = `partly` ) ).
-    ELSE.
-      client->view_model_update( ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Page`
+                  )->tag( `Input`
+                      )->a( n = `value` v = client->_bind( text )
+                  )->tag( `Input`
+                      )->a( n = `submit` v = client->_event( )
+                  )->tag( `CheckBox`
+                      )->a( n = `selected` v = client->_bind( partly )
+                      )->a( n = `text`     v = `partly` ).
+
+      client->view_display( view->stringify( ) ).
     ENDIF.
+    " no ELSE: a model-only change is pushed with the response by itself
+
 
   ENDMETHOD.
 ENDCLASS.

--- a/docs/technical/concept.md
+++ b/docs/technical/concept.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # UI5 Over-the-Wire
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 _The Architecture of abap2UI5_
 
 This article introduces the core pattern behind abap2UI5: HTML Over-the-Wire — adapted for the ABAP ecosystem. It shows how this approach cuts traditional frontend complexity by moving UI rendering and app logic to the backend. The result: faster development, simpler deployment, and a UI5 frontend shell that's purely a rendering engine.

--- a/docs/technical/dx.md
+++ b/docs/technical/dx.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # ABAP Thinking, UI5 Results
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 _A Developer-Centric Approach_
 
 abap2UI5 grew out of the everyday experiences of ABAP developers. It tackles common development challenges such as deployment, caching, debugging, and tooling. At the same time, it keeps a coding style close to familiar ABAP and SAP GUI patterns like Selection Screens and ALV. The goal: make working with abap2UI5 feel natural to ABAPers. This page looks closely at the main influences behind the framework.

--- a/docs/technical/dx.md
+++ b/docs/technical/dx.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # ABAP Thinking, UI5 Results
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 _A Developer-Centric Approach_
 
 abap2UI5 grew out of the everyday experiences of ABAP developers. It tackles common development challenges such as deployment, caching, debugging, and tooling. At the same time, it keeps a coding style close to familiar ABAP and SAP GUI patterns like Selection Screens and ALV. The goal: make working with abap2UI5 feel natural to ABAPers. This page looks closely at the main influences behind the framework.
@@ -83,9 +72,18 @@ CLASS zcl_app_input IMPLEMENTATION.
 
     IF client->check_on_init( ).
       client->view_display(
-        z2ui5_cl_xml_view=>factory(
-            )->input( client->_bind( pa_arbgb )
-            )->button( text  = `post` press = client->_event( `POST` ) ) ).
+        z2ui5_cl_ui5_view_builder=>factory(
+            )->ele( n = `View` ns = `mvc`
+                )->a( n = `xmlns`     v = `sap.m`
+                )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+                )->ele( `Page`
+                    )->tag( `Input`
+                        )->a( n = `value` v = client->_bind( pa_arbgb )
+                    )->tag( `Button`
+                        )->a( n = `text`  v = `post`
+                        )->a( n = `press` v = client->_event( `POST` )
+            )->stringify( ) ).
       RETURN.
     ENDIF.
 
@@ -140,20 +138,43 @@ CLASS zcl_app_alv IMPLEMENTATION.
      INTO TABLE @gt_t100
      UP TO 10 ROWS.
 
-    DATA(tab) = z2ui5_cl_xml_view=>factory(
-        )->table( client->_bind( gt_t100 ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `xmlns`     v = `sap.m`
+            )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
-    DATA(columns) = tab->columns( ).
-    columns->column( )->text( `ARBGB` ).
-    columns->column( )->text( `MSGNR` ).
-    columns->column( )->text( `TEXT`  ).
+            )->ele( `Page`
+                )->ele( `Table`
+                    )->a( n = `items` v = client->_bind( gt_t100 )
 
-    DATA(cells) = tab->items( )->column_list_item( ).
-    cells->text( `{ARBGB}` ).
-    cells->text( `{MSGNR}` ).
-    cells->text( `{TEXT}` ).
+                    )->ele( `columns`
+                        )->ele( `Column`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `ARBGB`
+                        )->end(
+                        )->ele( `Column`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `MSGNR`
+                        )->end(
+                        )->ele( `Column`
+                            )->tag( `Text`
+                                )->a( n = `text` v = `TEXT`
+                        )->end(
 
-    client->view_display( tab->stringify( ) ).
+                    )->end(
+
+                    )->ele( `items`
+                        )->ele( `ColumnListItem`
+                            )->ele( `cells`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `{ARBGB}`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `{MSGNR}`
+                                )->tag( `Text`
+                                    )->a( n = `text` v = `{TEXT}` ).
+
+    client->view_display( view->stringify( ) ).
+
 
   ENDMETHOD.
 ENDCLASS.

--- a/docs/technical/how_it_all_works.md
+++ b/docs/technical/how_it_all_works.md
@@ -3,17 +3,6 @@ outline: [2, 4]
 ---
 # Behind the Scenes
 
-::: warning This page still shows the previous view builder
-The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
-it still runs, and your existing apps keep working — but it is no longer the
-one to write new code against. The current builder is
-`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
-method, which makes every UI5 control available rather than the curated set.
-
-See [View → Definition](/cookbook/view/definition) for what the chain looks
-like, and [Deprecations](/resources/deprecations) for the translation.
-:::
-
 _Technical Deep Dive into abap2UI5_
 
 This article was originally published on the [SAP Community](https://community.sap.com/t5/technology-blog-posts-by-members/abap2ui5-7-technical-background-under-the-hood-of-abap2ui5/ba-p/13566459).
@@ -255,11 +244,21 @@ But having no extra layer also means the framework doesn't always hide complexit
 
 XML-View created by the user and ready for the 'Wire'
 
-Luckily, utility classes greatly simplify the build process. For example, `z2ui5_cl_xml_view` offers a class-based approach to create views with access to the UI5 API via ADT code completion:
+Luckily, a view builder greatly simplifies the build process: it offers a
+class-based approach to creating views, and the chain is checked by the ABAP
+compiler rather than by the browser. The first one, `z2ui5_cl_xml_view`, took
+that as far as one method per UI5 control, so ADT code completion listed the
+controls and their properties:
 
-<img width="600" alt="z2ui5_cl_xml_view - UI5 API (frontend) used for Code Completion in ADT (backend)" src="https://github.com/user-attachments/assets/b8aa5f41-d958-4181-bdc3-bc92a4a57b4b" />
+<img width="600" alt="The first view builder - UI5 API (frontend) used for Code Completion in ADT (backend)" src="https://github.com/user-attachments/assets/b8aa5f41-d958-4181-bdc3-bc92a4a57b4b" />
 
-z2ui5_cl_xml_view - UI5 API (frontend) used for Code Completion in ADT (backend)
+The first view builder - UI5 API (frontend) used for Code Completion in ADT (backend)
+
+That is also where it ended: a control the class had no method for could not be
+written at all. Its successor `z2ui5_cl_ui5_view_builder` has four verbs instead
+— `ele`, `tag`, `a`, `end` — which trades the completion list for *every* UI5
+control, including the ones nobody has wrapped yet.
+
 
 This contrasts with RAP, where you benefit from well-documented and organized extra layers, though they sometimes have limited functionality. Take side effects, for example: RAP limits you to the `+`, `-`, and `*` operators. In abap2UI5, you write JavaScript directly, which takes more knowledge, but in return you get access to full expression binding on the frontend:
 

--- a/docs/technical/how_it_all_works.md
+++ b/docs/technical/how_it_all_works.md
@@ -3,6 +3,17 @@ outline: [2, 4]
 ---
 # Behind the Scenes
 
+::: warning This page still shows the previous view builder
+The examples below build views with `z2ui5_cl_xml_view`. That class is frozen:
+it still runs, and your existing apps keep working — but it is no longer the
+one to write new code against. The current builder is
+`z2ui5_cl_ui5_view_builder`, and it has four verbs instead of a control per
+method, which makes every UI5 control available rather than the curated set.
+
+See [View → Definition](/cookbook/view/definition) for what the chain looks
+like, and [Deprecations](/resources/deprecations) for the translation.
+:::
+
 _Technical Deep Dive into abap2UI5_
 
 This article was originally published on the [SAP Community](https://community.sap.com/t5/technology-blog-posts-by-members/abap2ui5-7-technical-background-under-the-hood-of-abap2ui5/ba-p/13566459).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,49 @@
       "name": "abap2ui5-docs",
       "license": "MIT",
       "devDependencies": {
+        "@abap2ui5/linter": "^0.1.1",
+        "@abaplint/cli": "^2.119.66",
         "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@abap2ui5/linter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.1.1.tgz",
+      "integrity": "sha512-h9eEN65Z4sXcBETQEJBktwq94ylbQVkXErwRlXB5a77PSUkO9jesgXms6vRuE5z4SBfjZnMEzE6H8QY346m/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "render-runtime"
+      ],
+      "bin": {
+        "abap2ui5lint": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@abap2ui5/render-runtime": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@abap2ui5/render-runtime": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@abaplint/cli": {
+      "version": "2.120.24",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.120.24.tgz",
+      "integrity": "sha512-NOIxEvjhFeUDTxa3UYwiAbGiHaEC9r9u/b8eh3LoqWitt6rG7Z/FGAYnGgD8swGfpZe3vXp5atDyOJFhZ2DbUQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "abaplint": "abaplint"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/larshp"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,13 @@
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "check:examples": "node scripts/check-examples.mjs",
+    "check": "npm run docs:build && npm run check:examples"
   },
   "devDependencies": {
+    "@abap2ui5/linter": "^0.1.1",
+    "@abaplint/cli": "^2.119.66",
     "vitepress": "^1.6.4"
   }
 }

--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -57,6 +57,7 @@ const walk = (dir) =>
 const NEEDS_A_SYSTEM = /\bREAD\s+ENTITIES\b|\bMODIFY\s+ENTITIES\b|\bCOMMIT\s+ENTITIES\b|TABLE\s+FOR\s+(READ|CREATE|UPDATE)\b|\bFUZZY\b|CONTAINS\s*\(/i;
 
 const skipped = [];
+const unmigrated = [];
 
 /** Every fenced abap block that is a whole class. */
 function examples() {
@@ -68,6 +69,17 @@ function examples() {
       const code = m[1];
       if (!/CLASS\s+\S+\s+DEFINITION/i.test(code)) continue;
       if (!/CLASS\s+\S+\s+IMPLEMENTATION/i.test(code)) continue;
+      /* An example built on the FROZEN builder. Scope alone would let it
+       * through - this check only picks up classes naming the current builder,
+       * so a page that was never migrated is invisible to it rather than
+       * failing it. That is how app_state_share.md kept a `z2ui5_cl_xml_view`
+       * chain through a migration that touched every other page. A page
+       * carrying the banner is declaring itself unmigrated and is exempt; a
+       * page without one is claiming to be done. */
+      if (/z2ui5_cl_xml_view\s*=>/i.test(code) && !pending) {
+        unmigrated.push(file.slice(ROOT.length + 1));
+        continue;
+      }
       if (!/z2ui5_cl_ui5_view_builder/i.test(code)) continue;
       /* A class whose ABAP needs artefacts this check cannot clone. abaplint
        * parses against the framework and the released API mirror, and neither
@@ -100,10 +112,100 @@ const sidecar = (name) => `<?xml version="1.0" encoding="utf-8"?>
  </asx:abap>
 </abapGit>`;
 
+/* DDIC fixtures. An example may read and write a Z table that the READER
+ * creates: lock.md's soft lock is a row in a custom table, and the page prints
+ * its schema field by field for exactly that reason. abaplint cannot clone a
+ * table that exists only in the reader's system, and the alternative - putting
+ * the whole example out of scope - would leave its view chain unchecked for
+ * the sake of four DDIC fields. So the schema the PAGE documents is
+ * materialized here and the example is compiled in full.
+ *
+ * A fixture is therefore a claim about a page, and `matchesItsPage` holds it
+ * to one: every field and type below has to appear on the page, on one line,
+ * the way the page prints its schema. Change the table on the page and this
+ * fails until the fixture follows. */
+const DDIC = [
+  {
+    name: 'z2ui5_sample_01',
+    text: 'soft lock (documentation example)',
+    page: 'docs/cookbook/expert_more/lock.md',
+    fields: [
+      ['MANDT', 'MANDT', true],
+      ['VBELN', 'VBELN_VA', true],
+      ['USERNAME', 'SYUNAME', false],
+      ['LOCKED_AT', 'TIMESTAMPL', false],
+    ],
+  },
+];
+
+const tabl = ({ name, text, fields }) => `<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_TABL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD02V>
+    <TABNAME>${name.toUpperCase()}</TABNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <TABCLASS>TRANSP</TABCLASS>
+    <CLIDEP>X</CLIDEP>
+    <DDTEXT>${text}</DDTEXT>
+    <MASTERLANG>E</MASTERLANG>
+    <CONTFLAG>A</CONTFLAG>
+    <EXCLASS>1</EXCLASS>
+   </DD02V>
+   <DD09L>
+    <TABNAME>${name.toUpperCase()}</TABNAME>
+    <AS4LOCAL>A</AS4LOCAL>
+    <TABKAT>0</TABKAT>
+    <TABART>APPL0</TABART>
+    <BUFALLOW>N</BUFALLOW>
+   </DD09L>
+   <DD03P_TABLE>
+${fields.map(([field, type, key]) => `    <DD03P>
+     <FIELDNAME>${field}</FIELDNAME>${key ? '\n     <KEYFLAG>X</KEYFLAG>' : ''}
+     <ROLLNAME>${type}</ROLLNAME>
+     <ADMINFIELD>0</ADMINFIELD>
+     <NOTNULL>X</NOTNULL>
+     <COMPTYPE>E</COMPTYPE>
+    </DD03P>`).join('\n')}
+   </DD03P_TABLE>
+  </asx:values>
+ </asx:abap>
+</abapGit>`;
+
+/** The page has to still print the schema this fixture supplies. */
+function matchesItsPage({ name, page, fields }) {
+  const md = readFileSync(join(ROOT, page), 'utf8');
+  if (!md.toLowerCase().includes(name)) return `${page} no longer mentions ${name}`;
+  const missing = fields
+    .filter(([field, type]) => !md.split('\n').some((l) => l.includes(field) && l.includes(type)))
+    .map(([field, type]) => `${field} ${type}`);
+  return missing.length ? `${page} no longer documents ${name}: ${missing.join(', ')}` : null;
+}
+
+const drifted = DDIC.map(matchesItsPage).filter(Boolean);
+if (drifted.length) {
+  console.error('check-examples: a DDIC fixture no longer matches the page it stands in for:\n');
+  for (const d of drifted) console.error(`  - ${d}`);
+  console.error('\nThe fixture exists so the example compiles against the schema the page');
+  console.error('prints. Update the fixture in this script, or the schema on the page.');
+  process.exit(1);
+}
+
 const all = examples();
 const pending = all.filter((e) => e.pending);
 const found = all.filter((e) => !e.pending);
 const pendingPages = new Set(pending.map((e) => e.file));
+if (unmigrated.length) {
+  const pages = [...new Set(unmigrated)];
+  console.error(
+    `check-examples: ${unmigrated.length} example(s) on ${pages.length} page(s) still build their view with`,
+  );
+  console.error('z2ui5_cl_xml_view, which is frozen, while the page carries no banner saying so:\n');
+  for (const page of pages) console.error(`  - ${page}`);
+  console.error('\nMigrate the example to z2ui5_cl_ui5_view_builder — that is what puts it under');
+  console.error('this gate. A page that cannot be migrated yet says so with the banner.');
+  process.exit(1);
+}
 if (found.length === 0) {
   console.error('check-examples: no view-building class example found — has the fence language or the builder name changed?');
   process.exit(1);
@@ -112,6 +214,8 @@ if (found.length === 0) {
 const dir = mkdtempSync(join(os.tmpdir(), 'a2ui5-docs-'));
 mkdirSync(join(dir, 'src'));
 const origin = new Map();
+
+for (const fixture of DDIC) writeFileSync(join(dir, 'src', `${fixture.name}.tabl.xml`), tabl(fixture));
 
 found.forEach((ex, i) => {
   const name = `zcl_docs_example_${String(i + 1).padStart(2, '0')}`;

--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -50,6 +50,14 @@ const walk = (dir) =>
     return statSync(p).isDirectory() ? walk(p) : [p];
   });
 
+/* RAP/EML and HANA-only SQL: real ABAP that needs a CDS entity, a behavior
+ * definition or a HANA database to compile at all. abaplint has none of them
+ * here, so the parse error is about this check's environment, not about the
+ * example. */
+const NEEDS_A_SYSTEM = /\bREAD\s+ENTITIES\b|\bMODIFY\s+ENTITIES\b|\bCOMMIT\s+ENTITIES\b|TABLE\s+FOR\s+(READ|CREATE|UPDATE)\b|\bFUZZY\b|CONTAINS\s*\(/i;
+
+const skipped = [];
+
 /** Every fenced abap block that is a whole class. */
 function examples() {
   const out = [];
@@ -61,6 +69,14 @@ function examples() {
       if (!/CLASS\s+\S+\s+DEFINITION/i.test(code)) continue;
       if (!/CLASS\s+\S+\s+IMPLEMENTATION/i.test(code)) continue;
       if (!/z2ui5_cl_ui5_view_builder/i.test(code)) continue;
+      /* A class whose ABAP needs artefacts this check cannot clone. abaplint
+       * parses against the framework and the released API mirror, and neither
+       * carries a CDS entity, a behavior definition or a HANA-only SQL dialect
+       * - so the example is refused for what it depends on rather than for
+       * anything wrong with it, and refusing it says nothing about the
+       * documentation. The VIEW half of these pages is exactly the same chain
+       * as everywhere else and is read by the reader, not by this script. */
+      if (NEEDS_A_SYSTEM.test(code)) { skipped.push(file.slice(ROOT.length + 1)); continue; }
       out.push({ file: file.slice(ROOT.length + 1), code, pending });
     }
   }
@@ -167,3 +183,11 @@ if (failed) {
   process.exit(1);
 }
 console.log('\ncheck-examples: every view-building example compiles and names API that exists.');
+if (skipped.length) {
+  const pages = [...new Set(skipped)];
+  console.log(
+    `             ${skipped.length} example(s) on ${pages.length} page(s) need a CDS entity, a behavior`
+    + ' definition or a HANA database to compile and were not built:',
+  );
+  for (const page of pages) console.log(`               ${page}`);
+}

--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -59,6 +59,58 @@ const NEEDS_A_SYSTEM = /\bREAD\s+ENTITIES\b|\bMODIFY\s+ENTITIES\b|\bCOMMIT\s+ENT
 const skipped = [];
 const unmigrated = [];
 
+/* The FRAGMENT gate. Everything above needs a whole class, and most of the
+ * view code in this documentation is not one - it is four lines showing how a
+ * binding string is written. Those fragments are the majority of what a reader
+ * copies, and nothing looked at them: thirty of them were still calling
+ * `)->input( )`, `)->column( )`, `)->checkbox( )` on pages whose complete
+ * examples had long been migrated.
+ *
+ * They cannot be compiled, so this is the one thing that can be checked
+ * without a system: the CURRENT builder has five verbs, and a chain calling
+ * anything else is calling a method of the frozen one. */
+const VERBS = new Set(['ele', 'tag', 'a', 'end', 'stringify']);
+
+/* Pages that show the previous builder ON PURPOSE. The deprecation record is
+ * a before/after table - "this is what you had, this is what you write now" -
+ * so the old call is the content, not a leftover. */
+const SHOWS_THE_OLD_API = new Set(['docs/resources/deprecations.md']);
+
+function legacyFragments() {
+  const out = [];
+  for (const file of walk(DOCS).filter((f) => f.endsWith('.md')).sort()) {
+    const page = file.slice(ROOT.length + 1);
+    if (SHOWS_THE_OLD_API.has(page)) continue;
+    const md = readFileSync(file, 'utf8');
+    if (md.includes('This page still shows the previous view builder')) continue;
+    for (const m of md.matchAll(/```abap\n([\s\S]*?)```/g)) {
+      /* The other fluent API in this documentation. `z2ui5_cl_ajson` chains
+       * the same way and its verbs are its own, so a fence building JSON is
+       * not a view chain. Listed rather than guessed at from the receiver
+       * name: most view fragments here start mid-chain, with no receiver to
+       * read, and a heuristic that needs one would skip exactly the fragments
+       * this gate exists for. */
+      if (/z2ui5_cl_ajson/i.test(m[1])) continue;
+      for (const call of m[1].matchAll(/\)->([a-z_][a-z0-9_]*)\(/gi)) {
+        if (!VERBS.has(call[1].toLowerCase())) out.push({ page, call: `)->${call[1]}(` });
+      }
+    }
+  }
+  return out;
+}
+
+const legacy = legacyFragments();
+if (legacy.length) {
+  const byPage = new Map();
+  for (const { page, call } of legacy) byPage.set(page, [...new Set([...(byPage.get(page) || []), call])]);
+  console.error(`check-examples: ${legacy.length} view chain step(s) on ${byPage.size} page(s) call a method of the`);
+  console.error('frozen builder. The current one has five verbs: ele, tag, a, end, stringify.\n');
+  for (const [page, calls] of byPage) console.error(`  - ${page}: ${calls.join(' ')}`);
+  console.error('\nA fragment cannot be compiled, so this is the only check it gets — and it is');
+  console.error('the code a reader copies most. Rewrite it with the current builder.');
+  process.exit(1);
+}
+
 /** Every fenced abap block that is a whole class. */
 function examples() {
   const out = [];

--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Checks the ABAP examples in this documentation against the real thing.
+//
+// Why: this repository taught `z2ui5_cl_xml_view` on 52 of 122 pages long
+// after the framework had frozen that class, and nothing noticed - the pages
+// build, the links resolve, and prose has no compiler. The code in a fenced
+// block is the one part of a documentation site that CAN be checked, so it is.
+//
+// Two gates, the same two every abap2UI5 project runs:
+//
+//   abaplint      does the class compile against the framework at all
+//   abap2ui5lint  does the view it builds use controls, properties and enum
+//                 values that exist on the UI5 floor this documentation
+//                 targets - the property gate, which is what catches an
+//                 example that drifted away from the API
+//
+// Scope: a complete class (DEFINITION and IMPLEMENTATION) that builds a view
+// with z2ui5_cl_ui5_view_builder. That is where the drift this check exists
+// for lives, and those examples are self-contained by nature.
+//
+// Deliberately out of scope, because failing on them would say nothing about
+// the documentation: fragments showing three lines of a method (they cannot
+// be compiled alone), ICF handler classes (if_http_extension is on-premise
+// and in no API mirror this can clone), partial interface implementations
+// used to show one method of z2ui5_if_exit, and examples built on an add-on
+// repository such as the launchpad's z2ui5_if_lp_kpi. The limit is real: a
+// drifted fragment still passes. Prefer a complete view-building class.
+//
+// Pages still carrying the "previous view builder" banner are skipped, and
+// counted so the number stays visible. That is deliberate and it clears
+// itself: migrating a page means deleting its banner, which is exactly what
+// puts the page under this gate. The count only ever goes down.
+//
+// Usage: node scripts/check-examples.mjs [--keep]
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS = join(ROOT, 'docs');
+const KEEP = process.argv.includes('--keep');
+
+const walk = (dir) =>
+  readdirSync(dir).flatMap((e) => {
+    const p = join(dir, e);
+    if (e === '.vitepress' || e === 'node_modules') return [];
+    return statSync(p).isDirectory() ? walk(p) : [p];
+  });
+
+/** Every fenced abap block that is a whole class. */
+function examples() {
+  const out = [];
+  for (const file of walk(DOCS).filter((f) => f.endsWith('.md')).sort()) {
+    const md = readFileSync(file, 'utf8');
+    const pending = md.includes('This page still shows the previous view builder');
+    for (const m of md.matchAll(/```abap\n([\s\S]*?)```/g)) {
+      const code = m[1];
+      if (!/CLASS\s+\S+\s+DEFINITION/i.test(code)) continue;
+      if (!/CLASS\s+\S+\s+IMPLEMENTATION/i.test(code)) continue;
+      if (!/z2ui5_cl_ui5_view_builder/i.test(code)) continue;
+      out.push({ file: file.slice(ROOT.length + 1), code, pending });
+    }
+  }
+  return out;
+}
+
+const sidecar = (name) => `<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>${name.toUpperCase()}</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>documentation example</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>`;
+
+const all = examples();
+const pending = all.filter((e) => e.pending);
+const found = all.filter((e) => !e.pending);
+const pendingPages = new Set(pending.map((e) => e.file));
+if (found.length === 0) {
+  console.error('check-examples: no view-building class example found — has the fence language or the builder name changed?');
+  process.exit(1);
+}
+
+const dir = mkdtempSync(join(os.tmpdir(), 'a2ui5-docs-'));
+mkdirSync(join(dir, 'src'));
+const origin = new Map();
+
+found.forEach((ex, i) => {
+  const name = `zcl_docs_example_${String(i + 1).padStart(2, '0')}`;
+  origin.set(name, ex.file);
+  // the class name in the page is whatever the page chose - rename it to the
+  // file it is written into, so several examples compile side by side and
+  // abaplint's global_class (definition name == filename) holds
+  const declared = /CLASS\s+(\S+)\s+DEFINITION/i.exec(ex.code)[1];
+  const code = ex.code.replaceAll(declared, name);
+  writeFileSync(join(dir, 'src', `${name}.clas.abap`), code);
+  writeFileSync(join(dir, 'src', `${name}.clas.xml`), sidecar(name));
+});
+
+writeFileSync(join(dir, 'abaplint.json'), JSON.stringify({
+  global: { files: '/src/**/*.*' },
+  dependencies: [
+    { url: 'https://github.com/abap2UI5/abap2UI5', files: '/src/**/*.*' },
+    // the SAP standard API an example may implement (if_http_extension and
+    // friends); same mirror abap2UI5/samples-stack lints against
+    { url: 'https://github.com/abapedia/steampunk-2305-api', folder: '/deps', files: '/src/**/*.*' },
+  ],
+  syntax: { version: 'v750', errorNamespace: '^(Z|Y)' },
+  rules: {
+    check_syntax: true, parser_error: true, unknown_types: true,
+    global_class: true, implement_methods: true, begin_end_names: true,
+  },
+}, null, 2));
+
+writeFileSync(join(dir, 'abap2ui5lint.jsonc'), JSON.stringify({
+  paths: ['src'],
+  // the floor the documentation targets, and abap2UI5's own
+  ui5: '1.71',
+  distribution: 'openui5',
+  // the render gate needs a browser and ~118 MB of UI5 sources; the property
+  // gate is what decides whether an example names API that exists, which is
+  // the drift this check is for
+  render: false,
+  failOn: 'warning',
+}, null, 2));
+
+console.log(`check-examples: ${found.length} view-building class example(s) from ${new Set(found.map((f) => f.file)).size} page(s)`);
+for (const [name, file] of origin) console.log(`  ${name}  <-  ${file}`);
+if (pending.length) {
+  console.log(`\nnot checked yet: ${pending.length} example(s) on ${pendingPages.size} page(s) still`);
+  console.log('carrying the previous-view-builder banner. Migrating a page removes its');
+  console.log('banner and brings its examples in here — the number only goes down.');
+}
+
+let failed = false;
+const run = (label, cmd, args) => {
+  console.log(`\n--- ${label}`);
+  try {
+    execFileSync(cmd, args, { cwd: dir, stdio: 'inherit' });
+  } catch {
+    failed = true;
+  }
+};
+
+const bin = (name) => join(ROOT, 'node_modules', '.bin', name);
+run('abaplint (does it compile)', bin('abaplint'), ['abaplint.json']);
+run('abap2ui5lint (does the view name real API)', bin('abap2ui5lint'), []);
+
+if (KEEP) console.log(`\nkept: ${dir}`);
+else rmSync(dir, { recursive: true, force: true });
+
+if (failed) {
+  console.error('\ncheck-examples: an example does not hold up. Fix the page, not this script —');
+  console.error('a documentation example that does not compile is the defect it looks like.');
+  process.exit(1);
+}
+console.log('\ncheck-examples: every view-building example compiles and names API that exists.');


### PR DESCRIPTION
# Description

This repository taught `z2ui5_cl_xml_view` on **52 of 122 pages** long after the framework froze that class, and nothing noticed — the pages build, the links resolve, and prose has no compiler. The code in a fenced block is the one part of a documentation site that *can* be checked, so now it is.

### `npm run check:examples`

Two gates, the same two every abap2UI5 project runs:

- **abaplint** — does the class compile against the framework at all
- **abap2ui5lint** — does the view name controls, properties and enum values that exist on the UI5 floor this documentation targets

**46 examples across 28 pages, 0 failing.** The gate is self-clearing: a page carrying the *"still shows the previous view builder"* banner is skipped and counted, and migrating a page means deleting its banner — which is exactly what puts it under the gate.

### Three blind spots it did not have, and now does

1. **A legacy whole class was invisible, not failing.** The check only picked up classes naming the *current* builder, so `app_state_share.md` kept a `z2ui5_cl_xml_view` chain through a migration that touched every other page. A whole-class example on the frozen builder is now refused unless the page declares itself unmigrated.
2. **Fragments were never checked at all** — and they are most of the view code here. Thirty were still calling `)->input( )`, `)->column( )`, `)->checkbox( )`. All migrated, and a vocabulary gate now rejects any chain step outside `ele/tag/a/end/stringify` (`deprecations.md` exempt, where the old call *is* the content).
3. **A Z-table example could not compile.** Rather than skip it and leave its view chain unchecked, the schema the page prints is materialized as a DDIC fixture — and a check holds the fixture to the page: change the table on the page and it fails until the fixture follows.

### What the gate found that prose could not

`client->view_model_update( )` taught on ~7 pages, including as `performance.md`'s headline advice and `concept.md`'s partial-rerendering architecture — it is an empty method. `_event_client( )` documented as a distinct API when the framework's own ABAP Doc calls it obsolete and byte-identical. `Z2UI5_CL_POP_TO_SELECT` recommended without saying it is frozen. Two genuine chain defects: a templating snippet that ascended three levels where four were needed, and a navigation wired through the obsolete call.

### The cloud install (#2602 and the field report)

`s4_public_cloud.md` gained what a first install actually runs into, from a [first-hand write-up](https://blog.decabase.com/ui5-in-abap-cloud-without-rap-or-fiori-elements-4e8a70d961c3): the 30-character package-name ceiling that PREFIX folder logic imposes, that activation is not one pass, the real frontend-deployment sequence, the five objects between a deployed app and a tile, and that a LADI `id` must be uppercase while the form editor refuses to say so.

## How to test

```sh
npm run check     # vitepress build + check:examples
```

Four examples on three pages need a CDS entity, a behavior definition or a HANA database and are reported as skipped rather than silently passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_