### PR TITLE
Put the logo page in a sidebar, since one existed and nothing linked it

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -417,6 +417,12 @@ export default defineConfig({
           { text: "Contact", link: "/resources/contact" },
           { text: "Contribution", link: "/resources/contribution" },
           { text: "Sponsor", link: "/resources/sponsor" },
+          // The logo, the favicon and the cover image, for anyone writing
+          // about abap2UI5. The page existed and no sidebar linked it, so the
+          // only way in was knowing the URL - which nobody looking for a logo
+          // does. Found by scripts/generate-llms.mjs, which reports a page in
+          // the tree that no sidebar navigates to.
+          { text: "Logo, Press Kit", link: "/resources/logo" },
         ],
       },
     ],


### PR DESCRIPTION
`/resources/logo` holds the logo, the logo on white, the favicon and the cover image — the things somebody writing about abap2UI5 comes looking for. **No sidebar linked it**, so the only way in was already knowing the URL, which nobody looking for a logo does.

Found by `scripts/generate-llms.mjs`, which reports a page in the tree that no sidebar navigates to rather than silently publishing it. That report now comes back empty, which is the state it is meant to describe: **122 pages, all reachable**, and the *Other pages* fallback section in `llms.txt` is gone.

## One thing worth recording

The first attempt landed in the **nav bar** instead of the sidebar. The two `Contribution` / `Sponsor` lines are byte-identical in both structures, and a replace-first put it in the wrong one — the page stayed orphaned and the generator kept saying so.

Caught by asserting against the **built config** (`themeConfig.sidebar` contains the link, `themeConfig.nav` does not) rather than by grepping the file. Grepping would have said yes to both.

## Verification

- `npm run docs:build` → clean
- `node scripts/generate-llms.mjs` → 122 pages, no orphan reported
- `npm run check:samples` → exit 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_