### PR TITLE
Say the release that exists, and gate it so the next one is not missed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,8 +41,17 @@ jobs:
           cache: 'npm'
       - run: npm ci
 
+      # the release number in the nav bar, the deprecations page and the
+      # changelog, against the newest release tag of the framework. This one
+      # goes stale WITHOUT anybody touching this repository - a release happens
+      # over there - which is why it runs first: it is the check most likely to
+      # be true yesterday and false today.
+      - name: release version
+        run: npm run check:version
+
       # a page that does not build is a page nobody can read
       - name: vitepress build
+        if: ${{ !cancelled() }}
         run: npm run docs:build
 
       # the ABAP in the fenced blocks, against the real framework: does it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `scripts/check-examples.mjs` | Extracts every fenced ABAP block that builds a view, compiles it against the real framework and lints the view it produces |
 | `scripts/link-samples.mjs` | Generates the *Working Samples* block on a page from its `samples:` frontmatter plus `SAMPLES.md` in an `abap2UI5/samples` checkout, and checks the link in both directions |
 | `scripts/generate-llms.mjs` | Builds `llms.txt` / `llms-full.txt` / per-page markdown from the sidebar. Runs inside `docs:build`, so the deploy publishes them |
+| `scripts/check-version.mjs` | The release number in the nav bar, the deprecations page and the changelog, against the newest release tag of the framework |
 
 ## Build & verify — run before every commit
 
@@ -47,6 +48,19 @@ explicitly for this reason.
   the `IF` branch on each, and the prose on several pages walks through the code
   as it stands — that is R-6, worked across the whole organisation. The entry
   says so and names the condition for removing it.
+- **The release number lives in three hand-maintained places, and a release
+  happens in another repository.** The nav bar in `config.mjs`, the *Version
+  status* sentence in `deprecations.md` and the newest `###` heading in
+  `changelog.md`. `check:version` holds them to each other and to the newest
+  release tag. It exists because 1.143.0 shipped at 12:20 and for the rest of
+  that day the deprecations page said "Not in 1.142.0 — `z2ui5_cl_ui5_view_builder`
+  arrives with the next release": the page a reader opens to ask whether they
+  may use the current builder told them no, hours after it shipped. When you
+  move the number, **read the prose around it** — a sentence like "arrives with
+  the next release" goes stale with it and no gate can see that.
+  Note `releases/latest` answers `1.143.0-702` much of the time: the framework
+  publishes the 7.02 downport minutes after each release. Same version, second
+  distribution — the script strips the suffix.
 - **`llms.txt` is generated from the SIDEBAR, not from a directory walk.** A
   page in no sidebar is reported as an orphan and published anyway. If you add
   a page, add it to the sidebar or accept that nothing navigates to it.

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -91,7 +91,7 @@ export default defineConfig({
       {
         // the released framework version — z2ui5_if_app=>version in
         // abap2UI5/src/02/z2ui5_if_app.intf.abap is where it comes from
-        text: "1.142.0",
+        text: "1.143.0",
         items: [
           { text: "Release", link: "/resources/changelog" },
           { text: "Support", link: "/resources/support" },

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -6,6 +6,37 @@ outline: [2, 4]
 See [Deprecations](/resources/deprecations) for what is superseded but still
 shipping, and for the full removal list with migration notes.
 
+### 1.143.0
+2026-08-16
+- Added `z2ui5_cl_ui5_view_builder`, the view builder this documentation is written against: `factory( )` / `ele( )` / `tag( )` / `a( )` / `end( )` / `stringify( )`, with every UI5 control and property reachable because the builder knows none of them by name. `z2ui5_cl_xml_view` is frozen, not removed — it ships unchanged and keeps working
+- The model is pushed **automatically** when an event roundtrip changed it. The framework compares the model before and after `main( )` and sends it to every open view slot when it differs, so a handler can no longer render stale by forgetting a call. An unchanged model sends no payload at all
+- Error output: a 500 now carries the full diagnostic — the message chain, one block per exception (class, text, source position, kernel error id, public attributes) and the app / event / draft / url / system context. The error popup shows the messages only, with the detail one click away behind *Details* and in *Copy*
+- The HTTP handler asks ICF to gzip its responses where the client accepts it — 70–85% less transfer on installations whose ICM profile does not compress already
+- Added `_bind( json = abap_true )`: a bound string that already contains JSON is spliced into the model as a JSON node, for control properties that must receive an object (a `sap.ui.integration` Card manifest, whose keys are not valid ABAP field names)
+- Control-valued event arguments now reach the backend as data — `ViewSettingsDialog.confirm`, `SinglePlanningCalendar.selectedDatesChange` and the like used to break serialization entirely
+- Added `setP13nData` to `CONTROL_METHODS`, so seeding a `sap.m.p13n` panel no longer needs hand-written JavaScript
+- `message_toast_display( )` / `message_box_display( )` queue follow-up actions: several calls in one roundtrip all show, in call order, after the view rendered
+- The startup page was rebuilt — the five quickstart steps top to bottom, then one row per sample repository with its install status, and the system information as a popup
+- Developer Tools: the POPUP/POPOVER tabs now follow a dialog closed without a roundtrip; empty tabs grey out instead of opening blank; the NEST/NEST2 and System tabs are gone
+- The wire got leaner throughout (internal): action lists travel as real JSON arrays, session-constant browser data travels once per page load, a display action implies the slot teardown, and the routing mode is only re-sent when the frontend may not hold it
+- Fixes: a pending backend timer no longer fires into a destroyed controller; an app switch clears the previous app's keyboard shortcuts; a nested view re-displayed without its MAIN view gets the model too; `cc/Storage` compares by value, so a structure can be stored and read back; the `MessageToast` `Popup.Dock` warning is gone; the default CSP no longer names `frame-ancestors` in the `<meta>` tag
+- `src/99` test classes are back in CI: all 27 restored, the two disabled `xml_view` suites re-enabled, and the freeze now covers production code only
+
+**Obsolete — still compiles, still works**
+- `view_model_update( )`, `popup_model_update( )`, `popover_model_update( )` and the two nested variants now do **nothing**. The push is automatic; delete the calls when you next touch the app
+- `_event_client( )` → `follow_up_action( )`, which is the same call in the same position
+- `_bind( custom_mapper = … custom_filter = … )` → `omit_initial` / `omit_initial_paths` / `json`, or shape it in ABAP
+- `cs_event-wizard_set_next_step` → two `control_by_id` calls, which additionally reach `goToStep`
+
+**Removed**
+- `set_nav_back( )` and `set_nav_routing( )` from `z2ui5_if_client`. Routing is `follow_up_action( val = cs_event-set_nav_routing t_arg = ( mode ) )` now; `set_push_state( )` and `set_app_state_active( )` stay and delegate to the events
+- `cs_event-nav_to_route` → `nav_app_call( )`, which is the real navigation and pushes the same route history entry when routing is on
+- `cs_event-history_back` → `follow_up_action( |history.back()| )`, or `nav_app_leave( )` to return through the app stack
+- `VIEWNAME` from `z2ui5_if_types=>ty_s_get`. The framework never filled it — an app reading `client->get( )-viewname` has to drop the read
+- `z2ui5_if_app~check_sticky` / `check_initialized` moved to the framework's own app wrapper. Both attributes stay and are kept in sync, so a **read** still sees the truth; a direct **write** is no longer honored — use `set_session_stateful( )` and `check_on_init( )`
+- Curated formatter: `round2DP`, `dimensions`, `stockStatusState`, `stockStatusIcon`, `deliveryStatusState`. Rounding, joining and status-to-`ValueState` mapping are things ABAP finishes — bind the result. The date helpers and `expandInlineIcons` remain
+- `render_documentation( )`, `render_system_popup( )` and `render_contribution( )` from `z2ui5_cl_ui5_app_start`, with `cs_event-open_info`, `cs_event-close` and `cs_event-open_debug` — internals of the framework's own start page
+
 ### 1.142.0
 2026-07-20
 - Added frontend action functions: `control_by_id`, `binding_call`

--- a/docs/resources/deprecations.md
+++ b/docs/resources/deprecations.md
@@ -35,26 +35,26 @@ What it cannot decide it leaves alone and reports, so a run is safe to repeat.
 
 ## Version status
 
-The released version is **1.142.0**. Entries marked *next release* are already
+The released version is **1.143.0**. Entries marked *next release* are already
 on `main` but not in a release yet — they matter if you pull `main`, and they
 tell you what is coming if you do not.
 
 | What you have | What to write | Status |
 |---|---|---|
-| `view_model_update( )` and its four variants | delete the call | next release |
-| `_event_client( )` | `follow_up_action( )` | next release |
+| `view_model_update( )` and its four variants | delete the call | 1.143.0 |
+| `_event_client( )` | `follow_up_action( )` | 1.143.0 |
 | `_bind_edit( )` | `_bind( )` | 1.142.0 |
-| `_bind( custom_mapper = … custom_filter = … )` | `omit_initial` / `omit_initial_paths` / `json`, or shape it in ABAP | next release |
+| `_bind( custom_mapper = … custom_filter = … )` | `omit_initial` / `omit_initial_paths` / `json`, or shape it in ABAP | 1.143.0 |
 | `_bind( view = … )` | omit the parameter | 1.142.0 |
-| `z2ui5_if_app~check_sticky` / `check_initialized` | `set_session_stateful( )` / `check_on_init( )` | **removed**, next release |
-| `set_nav_back( )` / `set_nav_routing( )` | `follow_up_action( )` | **removed**, next release |
-| `cs_event-nav_to_route` | `nav_app_call( )` | **removed**, next release |
-| `cs_event-history_back` | `nav_app_leave( )` or a raw expression | **removed**, next release |
-| `client->get( )-viewname` | delete the read | **removed**, next release |
-| `Formatter.round2DP` and four siblings | compute it in ABAP | **removed**, next release |
+| `z2ui5_if_app~check_sticky` / `check_initialized` | `set_session_stateful( )` / `check_on_init( )` | **removed**, 1.143.0 |
+| `set_nav_back( )` / `set_nav_routing( )` | `follow_up_action( )` | **removed**, 1.143.0 |
+| `cs_event-nav_to_route` | `nav_app_call( )` | **removed**, 1.143.0 |
+| `cs_event-history_back` | `nav_app_leave( )` or a raw expression | **removed**, 1.143.0 |
+| `client->get( )-viewname` | delete the read | **removed**, 1.143.0 |
+| `Formatter.round2DP` and four siblings | compute it in ABAP | **removed**, 1.143.0 |
 | `z2ui5_cl_util_api*`, `z2ui5_cl_pop_bal` | `z2ui5_cl_util` / `z2ui5_cl_util_ext` | **removed**, 1.142.0 |
-| `cs_event-wizard_set_next_step` | two `control_by_id` calls | next release |
-| `z2ui5_cl_xml_view` | `z2ui5_cl_ui5_view_builder` | next release |
+| `cs_event-wizard_set_next_step` | two `control_by_id` calls | 1.143.0 |
+| `z2ui5_cl_xml_view` | `z2ui5_cl_ui5_view_builder` | 1.143.0 |
 | built-in popups | the [popups add-on](https://github.com/abap2UI5-addons/popups) | 1.142.0 |
 | `z2ui5.Util` | `z2ui5.Formatter` | 1.142.0 |
 
@@ -268,11 +268,16 @@ attribute on the element it follows, `end( )` ascends. One rule carries the
 whole builder — `a( )` applies to the element the chain is **pointing at** — so
 give an element its attributes before its first child.
 
-::: warning Not in 1.142.0
-`z2ui5_cl_ui5_view_builder` arrives with the next release. On 1.142.0 the typed
-builder is what you have, and it is not going anywhere: `z2ui5_cl_xml_view` and
-`z2ui5_cl_xml_view_cc` are frozen but ship unchanged, so a working view never
-has to be rewritten. Most cookbook pages are still written against them.
+::: tip Released in 1.143.0 — and nothing you have has to be rewritten
+`z2ui5_cl_ui5_view_builder` ships in 1.143.0, and this documentation is written
+against it throughout. `z2ui5_cl_xml_view` and `z2ui5_cl_xml_view_cc` are
+**frozen, not removed**: they ship unchanged and keep working, so a view that
+works today never has to be touched. Frozen means no new controls and no new
+properties — write the current builder for anything new, and migrate an old
+view when you are editing it anyway rather than for its own sake.
+
+On 1.142.0 or older the typed builder is what you have; the chain above needs
+1.143.0.
 :::
 
 ::: tip It was called `z2ui5_cl_ai_xml` for a while

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "check:examples": "node scripts/check-examples.mjs",
     "link:samples": "node scripts/link-samples.mjs",
     "check:samples": "node scripts/link-samples.mjs --check",
-    "check": "npm run docs:build && npm run check:examples && npm run check:samples",
-    "llms": "node scripts/generate-llms.mjs"
+    "check": "npm run check:version && npm run docs:build && npm run check:examples && npm run check:samples",
+    "llms": "node scripts/generate-llms.mjs",
+    "check:version": "node scripts/check-version.mjs"
   },
   "devDependencies": {
     "@abap2ui5/linter": "^0.2.0",

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/*
+ * check-version — the release number this documentation names has to be the
+ * release that exists.
+ *
+ * What this was written for, on the day it was written: abap2UI5 1.143.0 was
+ * published at 12:20, and for the rest of that day the documentation said the
+ * released version was 1.142.0 - in the navigation bar, in the deprecations
+ * page, and by omission in the changelog. Worse than the number: the
+ * deprecations page carried a warning box reading "Not in 1.142.0 -
+ * z2ui5_cl_ui5_view_builder arrives with the next release", so the page a
+ * reader opens to find out whether they may use the current view builder told
+ * them no, hours after it shipped.
+ *
+ * Nothing was broken to make that happen. The number simply lives in three
+ * hand-maintained places here and moves in a different repository, and prose
+ * has no compiler. Which is the whole argument for a gate: the release is a
+ * FACT about another repository, and a fact can be checked.
+ *
+ * Three places, and they must agree with each other and with the newest
+ * release tag of abap2UI5/abap2UI5:
+ *
+ *   docs/.vitepress/config.mjs    the version in the nav bar
+ *   docs/resources/deprecations.md   "The released version is **x.y.z**"
+ *   docs/resources/changelog.md      the topmost "### x.y.z" heading
+ *
+ * The tag is fetched over the network. When that fails - offline, rate limit,
+ * a sandbox with no route to github.com - the three are still checked against
+ * EACH OTHER and the run says clearly that the outside half did not happen.
+ * A documentation build should not go red because GitHub is unreachable, and
+ * it should not quietly claim to have verified something it did not.
+ *
+ *   node scripts/check-version.mjs        (npm run check:version)
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const API = 'https://api.github.com/repos/abap2UI5/abap2UI5/releases/latest';
+
+/* The framework publishes each release twice: `1.143.0` and, minutes later,
+ * `1.143.0-702` - the same code downported for NetWeaver 7.02, shipped as its
+ * own repository. So `releases/latest` answers `1.143.0-702` for most of the
+ * time after a release, and it is not a different version: it is the same
+ * version of a second distribution, and the documentation names the version.
+ *
+ * Found by running this gate rather than by reasoning about it - the first run
+ * against the real API failed on a repository that had just been corrected. */
+const versionOf = (tag) => tag.replace(/-\w+$/, '');
+
+/** Where the version is written, and how to find it in each file. */
+const SITES = [
+  {
+    file: 'docs/.vitepress/config.mjs',
+    what: 'the version in the nav bar',
+    re: /text:\s*"(\d+\.\d+\.\d+)"/,
+  },
+  {
+    file: 'docs/resources/deprecations.md',
+    what: 'the "Version status" sentence',
+    re: /The released version is \*\*(\d+\.\d+\.\d+)\*\*/,
+  },
+  {
+    file: 'docs/resources/changelog.md',
+    what: 'the newest release heading',
+    re: /^###\s+(\d+\.\d+\.\d+)\s*$/m,
+  },
+];
+
+const problems = [];
+const found = [];
+
+for (const site of SITES) {
+  const full = path.join(ROOT, site.file);
+  if (!fs.existsSync(full)) {
+    problems.push(`${site.file}: gone — this gate names it as one of the places the version lives`);
+    continue;
+  }
+  const m = site.re.exec(fs.readFileSync(full, 'utf8'));
+  if (!m) {
+    problems.push(
+      `${site.file}: no version found where ${site.what} should be\n`
+      + '    the file changed shape — fix the pattern in scripts/check-version.mjs,\n'
+      + '    or this gate silently stops checking that place',
+    );
+    continue;
+  }
+  found.push({ ...site, version: m[1] });
+}
+
+/* Half the check needs no network: three places naming three different
+ * versions is wrong whatever the tag says. */
+const distinct = [...new Set(found.map((f) => f.version))];
+if (distinct.length > 1) {
+  problems.push(
+    `the three places disagree: ${distinct.join(' / ')}\n`
+    + found.map((f) => `      ${f.version}  ${f.file} (${f.what})`).join('\n'),
+  );
+}
+
+/* And the half that does. */
+let tag = null;
+let latest = null;
+let why = '';
+try {
+  const res = await fetch(API, {
+    headers: { accept: 'application/vnd.github+json', 'user-agent': 'abap2ui5-docs-check-version' },
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  tag = (await res.json()).tag_name;
+  latest = versionOf(tag);
+} catch (err) {
+  why = err.message;
+}
+
+if (latest) {
+  for (const f of found) {
+    if (f.version !== latest) {
+      problems.push(
+        `${f.file}: ${f.what} says ${f.version}, the newest release is ${latest}`,
+      );
+    }
+  }
+}
+
+console.log(`check-version: ${found.length} place(s) name a version`);
+for (const f of found) console.log(`  ${f.version}  ${f.file} — ${f.what}`);
+console.log(
+  latest
+    ? `newest release of abap2UI5/abap2UI5: ${latest}`
+      + (tag === latest ? '' : `  (tag ${tag} — the 7.02 downport of the same version)`)
+    : `could NOT reach the release API (${why}) — the three places were checked\n`
+      + '  against each other only. Whether they match the actual release is UNVERIFIED.',
+);
+
+if (problems.length) {
+  console.error(`\n${problems.length} problem(s):`);
+  for (const p of problems) console.error(`  ${p}`);
+  console.error('\nA release moves in another repository and nothing here moves with it.');
+  console.error('Update all three places together — and read the pages around them: a');
+  console.error('sentence like "arrives with the next release" goes stale with the number.');
+  process.exit(1);
+}
+console.log('the documentation names the release that exists - OK');


### PR DESCRIPTION
abap2UI5 **1.143.0** was published at 12:20 today. For the rest of the day this documentation said the released version was 1.142.0 — in the nav bar, in the deprecations page, and by omission in the changelog.

The number is the small half. The deprecations page carried:

```
::: warning Not in 1.142.0
z2ui5_cl_ui5_view_builder arrives with the next release.
```

So the page a reader opens to find out **whether they may use the current view builder** told them no, hours after it shipped.

The same box also said *"Most cookbook pages are still written against them"*, which stopped being true when P1-A and P2-A migrated the pages. Measured: exactly **three** pages name the frozen class at all, and none is an unmigrated cookbook page — the history page, the migration table itself, and `custom_control.md`, which legitimately points at `z2ui5_cl_xml_view_cc`.

### What changed

- The nav bar, the *Version status* sentence and the changelog say **1.143.0**.
- Every deprecations row marked *next release* now says 1.143.0 — **verified row by row against the tag**, not assumed: `check_initialized`, `set_nav_back`, `set_nav_routing`, `nav_to_route`, `history_back` and `viewname` are gone from `1.143.0/src/02`, while `view_model_update`, `_event_client` and `_bind_edit` are present and carry their obsolete note in the interface.
- The warning box became a tip: the builder is released, the frozen classes ship unchanged so no working view has to be rewritten, and what frozen actually costs (no new controls, no new properties).
- A 1.143.0 changelog entry — the automatic model push, the view builder, the full error diagnostic, response compression, `_bind( json = )`, control-valued event arguments, plus the obsolete and removed lists.

### The gate

None of this was anybody's mistake. The number lives in three hand-maintained places here and moves in **another repository**, and prose has no compiler.

`npm run check:version` holds the three to each other and to the newest release tag of abap2UI5/abap2UI5. It runs first in CI — it is the check most likely to have been true yesterday and false today.

**It found a defect in itself on its first run against the real API**, which is the argument for running a gate rather than reasoning about one: `releases/latest` answers `1.143.0-702` for most of the time after a release, because the 7.02 downport is published minutes later. Same version, second distribution — the suffix is stripped, and the run prints the raw tag when it differs so nobody has to wonder.

Offline the three are still checked against each other, and the run says plainly that the outside half did not happen. A documentation build should not go red because GitHub is unreachable, and it should not claim to have verified something it did not.

### Verified

| | |
|---|---|
| stale entry, real API | fails, naming the file and both versions |
| corrected, real API | `the documentation names the release that exists - OK` |
| offline | passes on mutual consistency, prints `UNVERIFIED` |
| `npm run check` | version + build + examples + sample links, all green |

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_