### PR TITLE
Keep the callout boxes narrow, and give the outline its spacing back

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -184,9 +184,39 @@
 /* An outline entry that is too long now wraps rather than being cut. The
  * default is `white-space: nowrap` + `text-overflow: ellipsis`, which keeps
  * every entry one line tall at the price of not saying what it points at.
- * Line height comes down a little so a wrapped entry reads as one item. */
+ *
+ * The spacing needs care, and the obvious version was wrong. The default is
+ * `line-height: 32px` on a 14px font - generous, because it doubles as the gap
+ * BETWEEN entries. The first attempt here dropped it to 20px so the two lines
+ * of a wrapped entry would read as one item, which they did - and every
+ * single-line entry lost a third of its breathing room, so the list read as a
+ * cramped block.
+ *
+ * Splitting the two jobs fixes both: 24px carries the line, 4px of padding
+ * above and below carries the gap. A single-line entry still occupies 32px,
+ * exactly as before; a wrapped one keeps its two lines close together and
+ * still stands apart from its neighbours. Padding is set per side rather than
+ * as a shorthand - `.outline-link.nested` sets `padding-left: 13px` for the
+ * indent, and a shorthand would quietly flatten it. */
 .VPDocOutlineItem a.outline-link {
   white-space: normal;
   text-overflow: clip;
-  line-height: 20px;
+  line-height: 24px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+/* ------------------------------------------------- the callout boxes ---
+ *
+ * The tip/warning/info blocks keep the width the reading column had BEFORE it
+ * was widened. A callout is an aside - a paragraph or two, set apart - and the
+ * wider it gets the less it reads as one: at 830px a three-line note becomes a
+ * two-line slab that competes with the prose it interrupts. Prose and code got
+ * the extra width because they use it; a callout does not.
+ *
+ * 688px is not a round number picked to look tidy: it is exactly what the
+ * reading column was, so these boxes are unchanged from what they were rather
+ * than newly narrowed. */
+.vp-doc .custom-block {
+  max-width: 688px;
 }


### PR DESCRIPTION
Two corrections to #143, both visible on a rendered page and neither visible in the diff that caused them. One file, `docs/.vitepress/theme/style.css`.

### The callout boxes had followed the reading column out to 830px

A callout is an aside — a paragraph or two, set apart — and the wider it gets the less it reads as one: at 830px a three-line note becomes a two-line slab that competes with the prose it interrupts.

Back at **688px**, which is not a round number chosen to look tidy but exactly what the reading column was, so the boxes are **unchanged** rather than newly narrowed. Prose and code keep the extra width, because they use it.

### The outline spacing was my own damage

The default is `line-height: 32px` on a 14px font — generous, because it doubles as the gap **between** entries. Making long entries wrap, #143 dropped it to 20px so a wrapped entry's two lines would read as one item. They did, and every single-line entry lost a third of its breathing room, so the list read as a cramped block.

Splitting the two jobs fixes both: **24px carries the line, 4px of padding above and below carries the gap.**

| | text | callout | one-line outline entry | truncated |
|---|---|---|---|---|
| before #143 | 688px | 688px | 32px | 1 of 5 |
| after #143 | 830px | 830px | **20px** | 0 of 5 |
| now | 830px | **688px** | **32px** | 0 of 5 |

A single-line entry is 32px tall again — the default, exactly — while a wrapped entry keeps its lines close and still stands apart from its neighbours.

The padding is set per side rather than as a shorthand: `.outline-link.nested` carries `padding-left: 13px` for the indent, and a shorthand would quietly flatten the nesting.

Measured on `cookbook/event_navigation/routing` at 1680px, on top of current `main` (including the Dependabot action bumps from #141). `npm run check` is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_