### PR TITLE
A details block is content, not commentary — give it the full width

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -208,15 +208,24 @@
 
 /* ------------------------------------------------- the callout boxes ---
  *
- * The tip/warning/info blocks keep the width the reading column had BEFORE it
- * was widened. A callout is an aside - a paragraph or two, set apart - and the
- * wider it gets the less it reads as one: at 830px a three-line note becomes a
- * two-line slab that competes with the prose it interrupts. Prose and code got
- * the extra width because they use it; a callout does not.
+ * The tip/warning/danger blocks keep the width the reading column had BEFORE
+ * it was widened. A callout is an aside - a paragraph or two, set apart - and
+ * the wider it gets the less it reads as one: at 830px a three-line note
+ * becomes a two-line slab that competes with the prose it interrupts. Prose
+ * and code got the extra width because they use it; a callout does not.
  *
  * 688px is not a round number picked to look tidy: it is exactly what the
  * reading column was, so these boxes are unchanged from what they were rather
- * than newly narrowed. */
-.vp-doc .custom-block {
+ * than newly narrowed.
+ *
+ * `::: details` is excluded, and the exclusion is the whole point of writing
+ * `:not(.details)` rather than listing the three types. VitePress gives both
+ * the same `custom-block` class, but they are opposite things: a callout holds
+ * a REMARK about the text, a details block holds CONTENT the reader opened on
+ * purpose - a screenshot, a long listing, the ABAP Cloud variant of a setup
+ * step. Capping that at 688px put a narrow box under a full-width screenshot
+ * on the quickstart page, which is where this was noticed. Content follows the
+ * reading column; commentary does not. */
+.vp-doc .custom-block:not(.details) {
   max-width: 688px;
 }


### PR DESCRIPTION
Capping the callout boxes at the old reading width caught `::: details` too, because VitePress gives both the same `custom-block` class.

They are opposite things. A **callout** holds a *remark about* the text — it should stay narrow, so it reads as an aside rather than competing with the prose it interrupts. A **details block** holds *content the reader opened on purpose*: a screenshot, a long listing, the ABAP Cloud variant of a setup step.

On the quickstart page that produced a 688px box directly under an 830px screenshot, which is where it was noticed.

`:not(.details)` rather than listing `tip`/`warning`/`danger`, so a block type added later lands on the side that matches what it is: content follows the reading column, commentary does not.

Measured on that page at 1680px:

| | content | `::: details` | callouts |
|---|---|---|---|
| before | 830px | **688px** | 688px |
| after | 830px | **830px** | 688px |

`npm run check` is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_