### PR TITLE
Take the shorter dispatcher through the documentation

### DIFF
--- a/docs/configuration/ui5_versions.md
+++ b/docs/configuration/ui5_versions.md
@@ -37,7 +37,7 @@ DATA(theme)           = ui5-theme.             " e.g. `sap_horizon`
 The `gav` (group–artifact–version) field tells you which UI5 distribution is loaded: SAPUI5 ships the `com.sap.ui5` modules, OpenUI5 does not. Checking whether `gav` contains `com.sap.ui5` is the same logic the framework itself uses internally to detect the distribution. No custom control and no extra roundtrip are needed — the info is part of every request, so it already works in `check_on_init( )`:
 
 ```abap
-IF client->check_on_init( ) OR client->check_on_navigated( ).
+IF client->check_on_navigated( ).
 
   DATA(ui5) = client->get( )-s_ui5.
 

--- a/docs/cookbook/browser_interaction/focus.md
+++ b/docs/cookbook/browser_interaction/focus.md
@@ -34,7 +34,7 @@ After processing an event, call `client->follow_up_action( )` with `cs_event-set
 ```abap
 METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`
               )->a( n = `xmlns`      v = `sap.m`

--- a/docs/cookbook/browser_interaction/keyboard_shortcuts.md
+++ b/docs/cookbook/browser_interaction/keyboard_shortcuts.md
@@ -14,7 +14,7 @@ The `keyboard_shortcut` frontend event binds a key combination to a **named back
 ```abap
 METHOD z2ui5_if_app~main.
 
-  IF client->check_on_init( ) OR client->check_on_navigated( ).
+  IF client->check_on_navigated( ).
 
     client->follow_up_action( val   = client->cs_event-keyboard_shortcut
                               t_arg = VALUE #( ( `Ctrl+S` )

--- a/docs/cookbook/browser_interaction/scrolling.md
+++ b/docs/cookbook/browser_interaction/scrolling.md
@@ -42,7 +42,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_scrolling IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`
               )->a( n = `xmlns`     v = `sap.m`

--- a/docs/cookbook/browser_interaction/soft_keyboard.md
+++ b/docs/cookbook/browser_interaction/soft_keyboard.md
@@ -16,7 +16,7 @@ METHOD z2ui5_if_app~main.
 
     DATA input TYPE string.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/docs/cookbook/device_capabilities/audio.md
+++ b/docs/cookbook/device_capabilities/audio.md
@@ -21,7 +21,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_sound IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/docs/cookbook/device_capabilities/barcode_scanning.md
+++ b/docs/cookbook/device_capabilities/barcode_scanning.md
@@ -69,7 +69,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_focus IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`
@@ -126,7 +126,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_sound IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/docs/cookbook/device_capabilities/camera.md
+++ b/docs/cookbook/device_capabilities/camera.md
@@ -20,7 +20,7 @@ ENDCLASS.
 CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`
               )->a( n = `xmlns`       v = `sap.m`

--- a/docs/cookbook/eml_cds_sql/abap_sql.md
+++ b/docs/cookbook/eml_cds_sql/abap_sql.md
@@ -20,7 +20,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_sql IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       SELECT FROM sflight
         FIELDS carrid, connid, fldate, price, currency
@@ -82,7 +82,7 @@ ENDCLASS.
 
 Bind the search term with `_bind( )` and re-run the `SELECT` on every `SEARCH` event:
 ```abap
-IF client->check_on_init( ) OR client->check_on_navigated( ).
+IF client->check_on_navigated( ).
 
   load_data( ).
   render( ).

--- a/docs/cookbook/eml_cds_sql/cds.md
+++ b/docs/cookbook/eml_cds_sql/cds.md
@@ -19,7 +19,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_cds IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       SELECT FROM I_SalesOrder
        FIELDS salesorder, salesordertype, salesorganization

--- a/docs/cookbook/eml_cds_sql/draft_handling.md
+++ b/docs/cookbook/eml_cds_sql/draft_handling.md
@@ -156,7 +156,7 @@ CLASS z2ui5_cl_sample_draft_min IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
     me->client = client.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       " 1. Open a draft so we can edit
       MODIFY ENTITIES OF i_banktp ENTITY Bank EXECUTE Edit
         FROM VALUE #( ( %key-BankCountry    = bank_country
@@ -472,7 +472,7 @@ ENDMETHOD.
 ### 9. The Event Map and the View
 The dispatcher in `z2ui5_if_app~main` wires UI events to the methods above:
 ```abap
-IF client->check_on_init( ) OR client->check_on_navigated( ).
+IF client->check_on_navigated( ).
   on_init( ).
 ELSEIF client->check_on_event( `EDIT_TOGGLE` ).
   on_event_edit_toggle( ).
@@ -531,7 +531,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_draft IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       on_init( ).
     ELSEIF client->check_on_event( `EDIT_TOGGLE` ).
       on_event_edit_toggle( ).

--- a/docs/cookbook/eml_cds_sql/eml.md
+++ b/docs/cookbook/eml_cds_sql/eml.md
@@ -22,7 +22,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_eml_read IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       READ ENTITIES OF I_SalesOrderTP
         ENTITY SalesOrder

--- a/docs/cookbook/event_navigation/routing.md
+++ b/docs/cookbook/event_navigation/routing.md
@@ -16,7 +16,7 @@ Enable routing once per session with `client->set_nav_routing( )` — typically 
 ```abap
 METHOD z2ui5_if_app~main.
 
-  IF client->check_on_init( ) OR client->check_on_navigated( ).
+  IF client->check_on_navigated( ).
     client->set_nav_routing( ).   " mode defaults to cs_nav_mode-keep
     view_display( ).
   ENDIF.

--- a/docs/cookbook/expert_more/follow_up_action.md
+++ b/docs/cookbook/expert_more/follow_up_action.md
@@ -143,7 +143,7 @@ The `_generic` method creates a custom XML/HTML element — here an HTML `<scrip
 ```abap
   METHOD z2ui5_if_app~main.
 
-  IF client->check_on_init( ) OR client->check_on_navigated( ).
+  IF client->check_on_navigated( ).
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`
               )->a( n = `xmlns`      v = `sap.m`

--- a/docs/cookbook/expert_more/lock.md
+++ b/docs/cookbook/expert_more/lock.md
@@ -55,7 +55,7 @@ CLASS z2ui5_cl_sample_lock_1 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       on_init( ).
     ELSEIF client->check_on_event( `SAVE` ).
       on_event_save( ).
@@ -216,7 +216,7 @@ CLASS z2ui5_cl_sample_lock_2 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       on_init( ).
     ELSEIF client->check_on_event( `SAVE` ).
       on_event_save( ).
@@ -387,7 +387,7 @@ CLASS z2ui5_cl_sample_lock_3 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       on_init( ).
     ELSEIF client->check_on_event( `SAVE` ).
       on_event_save( ).
@@ -531,7 +531,7 @@ CLASS z2ui5_cl_sample_lock_4 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       on_init( ).
     ELSEIF client->check_on_event( `SAVE` ).
       on_event_save( ).
@@ -662,7 +662,7 @@ ENDCLASS.
 ## 5. Stateful Session
 For classic SAP GUI-like behaviour, switch the session to stateful and call the lock function module on init. The lock survives subsequent roundtrips as long as the session stays alive:
 ```abap
-IF client->check_on_init( ) OR client->check_on_navigated( ).
+IF client->check_on_navigated( ).
 
   CALL FUNCTION `ENQUEUE_EVVBAK`
     EXPORTING
@@ -744,7 +744,7 @@ CLASS z2ui5_cl_sample_lock_5 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       on_init( ).
     ELSEIF client->check_on_event( `SAVE` ).
       on_event_save( ).
@@ -945,7 +945,7 @@ CLASS z2ui5_cl_sample_lock_6 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       on_init( ).
     ELSEIF client->check_on_event( `SAVE` ).
       on_event_save( ).

--- a/docs/cookbook/expert_more/snippets.md
+++ b/docs/cookbook/expert_more/snippets.md
@@ -142,7 +142,7 @@ ENDCLASS.
 CLASS z2ui5_cl_app_write_output IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       cl_demo_output=>begin_section( `My Report` ).
       cl_demo_output=>write_data( sy-uname ).
@@ -191,7 +191,7 @@ ENDCLASS.
 CLASS z2ui5_cl_app_table_basic IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DO 20 TIMES.
         INSERT VALUE #( id    = sy-index
@@ -265,7 +265,7 @@ ENDCLASS.
 CLASS z2ui5_cl_app_table_sort IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DO 30 TIMES.
         INSERT VALUE #(

--- a/docs/cookbook/expert_more/statefulness.md
+++ b/docs/cookbook/expert_more/statefulness.md
@@ -20,7 +20,7 @@ No work process is pinned, no enqueue is held, no `SET/GET` parameters survive. 
 For private and on-premise systems, you can switch a running app to stateful mode. The same work process then handles every subsequent roundtrip of *this* user, and ABAP globals, locks, and open RFC connections survive between events:
 
 ```abap
-IF client->check_on_init( ) OR client->check_on_navigated( ).
+IF client->check_on_navigated( ).
   client->set_session_stateful( ).
 ENDIF.
 ```

--- a/docs/cookbook/model/tables.md
+++ b/docs/cookbook/model/tables.md
@@ -36,7 +36,7 @@ ENDCLASS.
 CLASS z2ui5_cl_sample_tab IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DO 100 TIMES.
         INSERT VALUE #(
@@ -93,7 +93,7 @@ To make a table editable, use editable cell controls (e.g. `input`) — the bind
 ```abap
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DO 100 TIMES.
         INSERT VALUE #(

--- a/docs/cookbook/popup_popover/popover.md
+++ b/docs/cookbook/popup_popover/popover.md
@@ -14,7 +14,7 @@ To show a popover, call `client->popover_display` and pass the ID of the control
 ```abap
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`
               )->a( n = `xmlns`     v = `sap.m`

--- a/docs/cookbook/popup_popover/popup.md
+++ b/docs/cookbook/popup_popover/popup.md
@@ -39,7 +39,7 @@ A typical popup flow shows a normal view, opens a popup, and finally closes it. 
 ```abap
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
         DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
             )->ele( n = `View` ns = `mvc`
                 )->a( n = `xmlns`     v = `sap.m`

--- a/docs/cookbook/view/nested_views.md
+++ b/docs/cookbook/view/nested_views.md
@@ -52,7 +52,7 @@ DATA(nested) = z2ui5_cl_ui5_view_builder=>factory(
                 )->a( n = `text`  v = `event`
                 )->a( n = `press` v = client->_event( `TEST` ) ).
 
-IF client->check_on_init( ) OR client->check_on_navigated( ).
+IF client->check_on_navigated( ).
   client->view_display( view->stringify( ) ).
 ENDIF.
 

--- a/docs/get_started/full_example.md
+++ b/docs/get_started/full_example.md
@@ -68,7 +68,7 @@ The `main` method is a pure dispatcher — the same pattern as in [Hello World](
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
@@ -357,7 +357,7 @@ CLASS zcl_app_full_example IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/docs/get_started/hello_world.md
+++ b/docs/get_started/hello_world.md
@@ -101,7 +101,7 @@ ENDCLASS.
 CLASS zcl_app_hello_world IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`
@@ -163,7 +163,7 @@ ENDCLASS.
 CLASS zcl_app_hello_world IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/docs/technical/cloud.md
+++ b/docs/technical/cloud.md
@@ -52,7 +52,7 @@ CLASS z2ui5_cl_demo_app_003 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       SELECT FROM I_SalesOrder
        FIELDS salesorder, salesorganization
@@ -95,7 +95,7 @@ CLASS z2ui5_cl_demo_app_004 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       SELECT FROM vbak
        FIELDS vbeln, vkorg

--- a/docs/technical/concept.md
+++ b/docs/technical/concept.md
@@ -207,7 +207,7 @@ CLASS z2ui5_cl_app_partial_rerendering IMPLEMENTATION.
 
     text = text && ` text`.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ) OR partly = abap_false.
+    IF client->check_on_navigated( ) OR partly = abap_false.
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`
               )->a( n = `xmlns`     v = `sap.m`

--- a/docs/technical/dx.md
+++ b/docs/technical/dx.md
@@ -70,7 +70,7 @@ ENDCLASS.
 CLASS zcl_app_input IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       client->view_display(
         z2ui5_cl_ui5_view_builder=>factory(
             )->ele( n = `View` ns = `mvc`
@@ -220,7 +220,7 @@ ENDCLASS.
 CLASS zcl_app_alv_event IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       client->nav_app_call( z2ui5_cl_pop_to_confirm=>factory(
         i_question_text = `Do you like dinosaurs?`
         i_title         = `Title`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "abap2ui5-docs",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "^0.2.0",
+        "@abap2ui5/linter": "^0.2.1",
         "@abaplint/cli": "^2.119.66",
         "vitepress": "^1.6.4"
       },
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@abap2ui5/linter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.0.tgz",
-      "integrity": "sha512-wZQ3MkVz+IiHBzuudizx7rQsYNoAMxM8cBsyDz0Oxrc7zaWb+cRKdx3h/+RqRUpPozGIOxnR2AD9SO0PZe4f/g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.1.tgz",
+      "integrity": "sha512-48uMFctR78nogNai1w6kE7Ho4IXLuEnGPq5BJkstpWL69ToL1G+OJ1t4fDOBmOcJ36uFejDn2ofnoBqEkt+9sA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "check:version": "node scripts/check-version.mjs"
   },
   "devDependencies": {
-    "@abap2ui5/linter": "^0.2.0",
+    "@abap2ui5/linter": "^0.2.1",
     "@abaplint/cli": "^2.119.66",
     "vitepress": "^1.6.4"
   },

--- a/scripts/link-samples.mjs
+++ b/scripts/link-samples.mjs
@@ -81,11 +81,23 @@ function resolveSamples() {
  *
  * The bold half is only there when the row carries a header of its own (the
  * generator drops one that would just repeat its section heading), so both
- * shapes have to parse. The trailing `<sub>` blocks are the small type under
- * the title - keywords, and the `@docs` links this script maintains - and there
- * may be none, one or several: matched as a group rather than counted, so
- * adding another one over there does not stop rows parsing over here. */
-const ROW = /^\|\s*(?:\*\*(?<title>[^*]+)\*\*\s*(?:—|--)\s*)?(?<sub>[^|<]*?)\s*(?<small>(?:<br><sub>[^<]*<\/sub>)*)\s*\|\s*\[`(?<cls>[A-Z0-9_]+)`\]\((?<path>[^)]+)\)\s*\|/;
+ * shapes have to parse.
+ *
+ * What follows the title is a run of `<br>` blocks, and they are matched as a
+ * GROUP rather than counted or typed: the small type in `<sub>` (keywords,
+ * then the `@docs` links this script maintains) and, since the samples
+ * repository gave every app a `" @summary`, a block of NORMAL type carrying
+ * that sentence:
+ *
+ *   | **Basics I** — Hello World<br>The smallest app that runs.<br><sub>hello world minimal</sub> | [`Z2UI5_CL_SMP_APP_493`](...) |
+ *
+ * The narrower pattern that expected `<br><sub>` blocks ONLY matched no rows
+ * at all the day the sentence arrived - every page's samples block then read
+ * "not in the sample catalogue", which is a wrong answer rather than a broken
+ * run. That is why this matches loosely: the row shape is maintained in
+ * another repository (three of them now), and a block this script does not
+ * know about must cost it nothing. */
+const ROW = /^\|\s*(?:\*\*(?<title>[^*]+)\*\*\s*(?:—|--)\s*)?(?<sub>[^|<]*?)\s*(?<small>(?:<br>(?:<sub>[^<]*<\/sub>|[^<]*))*)\s*\|\s*\[`(?<cls>[A-Z0-9_]+)`\]\((?<path>[^)]+)\)\s*\|/;
 
 /** class name (lower case) -> { label, path } for every app in the catalogue. */
 function parseCatalogue(text) {


### PR DESCRIPTION
```abap
IF client->check_on_init( ) OR client->check_on_navigated( ).   " before
IF client->check_on_navigated( ).                               " after
```

One condition too many — and a page that teaches it teaches the `OR` as if there were a case the second half does not cover. There is not: `check_on_init( )` is only ever true on a roundtrip where `check_on_navigated( )` is true as well. The framework raises both for a fresh `CREATE OBJECT` and for a bookmark-draft restore (`z2ui5_cl_ui5_action=>factory_first_start`), and `z2ui5_if_client` has said so in ABAP Doc since abap2UI5 #2614.

**84 examples on 50 pages.** `technical/concept.md` keeps its third term — the condition there is `… OR partly = abap_false`, and only the redundant half goes.

### Why this is the second attempt

It was written and reverted a fortnight ago, and the reason is worth recording: `@abap2ui5/linter` 0.2.0 read the `ELSE` of a `COND #( … )` as the end of a lifecycle branch, so an example whose `view_display( )` came four statements after a `COND` was reported as a branch that never re-displays. That is fixed in **0.2.1**, which this pins.

`check:examples`: 46 example files, 0 failing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_