### PR TITLE
Follow the MCP server's rename to mcp-server

### DIFF
--- a/docs/get_started/ai.md
+++ b/docs/get_started/ai.md
@@ -54,12 +54,12 @@ the frozen builder.
 
 ## Give it the loop
 
-[**abap2UI5/ai-mcp**](https://github.com/abap2UI5/ai-mcp) is an MCP server that
+[**abap2UI5/mcp-server**](https://github.com/abap2UI5/mcp-server) is an MCP server that
 turns the checks into a development loop, still without a system. It works with
 any MCP client — Claude Code, Cursor, VS Code:
 
 ```sh
-claude mcp add abap2ui5 -- node /path/to/ai-mcp/server.mjs
+claude mcp add abap2ui5 -- node /path/to/mcp-server/server.mjs
 ```
 
 The tools an agent then has:
@@ -86,7 +86,7 @@ editor has the loop without any separate configuration. Point
 `abap2ui5.mcp.reposRoot` at the folder holding the checkouts and the extension
 passes the paths through.
 
-It adds a second server of its own for the half ai-mcp deliberately does not
+It adds a second server of its own for the half mcp-server deliberately does not
 have: your configured **systems**. An agent can list them, search app classes
 over ADT and get the app rendered on the real system as a screenshot — while
 every credential prompt stays an ordinary VS Code dialog the agent never sees.

--- a/docs/get_started/next.md
+++ b/docs/get_started/next.md
@@ -21,7 +21,7 @@ The samples evolve all the time. Have one to share? Open a PR so others can lear
 :::
 
 ## Tooling
-Optional, and worth the ten minutes: a project [template](/get_started/project_setup) with the checks already wired up, a [linter](/technical/tools/linter) that finds broken views without a system, an [extension](https://github.com/abap2UI5/vscode-extension) that runs your app on `F9` next to the code, and an [MCP server](https://github.com/abap2UI5/ai-mcp) that lets an AI agent build and *look at* the app. See [Tooling](/get_started/tooling), and [Building with AI](/get_started/ai) if an assistant writes some of it.
+Optional, and worth the ten minutes: a project [template](/get_started/project_setup) with the checks already wired up, a [linter](/technical/tools/linter) that finds broken views without a system, an [extension](https://github.com/abap2UI5/vscode-extension) that runs your app on `F9` next to the code, and an [MCP server](https://github.com/abap2UI5/mcp-server) that lets an AI agent build and *look at* the app. See [Tooling](/get_started/tooling), and [Building with AI](/get_started/ai) if an assistant writes some of it.
 
 ## Development
 Build views, handle events, share data, and work with tables. The [Cookbook](/cookbook/overview) walks through the patterns you need for everyday work — start with the [Life Cycle](/cookbook/event_navigation/life_cycle) page.

--- a/docs/get_started/tooling.md
+++ b/docs/get_started/tooling.md
@@ -67,7 +67,7 @@ extension for the system connection.
 
 ## Let an AI agent build and see the app
 
-[**abap2UI5/ai-mcp**](https://github.com/abap2UI5/ai-mcp) — an MCP server that
+[**abap2UI5/mcp-server**](https://github.com/abap2UI5/mcp-server) — an MCP server that
 gives a coding agent the whole loop *without* an SAP system: it validates the
 view, transpiles the framework and the app to Node, boots the app in a
 headless browser and hands the agent a **screenshot**. That last step is the

--- a/docs/resources/samples.md
+++ b/docs/resources/samples.md
@@ -50,7 +50,7 @@ gives you the same sentence the catalogue would have.
 ## For AI agents
 
 The same three catalogues are queryable through the
-[MCP server](https://github.com/abap2UI5/ai-mcp) — the `examples` tool searches
+[MCP server](https://github.com/abap2UI5/mcp-server) — the `examples` tool searches
 all of them at once and answers with a repository, a class name and a path to
 read, never with a copied snippet:
 

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -3,7 +3,7 @@
  * generate-llms — this documentation, in the form a machine can actually read.
  *
  * The case this exists for is the one nothing else covers. An agent with the
- * MCP server (abap2UI5/ai-mcp) has tools. An agent working inside a checkout
+ * MCP server (abap2UI5/mcp-server) has tools. An agent working inside a checkout
  * has AGENTS.md and the skills. An agent that is simply ASKED "build me an
  * abap2UI5 app", with nothing but a web search, has neither - it lands on 70
  * rendered HTML pages wrapped in site navigation, or it falls back on training
@@ -234,7 +234,7 @@ const index = [
   '  with both gates and CI already wired up - begin an app here',
   '- [linter](https://github.com/abap2UI5/linter): checks an app class and the',
   '  view it builds without an SAP system (CLI, GitHub Action, VS Code)',
-  '- [ai-mcp](https://github.com/abap2UI5/ai-mcp): MCP server - query the sample',
+  '- [mcp-server](https://github.com/abap2UI5/mcp-server): MCP server - query the sample',
   '  catalogue, validate a view, deploy, build, boot the app headless and get a',
   '  screenshot back. No SAP system needed',
   '',

--- a/scripts/lib/catalogue.mjs
+++ b/scripts/lib/catalogue.mjs
@@ -8,7 +8,7 @@
  *
  * The row shape is maintained in abap2UI5/samples, /samples-controls and
  * /samples-stack - three repositories, none of them this one - and read here
- * and in abap2UI5/ai-mcp. It is a contract between five programs.
+ * and in abap2UI5/mcp-server. It is a contract between five programs.
  */
 import fs from 'node:fs';
 import path from 'node:path';

--- a/scripts/link-samples.mjs
+++ b/scripts/link-samples.mjs
@@ -7,7 +7,7 @@
  * link to the ROOT of abap2UI5/samples. A reader who follows it lands in a
  * repository of 300 files named z2ui5_cl_smp_app_<number> - the class name
  * encodes nothing - and has to guess. Meanwhile an AI agent can query the same
- * catalogue by keyword (abap2UI5/ai-mcp, the `examples` tool). The human had
+ * catalogue by keyword (abap2UI5/mcp-server, the `examples` tool). The human had
  * the worse deal.
  *
  * How it works, and why it is generated rather than written by hand:


### PR DESCRIPTION
`abap2UI5/ai-mcp` is now `abap2UI5/mcp-server`. The published documentation is where a stale name costs the most — a reader copies the command as it stands.

Seven files: `get_started/ai.md` (including the `claude mcp add … /path/to/mcp-server/server.mjs` line somebody pastes into their config), `get_started/next.md`, `get_started/tooling.md`, `resources/samples.md`, plus `scripts/generate-llms.mjs`, `scripts/lib/catalogue.mjs` and `scripts/link-samples.mjs`.

`docs/public/**` is gitignored build output and regenerates from these.

`npm run check`: green — tests, version, VitePress build, `check:examples`, `check:samples` (109 links up to date), `check:counts`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_