### PR TITLE
Install the MCP server from npm

### DIFF
--- a/docs/advanced/mcp_server.md
+++ b/docs/advanced/mcp_server.md
@@ -54,9 +54,19 @@ photograph it. Seconds per answer, no backend, no transpile.
 
 ```sh
 git clone https://github.com/abap2UI5/linter        # AI_VIEW_CHECK_HOME
-git clone https://github.com/abap2UI5/mcp-server
-cd linter && npm ci && cd ../mcp-server && npm ci
+cd linter && npm ci
 ```
+
+The server itself is published as `@abap2ui5/mcp-server`, so it needs no
+checkout — the `npx` command below fetches and runs it. Clone it as well only
+if you want to work *on* the server:
+
+```sh
+git clone https://github.com/abap2UI5/mcp-server && cd mcp-server && npm ci
+```
+
+That install is about 45 MB, and 19 MB of it is a Playwright driver only
+`run_app` uses — paid on the first start, cached afterwards.
 
 `screenshot_view` additionally needs the linter's render runtime and a browser
 — `npm i -D @abap2ui5/render-runtime && npx playwright install chromium` in the
@@ -101,8 +111,11 @@ far, and it is what buys an agent the ability to look at what it built.
 **Claude Code:**
 
 ```sh
-claude mcp add abap2ui5 -- node /path/to/mcp-server/server.mjs
+claude mcp add abap2ui5 -- npx --yes @abap2ui5/mcp-server
 ```
+
+From a checkout instead: `claude mcp add abap2ui5 -- node
+/path/to/mcp-server/server.mjs`.
 
 **Cursor** (`.cursor/mcp.json`), **VS Code** (`.vscode/mcp.json`), **Claude
 Desktop** (`claude_desktop_config.json`) and anything else reading the standard
@@ -112,8 +125,8 @@ stdio shape:
 {
   "mcpServers": {
     "abap2ui5": {
-      "command": "node",
-      "args": ["/path/to/mcp-server/server.mjs"],
+      "command": "npx",
+      "args": ["--yes", "@abap2ui5/mcp-server"],
       "env": {
         "AI_VIEW_CHECK_HOME": "/path/to/linter",
         "A2UI5_HOME": "/path/to/abap2UI5",
@@ -124,8 +137,12 @@ stdio shape:
 }
 ```
 
+To run a checkout instead, swap those two lines for `"command": "node"` and
+`"args": ["/path/to/mcp-server/server.mjs"]`.
+
 The three `env` entries are only needed when the checkouts are not siblings of
-`mcp-server`; drop the ones whose level you stopped short of. VS Code wants the
+the server — which they cannot be when it runs from npx, so state them there.
+Drop the ones whose level you stopped short of. VS Code wants the
 same object under a top-level `"servers"` key instead of `"mcpServers"`.
 
 ::: tip Using VS Code?

--- a/docs/get_started/ai.md
+++ b/docs/get_started/ai.md
@@ -89,7 +89,7 @@ loop, still without a system. It works with any MCP client — Claude Code,
 Cursor, VS Code:
 
 ```sh
-claude mcp add abap2ui5 -- node /path/to/mcp-server/server.mjs
+claude mcp add abap2ui5 -- npx --yes @abap2ui5/mcp-server
 ```
 
 The tools an agent then has:


### PR DESCRIPTION
# Description

`@abap2ui5/mcp-server@0.1.0` is on the registry, and mcp-server#22 moved the three setup levels out of that repository's README and into `advanced/mcp_server` here — so this page is now the place the install instructions live, and they still said "clone it".

- **Level 1** no longer clones the server. The linter clone stays (`AI_VIEW_CHECK_HOME` needs a checkout); the server checkout is named for what it is still actually for — working *on* the server.
- **Registration snippets**, here and in `get_started/ai`: `npx --yes @abap2ui5/mcp-server` as the default shape, `node /path/to/server.mjs` as the alternative.
- **The ~45 MB install** — 19 MB of it a Playwright driver only `run_app` uses — is stated where a reader first pays it.
- **The `env` note** gains the reason it matters more now: running from npx, the server has no siblings, so those paths must be given rather than inferred.

Verified against the published package rather than assumed — the bin is `abap2ui5-mcp` while the package is `@abap2ui5/mcp-server`, so npx has to fall back to "exactly one binary" to resolve it:

```
initialize -> {"name":"abap2ui5","version":"0.1.0"}
tools -> 14 tools
```

## How to test

```
npm ci && npm run check
```

Green here: `3 pass`, `the documentation names the release that exists - OK`, build + render OK, `every count matches its catalogue - OK`.

One note for anyone reproducing this locally: `docs/public/**/*.md` is gitignored and generated, so a working tree that has built before can hold copies of pages since renamed — `vitepress` then reports dead links in files that no longer have a source. Deleting the stale generated copies clears it; CI never sees it, because it starts from a clean checkout.

## Checklist

- [x] `npm run check` passes
- [x] npx resolution verified against the published package
- [x] Prose only — no config or script changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_