### PR TITLE
Ask Dependabot monthly, and keep majors out of the routine bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "06:23"
       timezone: Etc/UTC
     open-pull-requests-limit: 5
@@ -30,14 +29,21 @@ updates:
       # site that builds is what has to be verified, not each package alone.
       toolchain:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      toolchain-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "06:23"
       timezone: Etc/UTC
     groups:
       actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      actions-major:
+        patterns: ["*"]
+        update-types: ["major"]


### PR DESCRIPTION
# Description

Part of an ecosystem-wide change — the same edit lands in all ten repositories that carry a `dependabot.yml`.

Grouping was already at its limit (one group per ecosystem, `patterns: ["*"]`), so the volume came from **multiplication**: two to three ecosystems × ten repositories × every Tuesday ≈ **21 pull requests a week** for build-time tools.

**Monthly:** the same updates, a quarter as often. A documentation site is about as low-churn as this ecosystem gets, so weekly was asking a question whose answer was almost always "nothing".

**Majors travel alone:** each group is split by `update-types`, so a routine month produces one pull request per ecosystem with only minor and patch bumps, and a major arrives separately — visible as a major, and reviewable as one. A VitePress major in particular is not something to merge inside a group of patches.

The `day: monday` entries went with the switch: `day` is only honoured for `interval: weekly`, and leaving it would have been a setting that reads as active and is not.

## How to test

```
npm ci && npm run check
```

Config validated as YAML: every group carries `update-types`, no leftover `day:`.

## Checklist

- [x] YAML validated
- [ ] Unit tests added/updated — not applicable; configuration
- [x] No page content changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_