### PR TITLE
Run the examples from the page, and fix the three that could not run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `scripts/link-samples.mjs` | Generates the *Working Samples* block on a page from its `samples:` frontmatter plus `SAMPLES.md` in an `abap2UI5/samples` checkout, and checks the link in both directions |
 | `scripts/generate-llms.mjs` | Builds `llms.txt` / `llms-full.txt` / per-page markdown from the sidebar. Runs inside `docs:build`, so the deploy publishes them |
 | `scripts/check-version.mjs` | The release number in the nav bar, the deprecations page and the changelog, against the newest release tag of the framework |
+| `docs/.vitepress/playground.mjs` | Decides which fenced ABAP example gets a **Run** button, and wraps the fence; `theme/playground.js` is the browser half |
 | `scripts/lib/catalogue.mjs` | Parses a sample catalogue's rows; pinned by `test/catalogue.test.mjs`, because it has stopped matching twice and both times answered wrongly instead of failing |
 
 ## Build & verify — run before every commit
@@ -100,6 +101,60 @@ Nothing needs maintaining. Adding a page to the sidebar adds it here.
   written into the markdown so the site builds without a samples checkout. Run
   `npm run link:samples` after changing a page's `samples:` frontmatter;
   `check:samples` fails if a rewrite would change anything.
+
+## The Run button, and why its rules are hand-maintained
+
+An example that the [playground](https://github.com/abap2UI5/playground) can
+start carries a Run button; pressing it mounts the running app under the code.
+The code travels in the playground's URL fragment, read out of the rendered
+block at click time — so nothing is hosted here, and the example that runs is
+the text on the page rather than a copy of it.
+
+**This is the seventh decidable thing in this repository and the only one CI
+cannot decide.** Whether an example runs is a question only a playground can
+answer, and a playground is a three-minute build of another repository. So the
+rules in `docs/.vitepress/playground.mjs` are an approximation, they fail
+towards *no button*, and every one of them came from an example watched failing
+in a real one:
+
+| | |
+| --- | --- |
+| a complete class implementing `z2ui5_if_app` | the playground compiles a whole abapGit object, and the framework starts an app |
+| a name of at most 30 characters | not a playground limit — a longer class exists nowhere. Two were printed here for years, invisible to `check:examples`, which renames every example to `zcl_docs_example_NN` before compiling it |
+| displays something | `configuration/authorization.md` starts, shows an empty frame and demonstrates nothing |
+| no `SELECT` outside the tables the page has | the database in the page holds the framework's tables and what open-abap ships; T100 is there, VBAK is not |
+| no EML, CDS or HANA SQL | same list `check-examples.mjs` already skips |
+| no add-on, no on-premise SAP class, no function module | `z2ui5_if_lp_kpi`, `cl_bcs_message`, `cl_demo_output`, `describe_by_name` |
+| no method declared and never implemented, no local class | neither compiles as printed, here or in a system |
+
+`test/playground.test.mjs` pins one fixture per line of that table, **plus the
+shapes a rule written one word wider would have swallowed**: a `SELECT` in a
+comment, the word FROM inside a string, `INSERT VALUE #( )` into an internal
+table.
+
+**To redo the measurement** — after adding examples, or after the playground
+changes — build the playground, serve it, and open each fenced example in an
+embedded one, checking that the status line reaches `running` and that the app
+frame contains something:
+
+```sh
+git clone https://github.com/abap2UI5/playground && cd playground
+npm ci && npm run build && npm run serve      # the first build is a few minutes
+# then, for each example: /?embed=1&view=app#<the deflated fragment>
+```
+
+The last measurement: **61 complete app classes, 39 with a button, all 39
+started and rendered.** The 22 without one each have a reason the module prints.
+
+**The published playground is what readers get**, not the checkout you tested
+against. A change to the rules here can ship on its own; a change that depends
+on new playground behaviour has to wait for that deploy — and the button in its
+first form does depend on one. It needs the loader that names the file after the
+class in it (before that, `data-code` only worked for a class called
+`zcl_playground`, and every button here would have shown the reader a name
+error), the app-only layout fix for a column narrower than 820px, and
+`frameOptions="allow"` on the app frame. **Merge and deploy
+[abap2UI5/playground](https://github.com/abap2UI5/playground) first**, then this.
 
 ## Toolchain
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,27 @@ generated on every build and gitignored — never edit them, and nothing needs
 maintaining: the page list comes from the **sidebar**, so adding a page there
 adds it here. [AGENTS.md](AGENTS.md) has the details.
 
+### Running an example from the page
+
+An ABAP example that the [playground](https://github.com/abap2UI5/playground)
+can start carries a **Run this example** button under it, and pressing it puts
+the running app under the code — the framework compiled into the page, no
+server and no SAP system anywhere. The code that runs is read out of the block
+the reader is looking at, so the printed example and the running one cannot be
+two different things.
+
+Nothing is fetched until somebody presses it: a reader who never does makes no
+request to another site.
+
+Which blocks get a button is decided in `docs/.vitepress/playground.mjs`, and
+the rule is narrow on purpose — a button on an example that cannot run is worse
+than no button. It has to be a complete class implementing `z2ui5_if_app` that
+displays something and needs nothing the browser has not got: no table of its
+own, no CDS entity, no add-on repository, no on-premise SAP class. **39 of the
+262 ABAP blocks here** clear that today. Every rule was written from an example
+watched failing in a real playground; `test/playground.test.mjs` keeps one
+fixture per shape, and [AGENTS.md](AGENTS.md) says how to redo the measurement.
+
 ### Linking a sample from a page
 
 A page lists the samples that demonstrate it in its frontmatter, by class name

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitepress";
+import { playgroundButton } from "./playground.mjs";
 
 // Where the site is actually served from. Link previews (LinkedIn, Slack,
 // WhatsApp, X) only accept ABSOLUTE urls in og:image / og:url — a relative
@@ -11,6 +12,11 @@ const OG_IMAGE = `${SITE_URL}/og-image.png`;
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
+  // A Run button under every fenced example the playground can actually
+  // start. Which ones those are is decided in ./playground.mjs.
+  markdown: {
+    config: (md) => playgroundButton(md),
+  },
   lastUpdated: {
     text: "Updated at",
     formatOptions: {

--- a/docs/.vitepress/playground.mjs
+++ b/docs/.vitepress/playground.mjs
@@ -1,0 +1,287 @@
+/*
+ * A Run button on the examples that can actually run.
+ *
+ * The playground (abap2UI5/playground) is the whole framework compiled into a
+ * page: ABAP in, a running UI5 app out, no server and no SAP system anywhere.
+ * It can be embedded, and the code it runs can travel in the URL fragment —
+ * which means an example printed here can be started from here, without this
+ * repository hosting anything and without the example being written down a
+ * second time somewhere it could drift from the page.
+ *
+ * What this module decides is the only hard part: WHICH fenced block gets a
+ * button. A button on a block the playground cannot start is worse than no
+ * button — the reader clicks, waits several seconds for an ABAP runtime to
+ * boot, and is shown an error about their own documentation. So the rule is
+ * narrow, and it is a rule about what the BROWSER has rather than about what is
+ * good ABAP:
+ *
+ *   1. a complete global class — DEFINITION and IMPLEMENTATION, because the
+ *      playground compiles a whole abapGit object and nothing less,
+ *   2. implementing `z2ui5_if_app`, because that is what the framework starts,
+ *   3. that displays something, because a demo of a blank frame demonstrates
+ *      nothing,
+ *   4. and that needs nothing which is not in the page: no database table of
+ *      its own, no CDS entity, no behavior definition, no add-on repository,
+ *      no on-premise SAP class the transpiler does not implement.
+ *
+ * **Every rule below was put there by watching an example fail in a real
+ * playground**, not by reasoning about what might. All 61 complete app classes
+ * in this documentation were opened in one: 38 started, and the 23 that did not
+ * are the list of shapes here — except for three, which were defects in the
+ * documentation and were fixed instead. The 39 this module now offers a button
+ * for were then run again, and all 39 started and rendered.
+ *
+ * AGENTS.md says how to repeat that measurement, and that is also the honest
+ * limit of this file: the playground is the only thing that can decide the
+ * question and it is not in this repository, so these rules are a conservative
+ * approximation of it, maintained by hand. They fail towards NOT offering a
+ * button.
+ *
+ * An example that trips one of them is still printed, still checked by
+ * `check:examples` and still copied by readers. It simply has no button.
+ *
+ * The code the button runs is read from the rendered block at click time
+ * (`theme/playground.js`), not copied into an attribute here: the reader runs
+ * exactly the text they can see and copy, and a page cannot carry two versions
+ * of one example.
+ */
+
+/** A complete global class: both halves, not a fragment of a method. */
+const CLASS_DEFINITION = /CLASS\s+(\S+)\s+DEFINITION/i;
+const CLASS_IMPLEMENTATION = /CLASS\s+\S+\s+IMPLEMENTATION/i;
+
+/** What the framework starts. An app is a class that implements this. */
+const IS_AN_APP = /INTERFACES\s+z2ui5_if_app\b/i;
+
+/* The declared object name, read the way the playground reads it
+ * (`src/editor/registry.mjs`), because the file the code is put into is named
+ * after it: abaplint derives an object's name from its file name and refuses
+ * the pair when they disagree. */
+const DECLARED_NAME = /^\s*(?:CLASS|INTERFACE)\s+([a-zA-Z_]\w*)\s+(?:DEFINITION|PUBLIC)/im;
+
+/* An ABAP object name is at most 30 characters. Longer than that is not a
+ * playground limit at all - it is a class nobody can create in any system, and
+ * two of them were printed here for years. `check:examples` could not see them
+ * because it renames every example to `zcl_docs_example_NN` before compiling
+ * it, which is exactly 20. */
+const MAX_NAME = 30;
+
+/** Something has to arrive on screen. */
+const DISPLAYS_SOMETHING = /->\s*(?:view|popup|message_box|message_toast|nest_view)[a-z_]*_display\s*\(/i;
+
+/* The database in the page holds the framework's own tables and what open-abap
+ * ships. A business table is not among them, and `SELECT` from one is the
+ * single most common reason an example here cannot run - ten of the twenty-three
+ * failures. T100 is on the list because open-abap has it and because a page
+ * uses it. */
+const TABLES_THE_PAGE_HAS = new Set(['t100']);
+
+/*
+ * What the browser has not got, in the words the failure arrives in. Order
+ * matters only for which reason is reported first.
+ */
+const NEEDS_MORE_THAN_A_BROWSER = [
+  {
+    // draft_handling, eml, fuzzy_search
+    why: 'needs a CDS entity, a behavior definition or a HANA database',
+    what: /\bREAD\s+ENTITIES\b|\bMODIFY\s+ENTITIES\b|\bCOMMIT\s+ENTITIES\b|TABLE\s+FOR\s+(?:READ|CREATE|UPDATE)\b|\bFUZZY\b/i,
+  },
+  {
+    // launchpad — z2ui5_if_lp_kpi lives in abap2UI5-addons, not in the framework
+    why: 'needs an add-on repository that is not part of the framework',
+    what: /\bz2ui5_(?:if|cl)_lp_/i,
+  },
+  {
+    // email (cl_bcs_message), snippets (cl_demo_output), srtti (a DDIC lookup)
+    why: 'uses an on-premise SAP class the transpiler does not implement',
+    what: /\bcl_bcs\w*\b|\bcl_demo_output\b|\bcl_gui_\w+|\bcl_salv_\w+|\bdescribe_by_name\s*\(/i,
+  },
+  {
+    why: 'calls a function module, and there is no application server to call one on',
+    what: /\bCALL\s+FUNCTION\b/i,
+  },
+];
+
+/*
+ * ABAP with its comments taken out and its text blanked, so a rule can only be
+ * tripped by code. Both halves were put here by a false positive:
+ *
+ *   - `get_started/full_example.md` shows the SELECT a reader would write, as a
+ *     comment, above the demo data it uses instead — and it runs perfectly
+ *     well.
+ *   - `clipboard.md` says `mv_text = \`Hello from abap2UI5\``, and a rule
+ *     looking for `FROM <table>` read that as a table called abap2ui5.
+ *
+ * A comment is `*` in the first column, or `"` outside a literal. Finding that
+ * "outside" is what needs the three literal forms tracked — `'...'`,
+ * `` `...` `` and `|...|` — and a string template is full of the double quotes
+ * a simpler version would stop at. The delimiters are kept and only what is
+ * between them is blanked, so every offset in the line still means what it did.
+ */
+export function abapOnly(code) {
+  return code
+    .split('\n')
+    .map((line) => {
+      if (line.startsWith('*')) return '';
+      let out = '';
+      let quote;
+      for (const c of line) {
+        if (quote) {
+          out += c === quote ? c : ' ';
+          if (c === quote) quote = undefined;
+        } else if (c === "'" || c === '`' || c === '|') {
+          quote = c;
+          out += c;
+        } else if (c === '"') {
+          break;
+        } else {
+          out += c;
+        }
+      }
+      return out;
+    })
+    .join('\n');
+}
+
+/* Names that follow INSERT / UPDATE / MODIFY / FROM and are not tables:
+ * `INSERT VALUE #( … ) INTO TABLE lt_rows` is an internal-table statement, and
+ * it read as a table called VALUE. */
+const NOT_A_TABLE = new Set([
+  'value', 'table', 'corresponding', 'new', 'ref', 'conv', 'cond', 'switch',
+  'reduce', 'filter', 'exact', 'lines', 'initial',
+]);
+
+/** Every name the code introduces itself — a variable, a type, a parameter. */
+function declaredNames(code) {
+  const names = new Set();
+  const add = (re, group = 1) => {
+    for (const m of code.matchAll(re)) names.add(m[group].toLowerCase());
+  };
+  add(/\bDATA[:(]?\s*\(?\s*([a-z_]\w*)/gi);
+  add(/\bTYPES[:]?\s*(?:BEGIN\s+OF\s+)?([a-z_]\w*)/gi);
+  add(/\bFIELD-SYMBOLS[:]?\s*<([a-z_]\w*)>/gi);
+  add(/\b(?:IMPORTING|EXPORTING|CHANGING|RETURNING\s+VALUE\(|VALUE\()\s*([a-z_]\w*)/gi);
+  add(/^\s*([a-z_]\w*)\s+TYPE\s/gim);
+  return names;
+}
+
+/** The database tables this example reads or writes, as far as they can be told
+ *  apart from internal tables and from the class hierarchy. */
+function tablesUsed(code) {
+  const declared = declaredNames(code);
+  const out = new Set();
+  /* `FROM x`, except the `INHERITING FROM` of a class definition and except a
+   * work area handed to an internal-table statement — which is a name the code
+   * declared itself. */
+  const consider = (raw) => {
+    const name = raw.toLowerCase();
+    if (declared.has(name) || NOT_A_TABLE.has(name) || TABLES_THE_PAGE_HAS.has(name)) return;
+    out.add(name);
+  };
+  for (const m of code.matchAll(/(\bINHERITING\s+)?\bFROM\s+@?([a-z_]\w*)/gi)) {
+    if (!m[1]) consider(m[2]);
+  }
+  for (const m of code.matchAll(/^\s*(?:INSERT|UPDATE|MODIFY)\s+([a-z_]\w*)\s/gim)) consider(m[1]);
+  return [...out];
+}
+
+/** A method the class promises and never writes. abaplint stops the run on it,
+ *  and so would an activation in a real system: the example does not compile
+ *  as printed. */
+function unimplementedMethods(code) {
+  const definition = code.split(CLASS_IMPLEMENTATION)[0];
+  const declared = [];
+  for (const m of definition.matchAll(/^\s*METHODS:?\s+([^.]+)\./gim)) {
+    for (const one of m[1].split(',')) {
+      const name = /^\s*([a-z_]\w*)/i.exec(one)?.[1];
+      /* A redefinition or an interface method is implemented under another
+       * name, or by the superclass. */
+      if (name && !/\bREDEFINITION\b/i.test(one) && !one.includes('~')) declared.push(name);
+    }
+  }
+  return declared.filter((name) => !new RegExp(`^\\s*METHOD\\s+${name}\\s*\\.`, 'im').test(code));
+}
+
+/*
+ * A local class or interface, whether the example defines one or only calls
+ * one. Both are out, and for the same reason: a playground file is one abapGit
+ * object, and a class-local class is not an object - abapGit serializes it into
+ * a `.clas.locals_imp.abap` beside the class, which there is nowhere to put
+ * here. So an example calling `lcl_help=>…` has nothing to resolve, and an
+ * example defining `lcl_help` would have the file named after the wrong class.
+ */
+function localObjects(code) {
+  const names = new Set();
+  for (const m of code.matchAll(/\b(l(?:cl|if)_\w+)\b/gi)) names.add(m[1].toLowerCase());
+  return [...names];
+}
+
+/**
+ * The class this fence would run in the playground, or the reason it would not.
+ *
+ * @param {string} code the ABAP inside a ```abap fence
+ * @returns {{ name: string } | { why: string }}
+ */
+export function playgroundExample(code) {
+  if (!CLASS_DEFINITION.test(code) || !CLASS_IMPLEMENTATION.test(code)) {
+    return { why: 'not a complete class — the playground compiles whole objects' };
+  }
+  if (!IS_AN_APP.test(code)) {
+    return { why: 'does not implement z2ui5_if_app, so there is no app to start' };
+  }
+  const name = DECLARED_NAME.exec(code)?.[1];
+  if (!name) return { why: 'declares no global class' };
+  if (name.length > MAX_NAME) {
+    return { why: `${name} is ${name.length} characters — an ABAP object name is at most ${MAX_NAME}` };
+  }
+
+  const abap = abapOnly(code);
+  /* The reasons come before the "shows nothing" one on purpose: an example
+   * that needs an add-on also displays through it, and naming the add-on is
+   * the useful half of that sentence. */
+  for (const { why, what } of NEEDS_MORE_THAN_A_BROWSER) {
+    if (what.test(abap)) return { why };
+  }
+  const tables = tablesUsed(abap);
+  if (tables.length) {
+    return { why: `reads ${tables.join(', ')} — the database in the page holds the framework's tables and nothing else` };
+  }
+  const missing = unimplementedMethods(abap);
+  if (missing.length) {
+    return { why: `declares ${missing.join(', ')} and never implements it — this does not compile anywhere` };
+  }
+  const locals = localObjects(abap);
+  if (locals.length) {
+    return { why: `uses ${locals.join(', ')} — a class-local object has no file of its own here` };
+  }
+  if (!DISPLAYS_SOMETHING.test(abap)) {
+    return { why: 'displays nothing, so there would be nothing to see' };
+  }
+  return { name: name.toLowerCase() };
+}
+
+/** True when this fence should carry a Run button. */
+export const isRunnable = (code) => 'name' in playgroundExample(code);
+
+/*
+ * The markdown-it side. VitePress renders a fence into
+ * `<div class="language-abap">…</div>`; this wraps that in a container and
+ * hangs a button off it. The button does nothing until the theme's client
+ * script picks it up, so a page with JavaScript switched off is exactly the
+ * page it was before — printed code, and the copy button VitePress adds.
+ */
+export function playgroundButton(md) {
+  const fence = md.renderer.rules.fence;
+  md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+    const html = fence(tokens, idx, options, env, self);
+    const token = tokens[idx];
+    if (token.info.trim().split(/\s+/)[0] !== 'abap') return html;
+    if (!isRunnable(token.content)) return html;
+    return (
+      '<div class="a2ui5-play">' +
+      html +
+      '<button class="a2ui5-play-run" type="button">Run this example</button>' +
+      '</div>'
+    );
+  };
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -2,6 +2,7 @@
 import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
+import { setUpPlayground } from './playground.js'
 
 /** @type {import('vitepress').Theme} */
 export default {
@@ -12,6 +13,8 @@ export default {
     })
   },
   enhanceApp({ app, router, siteData }) {
-    // ...
+    // The Run button under a runnable ABAP example. One delegated listener for
+    // the whole site — the browser half of docs/.vitepress/playground.mjs.
+    if (!import.meta.env.SSR) setUpPlayground()
   }
 }

--- a/docs/.vitepress/theme/playground.js
+++ b/docs/.vitepress/theme/playground.js
@@ -1,0 +1,144 @@
+/*
+ * The Run button, once it is in a browser.
+ *
+ * `docs/.vitepress/playground.mjs` decides at build time which fenced example
+ * can be started and puts a button under it. This is what happens when it is
+ * pressed: the ABAP is read out of the block the reader is looking at, and an
+ * embedded playground — the whole framework compiled into a page — is mounted
+ * underneath it, running that exact text.
+ *
+ * Three things are deliberate.
+ *
+ * **Nothing is fetched until somebody clicks.** Not the loader script, not the
+ * playground, not the three megabytes it brings. A reader who never presses a
+ * button makes no request to another site and pays nothing, and a page with
+ * seven examples on it is still a page of prose.
+ *
+ * **The code comes from the DOM, not from an attribute.** The button reads the
+ * rendered code block, which is the same text the copy button copies. So the
+ * example that runs cannot be a different one from the example that is
+ * printed — there is only one copy of it, and it is the one on the page.
+ *
+ * **The app is shown, not the editor.** The code is already above it, in this
+ * site's own font and highlighting; a second copy in an editor beside it would
+ * be the same thing twice. What the page cannot show is the running app, so
+ * that is what the frame shows. "Open in the playground" is one link away for
+ * a reader who wants to change it.
+ */
+
+/* The published playground. Absolute rather than site-relative on purpose: it
+ * is a different project with its own deployment, and the code to run travels
+ * in the URL fragment, so this works from a local `docs:dev` as well as from
+ * the published site. */
+const PLAYGROUND = 'https://abap2ui5.github.io/playground/';
+const LOADER = `${PLAYGROUND}embed/abap2ui5-embed.js`;
+
+/** The embed loader, fetched once, on the first click anywhere on the site. */
+let loading;
+function loader() {
+  if (window.abap2ui5Embed) return Promise.resolve(window.abap2ui5Embed);
+  loading ??= new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = LOADER;
+    script.addEventListener('load', () =>
+      window.abap2ui5Embed
+        ? resolve(window.abap2ui5Embed)
+        : reject(new Error('The playground loader did not install itself.')));
+    script.addEventListener('error', () => reject(new Error(`${LOADER} could not be loaded.`)));
+    document.head.append(script);
+  });
+  return loading;
+}
+
+/** The ABAP in a runnable block: the text the reader sees and copies. */
+const sourceOf = (container) => container.querySelector('pre code')?.textContent ?? '';
+
+function fail(container, message) {
+  const note = document.createElement('p');
+  note.className = 'a2ui5-play-failed';
+  note.textContent = `${message} The example still runs at ${PLAYGROUND}.`;
+  container.append(note);
+}
+
+async function start(button) {
+  const container = button.closest('.a2ui5-play');
+  if (!container || container.dataset.running) return;
+  container.dataset.running = '1';
+  button.disabled = true;
+  button.textContent = 'Starting the ABAP runtime…';
+
+  let embed;
+  try {
+    embed = await loader();
+  } catch (e) {
+    button.remove();
+    fail(container, String(e.message || e));
+    return;
+  }
+
+  const source = sourceOf(container);
+  const demo = document.createElement('div');
+  demo.className = 'abap2ui5-demo';
+  demo.dataset.view = 'app';
+  /* Already clicked — the loader's own button would be a second one. */
+  demo.dataset.auto = '1';
+  demo.dataset.code = source;
+  container.append(demo);
+  embed.setUp(container);
+
+  button.replaceWith(bar(container, demo, embed, source));
+}
+
+/** What replaces the button: close it again, or take it somewhere it can be
+ *  edited. Both only make sense once something is running. */
+function bar(container, demo, embed, source) {
+  const bar = document.createElement('div');
+  bar.className = 'a2ui5-play-bar';
+
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'a2ui5-play-close';
+  close.textContent = 'Close';
+  close.addEventListener('click', () => {
+    /* The frame is a whole ABAP runtime; removing the element is what frees
+     * it. Then the block is back to what it was, button and all. */
+    demo.remove();
+    delete container.dataset.running;
+    bar.replaceWith(runButton());
+  });
+
+  const open = document.createElement('a');
+  open.className = 'a2ui5-play-open';
+  open.target = '_blank';
+  open.rel = 'noopener';
+  open.textContent = 'Open in the playground';
+  /* Built by the loader rather than here: the fragment format is the
+   * playground's, and a fragment it cannot read is quietly replaced by its own
+   * sample — a wrong link that looks like a working one. An older loader that
+   * cannot build one still gets a link, to the playground itself. */
+  open.href = PLAYGROUND;
+  Promise.resolve(embed.url?.({ code: source })).then((href) => {
+    if (href) open.href = href;
+  }, () => {});
+
+  bar.append(close, open);
+  return bar;
+}
+
+const runButton = () => {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'a2ui5-play-run';
+  button.textContent = 'Run this example';
+  return button;
+};
+
+/* One listener for the whole site, installed once. VitePress swaps pages
+ * without reloading, so anything bound per page has to be re-bound on every
+ * navigation; a delegated listener never notices. */
+export function setUpPlayground() {
+  document.addEventListener('click', (e) => {
+    const button = e.target.closest?.('.a2ui5-play-run');
+    if (button) start(button);
+  });
+}

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -249,3 +249,125 @@
 .vp-doc .custom-block:not(.details) {
   max-width: 688px;
 }
+
+/* ------------------------------------------------ the Run button ---
+ *
+ * Under a fenced example the playground can start (docs/.vitepress/
+ * playground.mjs decides which), a button that runs it — and, once pressed,
+ * the running app underneath it.
+ *
+ * The button sits ON the code block rather than beside it: it is about the
+ * lines above it and nothing else, so it is drawn as the block's own bottom
+ * edge, sharing its background and losing the rounded corners between them.
+ * The alternative — a floating button in the margin — reads as page chrome and
+ * has to be aimed at.
+ *
+ * It is deliberately quiet. A documentation page is read, and a red button
+ * under every second example would turn a chapter into a control panel. It
+ * uses the code block's own muted colours and takes the brand colour only on
+ * hover, when it is being considered. */
+.vp-doc .a2ui5-play {
+  margin: 16px 0;
+}
+
+.vp-doc .a2ui5-play div[class*="language-"] {
+  margin-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.vp-doc .a2ui5-play-run,
+.vp-doc .a2ui5-play-bar {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 7px 14px;
+  border: 0;
+  border-top: 1px solid var(--vp-c-divider);
+  border-radius: 0 0 8px 8px;
+  background-color: var(--vp-code-block-bg);
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 20px;
+  text-align: left;
+}
+
+.vp-doc .a2ui5-play-run {
+  gap: 9px;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+/* A play triangle, drawn rather than fetched: this site's icon font is a
+ * stylesheet from a CDN, and a button showing an empty square until it arrives
+ * is worse than one that never needed it. */
+.vp-doc .a2ui5-play-run::before {
+  content: "";
+  border: 5px solid transparent;
+  border-right-width: 0;
+  border-left: 8px solid currentColor;
+}
+
+.vp-doc .a2ui5-play-run:hover {
+  color: var(--vp-c-brand-1);
+}
+
+.vp-doc .a2ui5-play-run:disabled {
+  cursor: progress;
+}
+
+/* Once something is running, the bar is between the code and the app and is no
+ * longer the bottom of anything. */
+.vp-doc .a2ui5-play-bar {
+  gap: 16px;
+  border-radius: 0;
+}
+
+.vp-doc .a2ui5-play-close {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.vp-doc .a2ui5-play-open {
+  margin-left: auto;
+  color: inherit;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.vp-doc .a2ui5-play-open::after {
+  content: " ↗";
+}
+
+.vp-doc .a2ui5-play-close:hover,
+.vp-doc .a2ui5-play-open:hover {
+  color: var(--vp-c-brand-1);
+}
+
+/* The frame the app runs in. It is a live application, not a figure: it
+ * continues the code block's own edges downwards, so the example and what it
+ * produces read as one thing. */
+.vp-doc .a2ui5-play .abap2ui5-demo {
+  border: 1px solid var(--vp-c-divider);
+  border-top: 0;
+  border-radius: 0 0 8px 8px;
+  background: var(--vp-c-bg);
+  overflow: hidden;
+}
+
+/* The loader could not be reached — an offline reader, or a blocked
+ * third-party request. Say so where the button was, and say where the example
+ * can be run instead. */
+.vp-doc .a2ui5-play-failed {
+  margin: 0;
+  padding: 7px 14px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0 0 8px 8px;
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+}

--- a/docs/cookbook/model/formatter.md
+++ b/docs/cookbook/model/formatter.md
@@ -20,15 +20,15 @@ UI5 formatter types use a special JSON-based binding syntax with these key eleme
 
 Note on ABAP syntax: inside string templates (`|...|`), escape the curly braces as `\{` and `\}`, because `{ }` normally denotes an embedded ABAP expression.
 
-The `path = abap_true` parameter on `_bind` returns only the raw model path rather than the full binding expression, so you can embed it inside the `parts` array or a single-path `path:` entry. The path is e.g. `/AMOUNT`.
+The `path = abap_true` parameter on `_bind` returns only the raw model path rather than the full binding expression, so you can embed it inside the `parts` array or a single-path `path:` entry. The path is e.g. `/AMOUNT`, **unquoted** — so the quotes around it are yours to write, and they have to be `'` or `"`. A backtick is an ABAP string delimiter, not a UI5 one: written here it survives into the binding string, and UI5 answers with a syntax error and renders nothing at all.
 
 For example, this ABAP code:
 ```abap
-|\{ parts: [`{ client->_bind( val = amount path = abap_true ) }`], type: 'sap.ui.model.type.Currency' \}|
+|\{ parts: ['{ client->_bind( val = amount path = abap_true ) }'], type: 'sap.ui.model.type.Currency' \}|
 ```
 produces this UI5 binding string at runtime:
 ```text
-{ parts: ["/AMOUNT"], type: 'sap.ui.model.type.Currency' }
+{ parts: ['/AMOUNT'], type: 'sap.ui.model.type.Currency' }
 ```
 
 The sections below show the binding-string pattern for each ABAP type that needs a formatter. Each pattern is the minimum that makes the value display and parse correctly — for runnable apps with full `formatOptions`, `constraints`, and read-only variants, see the [samples repository](https://github.com/abap2UI5/samples).
@@ -39,8 +39,8 @@ ABAP `p LENGTH n DECIMALS m` + a `c LENGTH 3` currency code (a plain `string` al
 
 ```abap
 )->tag( `Input`
-    )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val = amount   path = abap_true ) }`,
-                                       `{ client->_bind( val = currency path = abap_true ) }` ],
+    )->a( n = `value` v = |\{ parts: [ '{ client->_bind( val = amount   path = abap_true ) }',
+                                       '{ client->_bind( val = currency path = abap_true ) }' ],
                               type: 'sap.ui.model.type.Currency' \}|
 ```
 
@@ -59,7 +59,7 @@ ABAP `n LENGTH n` is sent as a digit string, leading zeros included. Without a t
 
 ```abap
 )->tag( `Text`
-    )->a( n = `text` v = |\{ path: `{ client->_bind( val = numeric path = abap_true ) }`,
+    )->a( n = `text` v = |\{ path: '{ client->_bind( val = numeric path = abap_true ) }',
                              type: 'sap.ui.model.odata.type.String',
                              constraints: \{ isDigitSequence: true \} \}|
 ```
@@ -72,7 +72,7 @@ ABAP `d` is an 8-character string `YYYYMMDD`. `DatePicker` accepts it directly v
 
 ```abap
 )->tag( `DatePicker`
-    )->a( n = `value` v = |\{ path: `{ client->_bind( val = mv_date path = abap_true ) }`,
+    )->a( n = `value` v = |\{ path: '{ client->_bind( val = mv_date path = abap_true ) }',
                               type: 'sap.ui.model.type.Date',
                               formatOptions: \{ pattern: 'yyyy-MM-dd',
                                                 source: \{ pattern: 'yyyyMMdd' \} \} \}|
@@ -86,7 +86,7 @@ ABAP `t` is a 6-character string `HHMMSS`. Same pattern as Date, with `sap.ui.mo
 
 ```abap
 )->tag( `TimePicker`
-    )->a( n = `value` v = |\{ path: `{ client->_bind( val = mv_time path = abap_true ) }`,
+    )->a( n = `value` v = |\{ path: '{ client->_bind( val = mv_time path = abap_true ) }',
                               type: 'sap.ui.model.type.Time',
                               formatOptions: \{ pattern: 'HH:mm:ss',
                                                 source: \{ pattern: 'HHmmss' \} \} \}|
@@ -127,7 +127,7 @@ A custom JS formatter wired through `sap.ui.model.SimpleType` is the third optio
 **Send as string with a source pattern** — convert to a string in `yyyyMMddHHmmss` format on the ABAP side, then bind with `sap.ui.model.type.DateTime`:
 ```abap
 )->tag( `DateTimePicker`
-    )->a( n = `value` v = |\{ path: `{ client->_bind( val = mv_ts_string path = abap_true ) }`,
+    )->a( n = `value` v = |\{ path: '{ client->_bind( val = mv_ts_string path = abap_true ) }',
                               type: 'sap.ui.model.type.DateTime',
                               formatOptions: \{ pattern: 'yyyy-MM-dd HH:mm:ss',
                                                 source: \{ pattern: 'yyyyMMddHHmmss' \} \} \}|
@@ -204,51 +204,51 @@ CLASS z2ui5_cl_smp_app_067 IMPLEMENTATION.
                             )->tag( `Label`
                                 )->a( n = `text` v = `One field`
                             )->tag( `Input`
-                                )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val  = amount
-                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
-                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency' \}|
+                                )->a( n = `value` v = |\{ parts: [ '{ client->_bind( val  = amount
+                                                                             path = abap_true ) }', '{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }'], type: 'sap.ui.model.type.Currency' \}|
                             )->tag( `Label`
                                 )->a( n = `text` v = `Two fields`
                             )->tag( `Input`
-                                )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val  = amount
-                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
-                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{showMeasure: false\} \}|
+                                )->a( n = `value` v = |\{ parts: [ '{ client->_bind( val  = amount
+                                                                             path = abap_true ) }', '{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }'], type: 'sap.ui.model.type.Currency', formatOptions: \{showMeasure: false\} \}|
                             )->tag( `Label`
                                 )->a( n = `text` v = `Two fields`
                             )->tag( `Input`
-                                )->a( n = `value` v = |\{ parts: [ `{ client->_bind( val  = amount
-                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
-                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{showNumber: false\} \}|
+                                )->a( n = `value` v = |\{ parts: [ '{ client->_bind( val  = amount
+                                                                             path = abap_true ) }', '{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }'], type: 'sap.ui.model.type.Currency', formatOptions: \{showNumber: false\} \}|
                             )->tag( `Label`
                                 )->a( n = `text` v = `Default`
                             )->tag( `Text`
-                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
-                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
-                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency' \}|
+                                )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
+                                                                             path = abap_true ) }', '{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }'], type: 'sap.ui.model.type.Currency' \}|
                             )->tag( `Label`
                                 )->a( n = `text` v = `preserveDecimals:false`
                             )->tag( `Text`
-                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
-                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
-                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{ preserveDecimals : false \} \}|
+                                )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
+                                                                             path = abap_true ) }', '{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }'], type: 'sap.ui.model.type.Currency', formatOptions: \{ preserveDecimals : false \} \}|
                             )->tag( `Label`
                                 )->a( n = `text` v = `currencyCode:false`
                             )->tag( `Text`
-                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
-                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
-                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{ currencyCode : false \} \}|
+                                )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
+                                                                             path = abap_true ) }', '{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }'], type: 'sap.ui.model.type.Currency', formatOptions: \{ currencyCode : false \} \}|
                             )->tag( `Label`
                                 )->a( n = `text` v = `style:'short'`
                             )->tag( `Text`
-                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
-                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
-                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{ style : 'short' \} \}|
+                                )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
+                                                                             path = abap_true ) }', '{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }'], type: 'sap.ui.model.type.Currency', formatOptions: \{ style : 'short' \} \}|
                             )->tag( `Label`
                                 )->a( n = `text` v = `style:'long'`
                             )->tag( `Text`
-                                )->a( n = `text` v = |\{ parts: [ `{ client->_bind( val  = amount
-                                                                             path = abap_true ) }`, `{ client->_bind( val  = currency
-                                                                                                                      path = abap_true ) }`], type: 'sap.ui.model.type.Currency', formatOptions: \{   style : 'long' \} \}|
+                                )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
+                                                                             path = abap_true ) }', '{ client->_bind( val  = currency
+                                                                                                                      path = abap_true ) }'], type: 'sap.ui.model.type.Currency', formatOptions: \{   style : 'long' \} \}|
 
                             )->tag( `Label`
                                 )->a( n = `text` v = `event`
@@ -283,8 +283,8 @@ CLASS z2ui5_cl_smp_app_067 IMPLEMENTATION.
                             )->tag( `Label`
                                 )->a( n = `text` v = `Without leading Zeros`
                             )->tag( `Text`
-                                )->a( n = `text` v = |\{ path : `{ client->_bind( val  = numeric
-                                                                                  path = abap_true ) }`, type : 'sap.ui.model.odata.type.String', constraints : \{ isDigitSequence : true \} \}| ).
+                                )->a( n = `text` v = |\{ path : '{ client->_bind( val  = numeric
+                                                                                  path = abap_true ) }', type : 'sap.ui.model.odata.type.String', constraints : \{ isDigitSequence : true \} \}| ).
 
     client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/model/tables.md
+++ b/docs/cookbook/model/tables.md
@@ -147,7 +147,7 @@ To make a table editable, use editable cell controls (e.g. `input`) — the bind
 ### Nested Structures
 You can also bind nested structures — use `structure/component` as the binding path:
 ```abap
-CLASS z2ui5_cl_sample_nested_structures DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_nested_struc DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
@@ -163,7 +163,7 @@ CLASS z2ui5_cl_sample_nested_structures DEFINITION PUBLIC.
 
 ENDCLASS.
 
-CLASS z2ui5_cl_sample_nested_structures IMPLEMENTATION.
+CLASS z2ui5_cl_sample_nested_struc IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     mt_itab = VALUE #(

--- a/docs/technical/concept.md
+++ b/docs/technical/concept.md
@@ -195,14 +195,14 @@ In standard UI5, updating the XML View usually causes a full re-render. But abap
 An example:
 
 ```abap
-CLASS z2ui5_cl_app_partial_rerendering DEFINITION PUBLIC.
+CLASS z2ui5_cl_app_partial_render DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
     DATA text TYPE string.
     DATA partly TYPE abap_bool.
 ENDCLASS.
 
-CLASS z2ui5_cl_app_partial_rerendering IMPLEMENTATION.
+CLASS z2ui5_cl_app_partial_render IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     text = text && ` text`.

--- a/test/playground.test.mjs
+++ b/test/playground.test.mjs
@@ -1,0 +1,203 @@
+/*
+ * Which fenced example gets a Run button.
+ *
+ * The decision is made in `docs/.vitepress/playground.mjs`, and the thing that
+ * could really decide it — the playground itself — is not in this repository.
+ * So the rules there are an approximation, and this file is what keeps the
+ * approximation honest: one fixture per shape that was actually watched failing
+ * in a playground, and one per shape that was watched SUCCEEDING and would be
+ * lost to a rule written one word too wide — a SELECT in a comment, the word
+ * FROM inside a string, an INSERT into an internal table.
+ *
+ * The failure this guards against is not a red page. It is a Run button on an
+ * example that cannot run: the reader clicks it, waits several seconds for an
+ * ABAP runtime to boot, and is shown an error message about the documentation
+ * they were reading. Every rule here therefore fails towards NO button.
+ *
+ *   node --test test/
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { abapOnly, playgroundExample } from '../docs/.vitepress/playground.mjs';
+
+/** A complete app class, with `body` as the whole of `main`. */
+const app = (name, body) => `CLASS ${name} DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+ENDCLASS.
+
+CLASS ${name} IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+${body}
+  ENDMETHOD.
+ENDCLASS.`;
+
+const DISPLAY = '    client->message_box_display( `Hello` ).';
+
+const runs = (code) => playgroundExample(code).name;
+const refused = (code) => playgroundExample(code).why;
+
+test('a complete app class that displays something gets a button', () => {
+  assert.equal(runs(app('zcl_app_hello', DISPLAY)), 'zcl_app_hello');
+});
+
+test('the name comes from the class, because the file is named after it', () => {
+  // The playground puts the code in a file called after the class and refuses
+  // the pair when they disagree - abapGit's rule, and abaplint's.
+  assert.equal(runs(app('z2ui5_cl_sample_tab', DISPLAY)), 'z2ui5_cl_sample_tab');
+});
+
+test('a fragment of a method gets nothing - there is no object to compile', () => {
+  assert.match(refused('view->ele( `Page` )->a( n = `title` v = `x` ).'), /not a complete class/);
+});
+
+test('a class that is not an app gets nothing', () => {
+  const helper = `CLASS zcl_helper DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    METHODS do.
+ENDCLASS.
+CLASS zcl_helper IMPLEMENTATION.
+  METHOD do.
+  ENDMETHOD.
+ENDCLASS.`;
+  assert.match(refused(helper), /z2ui5_if_app/);
+});
+
+test('a class name longer than 30 characters gets nothing, and says why', () => {
+  // Not a playground limit: an ABAP object name is 30 characters, so this is a
+  // class nobody can create anywhere. Two of them were printed here for years,
+  // invisible to check:examples because it renames every example before
+  // compiling it.
+  const why = refused(app('z2ui5_cl_sample_nested_structures', DISPLAY));
+  assert.match(why, /33 characters/);
+});
+
+test('an app that displays nothing gets nothing', () => {
+  // configuration/authorization.md: an authority check and a RETURN. It starts
+  // perfectly well and shows an empty frame, which demonstrates nothing.
+  const code = app('z2ui5_cl_app', `    AUTHORITY-CHECK OBJECT \`Z_APP_AUTH\` ID \`APP\` FIELD \`Z2UI5_APP_001\`.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.`);
+  assert.match(refused(code), /displays nothing/);
+});
+
+test('a SELECT from a business table gets nothing', () => {
+  const code = app('z2ui5_cl_sample_sql', `    SELECT FROM sflight FIELDS * INTO TABLE @DATA(rows).
+${DISPLAY}`);
+  assert.match(refused(code), /sflight/);
+});
+
+test('a SELECT from a table the page does have keeps its button', () => {
+  // technical/dx.md reads T100, which open-abap ships and which therefore is
+  // there. A rule that refused every SELECT would have taken this one too.
+  assert.equal(runs(app('zcl_app_alv', `    SELECT FROM t100 FIELDS * INTO TABLE @DATA(rows).
+${DISPLAY}`)), 'zcl_app_alv');
+});
+
+test('a SELECT in a comment is not a SELECT', () => {
+  // get_started/full_example.md prints the SELECT a reader would write, as a
+  // comment, above the demo data it uses instead - and it runs.
+  const code = app('zcl_app_full_example', `    " in your system, replace this with a SELECT, e.g.:
+    " SELECT order_id FROM zsd_order INTO TABLE @DATA(rows)
+${DISPLAY}`);
+  assert.equal(runs(code), 'zcl_app_full_example');
+});
+
+test('the word FROM inside a string is not a table', () => {
+  // cookbook/browser_interaction/clipboard.md says `Hello from abap2UI5`.
+  const code = app('z2ui5_cl_sample_clipboard', `    DATA(text) = \`Hello from abap2UI5\`.
+${DISPLAY}`);
+  assert.equal(runs(code), 'z2ui5_cl_sample_clipboard');
+});
+
+test('INSERT VALUE #( ) into an internal table is not a database write', () => {
+  const code = app('z2ui5_cl_app_table_basic', `    DATA rows TYPE string_table.
+    INSERT VALUE #( ) INTO TABLE rows.
+${DISPLAY}`);
+  assert.equal(runs(code), 'z2ui5_cl_app_table_basic');
+});
+
+test('EML gets nothing', () => {
+  const code = app('z2ui5_cl_sample_eml', `    READ ENTITIES OF i_salesorder IN LOCAL MODE ENTITY salesorder ALL FIELDS WITH VALUE #( ) RESULT DATA(rows).
+${DISPLAY}`);
+  assert.match(refused(code), /CDS entity|behavior definition/);
+});
+
+test('an add-on interface gets nothing', () => {
+  const code = `CLASS z2ui5_cl_lp_kpi_hello DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    INTERFACES z2ui5_if_lp_kpi.
+ENDCLASS.
+CLASS z2ui5_cl_lp_kpi_hello IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+${DISPLAY}
+  ENDMETHOD.
+  METHOD z2ui5_if_lp_kpi~count.
+  ENDMETHOD.
+ENDCLASS.`;
+  assert.match(refused(code), /add-on/);
+});
+
+test('an on-premise SAP class gets nothing', () => {
+  for (const call of ['cl_bcs_message=>create( )', 'cl_demo_output=>get( )',
+    'cl_abap_structdescr=>describe_by_name( `USR01` )']) {
+    assert.match(refused(app('z2ui5_cl_sample', `    DATA(x) = ${call}.
+${DISPLAY}`)), /on-premise/, call);
+  }
+});
+
+test('a method that is declared and never implemented gets nothing', () => {
+  // cookbook/event_navigation/life_cycle.md. This is not a playground limit
+  // either - the class does not activate in any system.
+  const code = `CLASS z2ui5_cl_demo_app_001 DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+  PROTECTED SECTION.
+    METHODS render_main.
+ENDCLASS.
+CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+${DISPLAY}
+  ENDMETHOD.
+ENDCLASS.`;
+  assert.match(refused(code), /render_main/);
+});
+
+test('a local class gets nothing, defined here or not', () => {
+  // cookbook/device_capabilities/spreadsheet.md calls lcl_help=>itab_get_by_xlsx.
+  // Defining it in the same fence would not help: a playground file is one
+  // abapGit object, and a class-local class is not one - abapGit puts it in a
+  // .clas.locals_imp.abap beside the class, which there is nowhere to put here.
+  const calls = app('z2ui5_cl_sample_upload', `    DATA(rows) = lcl_help=>itab_get_by_xlsx( \`x\` ).
+${DISPLAY}`);
+  assert.match(refused(calls), /lcl_help/);
+
+  const defines = `CLASS lcl_help DEFINITION.
+  PUBLIC SECTION.
+    CLASS-METHODS get RETURNING VALUE(r) TYPE string.
+ENDCLASS.
+CLASS lcl_help IMPLEMENTATION.
+  METHOD get.
+  ENDMETHOD.
+ENDCLASS.
+${app('z2ui5_cl_sample_upload', `    DATA(text) = lcl_help=>get( ).
+${DISPLAY}`)}`;
+  assert.match(refused(defines), /lcl_help/);
+});
+
+test('comments go, string templates keep their braces', () => {
+  const stripped = abapOnly([
+    '* a full-line comment',
+    'DATA(x) = 1. " a trailing one',
+    'DATA(y) = |a { x } b|.',
+    'DATA(z) = `a " b`.',
+  ].join('\n'));
+  assert.equal(stripped.includes('full-line'), false);
+  assert.equal(stripped.includes('trailing'), false);
+  assert.match(stripped, /DATA\(x\) = 1\./);
+  // The delimiters stay so nothing shifts; a double quote inside a literal is
+  // not the start of a comment.
+  assert.match(stripped, /DATA\(z\) = ` {5}`\./);
+});


### PR DESCRIPTION
The playground is the whole framework compiled into a page, it can be embedded, and the code it runs travels in the URL fragment. So an example printed here can be started from here: a **Run this example** button under the block, the running app under the code, and nothing hosted or written down twice — the ABAP that runs is read out of the rendered block at click time, so the printed example and the running one cannot drift apart.

Nothing is fetched until somebody presses a button. A reader who never does makes no request to another site.

## Which blocks get one

The only hard part, and the rule is narrow, because a button on an example that cannot run is worse than no button: the reader waits several seconds for an ABAP runtime to boot and is shown an error about the documentation they were reading.

**All 61 complete app classes here were opened in a real playground to find out.** 38 started. The 23 that did not are the rules in `docs/.vitepress/playground.mjs`, one per shape, each printing the reason it refused — an own table, a CDS entity, an add-on, an on-premise class, a method declared and never implemented, a local class.

Except three, which were not playground limits but defects in these pages, each invisible to every check this repository runs.

## The three

**Two class names of 32 and 33 characters.** An ABAP object name is 30; these classes exist nowhere. `check:examples` could not see them because it renames every example to `zcl_docs_example_NN` before compiling it.

**Every binding string on `cookbook/model/formatter.md` quoted its model path with ABAP backticks.** They are ABAP string delimiters, not UI5 ones, so they survive into the binding string; UI5 answers with a syntax error and renders nothing at all. The page taught a pattern that has never worked, in 24 places, and said so itself two paragraphs earlier — the "produces this at runtime" line shows quotes the ABAP above it does not write. The framework's own code uses `'`. Fixed, and the example now runs and renders.

## After the fixes

**39 examples carry a button. All 39 were run again; all 39 started and rendered.** The other 22 print their reason.

## The limit, stated

Whether an example runs is a question only a playground can answer, and a playground is a three-minute build of another repository — so this is the seventh decidable thing here and the only one CI cannot decide. The rules are a conservative approximation and they fail towards *no button*. AGENTS.md says how to repeat the measurement; `test/playground.test.mjs` pins one fixture per rule, and one per shape a rule written a word wider would have swallowed: a `SELECT` in a comment, the word FROM inside a string, an `INSERT VALUE #( )` into an internal table.

## Verification

`npm run check` green — 20 unit tests, `check:version`, `docs:build`, `check:examples` (46 examples compile and lint clean against UI5 1.71). `check:samples` and `check:counts` skip without the sibling checkouts, as usual; CI does them.

Checked in a browser against the real build, in light and dark, at the width a documentation column actually has.

## Order

Depends on [abap2UI5/playground#7](https://github.com/abap2UI5/playground/pull/7) being **deployed** first: the button needs the loader that names a file after the class in it (before that, `data-code` only worked for a class called `zcl_playground`, and every button here would have shown the reader a name error), the app-only layout fix below 820px, and `frameOptions="allow"` on the app frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018a4Vx4vw49zC8xV69uh5Qq

---
_Generated by [Claude Code](https://claude.ai/code/session_018a4Vx4vw49zC8xV69uh5Qq)_