### PR TITLE
Point the home page at the playground, and put Support in the nav bar

### DIFF
--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -3,6 +3,7 @@ import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
 import { setUpPlayground } from './playground.js'
+import { SupportLink } from './support-link.js'
 
 /** @type {import('vitepress').Theme} */
 export default {
@@ -10,6 +11,8 @@ export default {
   Layout: () => {
     return h(DefaultTheme.Layout, null, {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
+      // After the LinkedIn and GitHub icons, at the right-hand end of the bar.
+      'nav-bar-content-after': () => h(SupportLink),
     })
   },
   enhanceApp({ app, router, siteData }) {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -371,3 +371,38 @@
   color: var(--vp-c-text-2);
   font-size: 13px;
 }
+
+/* ------------------------------------------- the Support icon ---
+ *
+ * `docs/.vitepress/theme/support-link.js` puts the Support page at the
+ * right-hand end of the nav bar, after the social icons. It is one more thing
+ * in that row, so it is drawn as one: the same 36px box, the same muted
+ * colour, the same 20px glyph — and the same disappearing act below 768px,
+ * where the default theme drops the social links and the hamburger takes over.
+ * Copied rather than inherited, because VPSocialLink's styles are scoped to
+ * that component and this is deliberately not one. */
+.a2ui5-support {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  color: var(--vp-c-text-2);
+  transition: color 0.5s;
+}
+
+.a2ui5-support:hover {
+  color: var(--vp-c-text-1);
+  transition: color 0.25s;
+}
+
+.a2ui5-support svg {
+  width: 20px;
+  height: 20px;
+}
+
+@media (max-width: 767px) {
+  .a2ui5-support {
+    display: none;
+  }
+}

--- a/docs/.vitepress/theme/support-link.js
+++ b/docs/.vitepress/theme/support-link.js
@@ -1,0 +1,44 @@
+/*
+ * The Support page, as an icon at the right-hand end of the nav bar.
+ *
+ * Somebody who is stuck looks at the top of the page, not two scrolls down a
+ * sidebar. It sits after the LinkedIn and GitHub icons, in the slot the default
+ * theme leaves free there (`nav-bar-content-after`), and it is drawn to match
+ * them — this is one more thing in that row, not a button competing with it.
+ *
+ * Why it is not a `socialLinks` entry, which is what that row is:
+ * `VPSocialLink` hardcodes `target="_blank" rel="noopener"` and passes its
+ * `link` through verbatim. Both are right for a link that leaves the site and
+ * wrong for one that does not — a page of this documentation would open in a
+ * second tab, and the href would miss the `/docs/` base and 404 on the
+ * published site while working perfectly in a local dev server.
+ */
+import { h } from 'vue';
+import { withBase } from 'vitepress';
+
+/* A speech bubble: the Support page is "ask somebody" — an issue, or the Slack
+ * channel — rather than a manual. Inline rather than one of Font Awesome's,
+ * because that stylesheet comes from a CDN and an icon that is an empty square
+ * until it arrives is worse than one that never needed it. */
+const SPEECH_BUBBLE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+  <path fill="currentColor" d="M12 3c5.52 0 10 3.36 10 7.5S17.52 18 12 18c-.86 0-1.7-.08-2.5-.24L4.5 20.5a.6.6 0 0 1-.88-.66l.86-3.3C2.9 15.2 2 13.44 2 11.5 2 6.36 6.48 3 12 3Z"/>
+</svg>`;
+
+/* Built rather than written as a path: the site is published under /docs/, and
+ * `.html` because this build does not use clean URLs — the pages next to this
+ * one are linked as `/docs/resources/support.html` too. Both are read from the
+ * config rather than assumed; a raw `/resources/support` here is a 404 that
+ * only shows up after a deploy. */
+const SUPPORT = () => withBase('/resources/support.html');
+
+export const SupportLink = {
+  name: 'SupportLink',
+  render: () =>
+    h('a', {
+      class: 'a2ui5-support',
+      href: SUPPORT(),
+      'aria-label': 'Support',
+      title: 'Support',
+      innerHTML: SPEECH_BUBBLE,
+    }),
+};

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,11 +17,11 @@ hero:
       text: Get Started
       link: /get_started/quickstart
     - theme: alt
-      text: Introduction
-      link: /get_started/about
+      text: What's New?
+      link: /resources/changelog
     - theme: alt
-      text: Live Demo
-      link: https://abap2ui5.github.io/web-abap2UI5-build/
+      text: Playground
+      link: https://abap2ui5.github.io/playground/
 
 # One card per reader journey, in the order a newcomer meets them: install,
 # look things up, copy from working apps, take it to production, understand
@@ -73,6 +73,6 @@ ENDCLASS.
 That's it — no JavaScript, no OData service, no frontend deployment. Copy the
 class into your system and it runs anywhere abapGit reaches, from legacy R/3
 releases to S/4HANA Cloud and BTP. The [Hello World](/get_started/hello_world)
-page explains what happens here — or try apps like it in the
-[live demo](https://abap2ui5.github.io/web-abap2UI5-build/), right in your
-browser, no SAP system needed.
+page explains what happens here — or press **Run this example** above and watch
+this very class start in the [playground](https://abap2ui5.github.io/playground/):
+the whole framework compiled into a browser page, no SAP system needed.


### PR DESCRIPTION
Three changes to how somebody arriving here gets moving.

## Live Demo → Playground

The **Live Demo** button pointed at `web-abap2UI5-build`, which is a prebuilt abap2UI5 running in a browser — a demo *of* the framework. The playground is the same framework plus an editor: the reader can change the ABAP and press Run. It replaces the button and the sentence under the nine-line class.

That sentence now says the shorter thing anyway. Since #159 the example above it carries a **Run this example** button of its own, so the playground is one click away from the code rather than a page away from it.

`web-abap2UI5-build` is still linked from `get_started/quickstart`, `get_started/next` and — as a credit to larshp, which it should stay — `resources/sponsor`. Those three are untouched here; say the word if they should follow.

## Introduction → What's New?

Both hero buttons beside *Get Started* pointed at reading. The release notes are the page somebody already using this comes back for. `/get_started/about` is still in the nav bar and in the sidebar, so nothing is orphaned.

## Support, as an icon in the nav bar

After LinkedIn and GitHub, drawn to match them — same 36px box, same muted colour, same 20px glyph, and gone below 768px where the default theme drops the social row and the hamburger takes over. Somebody who is stuck looks at the top of the page, not two scrolls down a sidebar.

It is **not** a `socialLinks` entry, which is what that row is. `VPSocialLink` hardcodes `target="_blank" rel="noopener"` and passes its `link` through verbatim: a page of this documentation would open in a second tab, and the href would miss the `/docs/` base — a 404 on the published site that a local dev server would never show. So it goes in the `nav-bar-content-after` slot as an ordinary internal link, with the base and the `.html` this build uses applied through `withBase`.

## Verification

`npm run check` green. Built and driven in a browser, light and dark: the icon lands at x=1332 after the two social icons, the hero reads *Get Started · What's New? · Playground*, and clicking the icon navigates to `/docs/resources/support.html` in the same tab and lands on the Support page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018a4Vx4vw49zC8xV69uh5Qq

---
_Generated by [Claude Code](https://claude.ai/code/session_018a4Vx4vw49zC8xV69uh5Qq)_