### PR TITLE
Take the code off the home page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,9 @@ npm ci && npm run build && npm run serve      # the first build is a few minutes
 ```
 
 The last measurement: **61 complete app classes, 39 with a button, all 39
-started and rendered.** The 22 without one each have a reason the module prints.
+started and rendered.** The home page has since dropped its example, so the
+figure today is 60 and 38; the 22 without a button each have a reason the module
+prints.
 
 **The published playground is what readers get**, not the checkout you tested
 against. A change to the rules here can ship on its own; a change that depends

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Which blocks get a button is decided in `docs/.vitepress/playground.mjs`, and
 the rule is narrow on purpose — a button on an example that cannot run is worse
 than no button. It has to be a complete class implementing `z2ui5_if_app` that
 displays something and needs nothing the browser has not got: no table of its
-own, no CDS entity, no add-on repository, no on-premise SAP class. **39 of the
-262 ABAP blocks here** clear that today. Every rule was written from an example
+own, no CDS entity, no add-on repository, no on-premise SAP class. **38 of the
+261 ABAP blocks here** clear that today. Every rule was written from an example
 watched failing in a real playground; `test/playground.test.mjs` keeps one
 fixture per shape, and [AGENTS.md](AGENTS.md) says how to redo the measurement.
 

--- a/docs/.vitepress/playground.mjs
+++ b/docs/.vitepress/playground.mjs
@@ -26,10 +26,11 @@
  *
  * **Every rule below was put there by watching an example fail in a real
  * playground**, not by reasoning about what might. All 61 complete app classes
- * in this documentation were opened in one: 38 started, and the 23 that did not
- * are the list of shapes here — except for three, which were defects in the
- * documentation and were fixed instead. The 39 this module now offers a button
- * for were then run again, and all 39 started and rendered.
+ * this documentation had then were opened in one: 38 started, and the 23 that
+ * did not are the list of shapes here — except for three, which were defects in
+ * the documentation and were fixed instead. Every example that came out of that
+ * with a button was then run again, and every one of them started and
+ * rendered.
  *
  * AGENTS.md says how to repeat that measurement, and that is also the honest
  * limit of this file: the playground is the only thing that can decide the

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -206,26 +206,6 @@
   padding-bottom: 4px;
 }
 
-/* ------------------------------------------------------ the home page ---
- *
- * The markdown section under the feature cards (the hello-world class). The
- * home layout hands markdown content the full 1152px of the feature grid; a
- * nine-line code block at that width reads as a banner, not as code. Center
- * it at the width the reading column uses everywhere else, and give it air
- * against the cards above so it starts a section instead of trailing one. */
-.VPHome .vp-doc > div {
-  max-width: 688px;
-  margin: 40px auto 0;
-}
-
-/* The section heading on the home page has no sections above it to separate
- * from — the top rule that earns its keep on a long cookbook page is just a
- * stray line here. */
-.VPHome .vp-doc h2 {
-  border-top: none;
-  padding-top: 0;
-}
-
 /* ------------------------------------------------- the callout boxes ---
  *
  * The tip/warning/danger blocks keep the width the reading column had BEFORE

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,25 +54,3 @@ features:
     details: Browse the code, report issues, contribute — the project is built in the open.
     link: https://github.com/abap2UI5/abap2UI5/
 ---
-
-## A complete app in nine lines
-
-```abap
-CLASS zcl_app_hello_world DEFINITION PUBLIC.
-  PUBLIC SECTION.
-    INTERFACES z2ui5_if_app.
-ENDCLASS.
-
-CLASS zcl_app_hello_world IMPLEMENTATION.
-  METHOD z2ui5_if_app~main.
-    client->message_box_display( `Hello World` ).
-  ENDMETHOD.
-ENDCLASS.
-```
-
-That's it — no JavaScript, no OData service, no frontend deployment. Copy the
-class into your system and it runs anywhere abapGit reaches, from legacy R/3
-releases to S/4HANA Cloud and BTP. The [Hello World](/get_started/hello_world)
-page explains what happens here — or press **Run this example** above and watch
-this very class start in the [playground](https://abap2ui5.github.io/playground/):
-the whole framework compiled into a browser page, no SAP system needed.


### PR DESCRIPTION
The hero, the six cards, and nothing under them.

**What goes with it.** The paragraph that followed the class opened with "That's it — no JavaScript, no OData service, no frontend deployment", about the listing above it, and pointed at Hello World and the playground. The tagline already says the first half, the Quickstart card and the Playground button carry the second, and a paragraph whose first two words refer to a code block that is gone is not a paragraph worth keeping.

Two things follow from the removal rather than being separate changes:

**The home page CSS goes too.** `.VPHome .vp-doc > div` capped that markdown section at the reading column, and `.VPHome .vp-doc h2` took the top rule off its heading. Both existed for the block that just left, and a rule that styles nothing is a rule nobody can check. The reasoning is in the commit message if prose ever comes back to that page.

**The counts follow.** The home page carried one of the runnable examples, so this documentation now has **60 complete app classes and 38 Run buttons across 261 fenced blocks**, not 61, 39 and 262. `README.md`, `AGENTS.md` and the module header say so. The measurement itself is unchanged — it was taken on the 61 that existed then, and every example that came out of it with a button was run and rendered.

## Verification

`npm run check` green. Built and loaded in a browser: no code block on the page, the `.vp-doc` container renders empty, and the page is hero + cards + footer at 1209px tall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018a4Vx4vw49zC8xV69uh5Qq

---
_Generated by [Claude Code](https://claude.ai/code/session_018a4Vx4vw49zC8xV69uh5Qq)_