### PR TITLE
Point the documentation at the three sample pages, once

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -132,6 +132,27 @@ export default defineConfig({
         text: "Links",
         items: [
           {
+            // The three sample corpora publish a searchable page each, and
+            // those pages call each other Learn / Controls / Stack in a bar
+            // all three carry. Same three words here, so a reader arriving
+            // from one of them recognises where they are. The repositories are
+            // under "Project" below: a page is what you want when you are
+            // looking for a sample, the repository when you are installing it.
+            text: "Samples",
+            items: [
+              { text: "Learn", link: "https://abap2ui5.github.io/samples/" },
+              {
+                text: "Controls",
+                link: "https://abap2ui5.github.io/samples-controls/",
+              },
+              {
+                text: "Stack",
+                link: "https://abap2ui5.github.io/samples-stack/",
+              },
+              { text: "Which one to search", link: "/resources/samples" },
+            ],
+          },
+          {
             text: "Project",
             items: [
               {

--- a/docs/get_started/next.md
+++ b/docs/get_started/next.md
@@ -6,15 +6,16 @@ outline: [2, 4]
 You've installed abap2UI5 and built your first app. From here, pick the direction that fits your goals.
 
 ## Sample Apps
-With hundreds of samples, the [samples repository](https://github.com/abap2UI5/samples) is the fastest way to learn abap2UI5. Browse tables, lists, trees, and other UI5 controls — copy and paste snippets to speed up your own work:
+Hundreds of working apps, and the fastest way to learn abap2UI5 is to read one that already does what you are about to write. They live in three repositories, each with a page that searches it — [**Learn**](https://abap2ui5.github.io/samples/) is the one to start on: the path from the smallest app that runs to files, devices and custom CSS, one idea per sample.
 
-Looking for one in particular? The [sample catalogue](https://github.com/abap2UI5/samples/blob/main/SAMPLES.md) lists every app on one page with the words you would search it by, so `Ctrl+F` for `f4`, `tree` or `nav_app_call` lands on the class that does it. The [Cookbook](/cookbook/overview) links the same apps from the page that explains the pattern.
+Looking for one in particular? Search the page, or `Ctrl+F` the [catalogue](https://github.com/abap2UI5/samples/blob/main/SAMPLES.md) for `f4`, `tree` or `nav_app_call`. [Sample Catalogues](/resources/samples) tells the three repositories apart, and the [Cookbook](/cookbook/overview) links the same apps from the page that explains the pattern.
 
 ![Sample apps overview showing tables, lists, trees, and other UI5 controls](/get_started/image-1.png)
 
-_No system at hand? The [live demo](https://abap2ui5.github.io/web-abap2UI5-build/) runs
-these samples in the browser — the whole abap2UI5 stack, backend included,
-transpiled to JavaScript and rebuilt daily from `main`. Nothing to install._
+_No system at hand? Every card on the **Learn** and **Controls** pages opens
+that class in the [playground](https://abap2ui5.github.io/playground/) — the
+ABAP in an editor with the app running beside it, in the browser. Nothing to
+install._
 
 ::: tip Contribution
 The samples evolve all the time. Have one to share? Open a PR so others can learn from it.

--- a/docs/get_started/tooling.md
+++ b/docs/get_started/tooling.md
@@ -69,13 +69,13 @@ extension for the system connection.
 
 ## Where the samples live
 
-Three repositories, in the order they build on each other:
+Three repositories, each with a searchable page of its own:
+[**Learn**](https://abap2ui5.github.io/samples/) for *“Where do I start?”*,
+[**Controls**](https://abap2ui5.github.io/samples-controls/) for *“Which
+control does what?”*, and [**Stack**](https://abap2ui5.github.io/samples-stack/)
+for *“Will my system run it?”*.
 
-| | |
-| --- | --- |
-| [samples](https://github.com/abap2UI5/samples) | the fundamentals — binding, events, popups, navigation, and complete little apps |
-| [samples-controls](https://github.com/abap2UI5/samples-controls) | the UI5 demo kit rebuilt in abap2UI5, one app per official sample |
-| [samples-stack](https://github.com/abap2UI5/samples-stack) | abap2UI5 together with OData, RAP, WebSockets and the Fiori Launchpad |
-
+[Sample Catalogues](/resources/samples) is the page that tells the three apart
+— what each one holds, how many, and which to search for what you are asking.
 All three install with abapGit and carry an overview app that lists everything
 they contain.

--- a/docs/resources/samples.md
+++ b/docs/resources/samples.md
@@ -12,13 +12,35 @@ time than reading this page.
 
 | | | you are asking |
 |---|--:|---|
-| [**samples**](https://github.com/abap2UI5/samples/blob/main/SAMPLES.md) | 152 | *has somebody already built this pattern?* — value help, navigation between apps, trees, tables, timers, file up- and download. Runs on a bare abap2UI5 install. |
-| [**samples-controls**](https://github.com/abap2UI5/samples-controls/blob/main/SAMPLES.md) | 430 | *how is this UI5 control expressed in ABAP?* — the UI5 demo kit, rebuilt control by control, grouped by library. |
-| [**samples-stack**](https://github.com/abap2UI5/samples-stack/blob/main/SAMPLES.md) | 32 | *how do I reach my system from an app?* — OData, RAP, APC, MIME, the Fiori Launchpad. Each needs something the framework alone does not give you. |
+| [**Learn**](https://abap2ui5.github.io/samples/) — abap2UI5/samples, [catalogue](https://github.com/abap2UI5/samples/blob/main/SAMPLES.md) | 152 | *“Where do I start?”* — value help, navigation between apps, trees, tables, timers, file up- and download. Runs on a bare abap2UI5 install. |
+| [**Controls**](https://abap2ui5.github.io/samples-controls/) — abap2UI5/samples-controls, [catalogue](https://github.com/abap2UI5/samples-controls/blob/main/SAMPLES.md) | 430 | *“Which control does what?”* — the UI5 demo kit, rebuilt control by control, grouped by library. |
+| [**Stack**](https://abap2ui5.github.io/samples-stack/) — abap2UI5/samples-stack, [catalogue](https://github.com/abap2UI5/samples-stack/blob/main/SAMPLES.md) | 32 | *“Will my system run it?”* — OData, RAP, APC, MIME, the Fiori Launchpad. Each needs something the framework alone does not give you. |
 
-Start with **samples** if you are learning abap2UI5, with **samples-controls**
-if you know which control you want, and with **samples-stack** only when the
-app has to talk to something in your system.
+They are not three steps to work through in order. **Learn** is a path and does
+have a beginning; **Controls** is a reference you come back to whenever you
+need one control; **Stack** only matters once the app has to talk to something
+in your system. Pick the one that matches what you are asking today.
+
+::: tip The three verbs are the same everywhere
+**Learn**, **Controls** and **Stack** are what the three pages call each other
+in the bar at the top of each of them, and what the playground calls them in
+its About dialog. Same word, same page, wherever you meet it.
+:::
+
+## Two ways to read a catalogue
+
+Each repository publishes its corpus twice, from one scan, so the two cannot
+disagree:
+
+| | |
+|---|---|
+| the **page** (the first link in each row above) | searchable in the browser, with the facets that corpus is actually asked for — a release your system runs, a control used anywhere in a view, a technology and the setup it needs |
+| the **catalogue** `SAMPLES.md` | the same corpus as one long page on GitHub, for `Ctrl+F` and for reading offline. The counts above are of these. |
+
+The pages are the better answer to *"is there a sample for X"*, because they
+filter; the catalogues are the better answer to *"show me everything"*. The
+page for **Learn** deliberately shows only the portable subset that survives
+every build, so it lists fewer apps than the 152 the catalogue counts.
 
 ## The pages have the same shape on purpose
 
@@ -77,3 +99,14 @@ with [abapGit](https://abapgit.org), then start any class by name:
 Each repository also ships an **overview app** that lists its own samples with
 a search box, so once the repository is in your system you do not need the page
 here at all.
+
+### Without a system
+
+Every card on the **Learn** and **Controls** pages carries a button that opens
+that class in the [playground](https://abap2ui5.github.io/playground/) — the
+ABAP in an editor with the app running beside it, in the browser, nothing
+installed anywhere.
+
+**Stack** is the exception, and says so on its own cards: a Gateway service, a
+RAP business object, an APC channel or a launchpad is precisely what the
+playground does not have, so those samples would open there and then fail.


### PR DESCRIPTION
The three sample corpora publish a searchable page each, and those pages now carry a bar naming each other — **Learn**, **Controls**, **Stack**. This repository told the same story in **four places, in three different framings**, and linked none of those pages:

| where | what it said | what it linked |
|---|---|---|
| `resources/samples.md` | the long version — three repositories, three questions | the `SAMPLES.md` files |
| `get_started/tooling.md` | a second three-row table, *"in the order they build on each other"* | the GitHub repositories |
| `get_started/next.md` | the samples repository, plus a live demo | `web-abap2UI5-build` |
| the nav, under Links → Project | three repository names | the GitHub repositories |

That second one is worth naming: *"in the order they build on each other"* is the ladder framing that was just removed from the samples-stack page, because it claims an order that does not hold — Controls is a reference you come back to whenever you need one control, not a step you finish.

## One long telling, three pointers

**`resources/samples.md`** stays the one page that tells the three apart, and is the only one that argues:

- each row is now **led by the page** and closed by the catalogue;
- the three questions are worded **exactly as the card strip on the pages words them** — *"Where do I start?"*, *"Which control does what?"*, *"Will my system run it?"* — so a reader who saw one recognises the other;
- a new short section says what the two links are *for*: the page filters (release, control, technology), the catalogue is everything on one screen for `Ctrl+F`;
- and a *Without a system* section, because the playground link per card is the honest answer to that — including why **Stack** is the exception and says so on its own cards.

**`tooling.md`** and **`next.md`** shrink to a pointer at it. The **nav** gains a *Samples* group carrying the three pages under the same three verbs, with the repositories left where they were under *Project* — a page is what you want when you are looking for a sample, the repository when you are installing one.

## The counts are untouched, and still checked

`check:counts` anchors each figure on the `SAMPLES.md` link in its row, so the catalogue link **stays last in every row** and the check keeps working unchanged — no regex was loosened to make this diff fit.

The counts count the catalogues, and the pages do not all count the same thing: Learn's page shows only the portable subset that survives every build, so it lists fewer apps than the 152 its catalogue counts. Rather than print two numbers for one repository, the page now says that in a sentence, and the table keeps the catalogue figures it always had.

## `next.md` stops advertising the old in-browser demo

It sent readers with no system to `web-abap2UI5-build`. The answer the three pages themselves give is the playground — every card on Learn and Controls opens its class there — so that is what it says now.

## Verification

`npm run check` locally, with `SAMPLES_HOME` pointing at an `abap2UI5/samples` checkout:

- `test` — 20 pass, 0 fail
- `docs:build` — build complete, all pages render
- `check:examples` — every view-building example compiles and names API that exists (the four EML/CDS examples are skipped as they always are)
- `check:samples` — 152 samples in the catalogue, 39 pages declaring 109 links, up to date
- `check:counts` — **4 claims found on the page, every count matches its catalogue**, which is the one that would have caught a careless table rewrite

---
_Generated by [Claude Code](https://claude.ai/code/session_014QKMsbCiREgnpdfVvQYsa2)_