### PR TITLE
Home page: a face on the Support icon, five cards, links that are just the repos

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -129,53 +129,28 @@ export default defineConfig({
         ],
       },
       {
+        // Just the repositories, flat. The dropdown used to carry the three
+        // sample catalogues on top of them, which meant nine entries in two
+        // groups and a reader scanning for "where is the code" reading past
+        // half of it first. The catalogues are a reading destination and are
+        // linked where a reader looks for one — /resources/samples in the
+        // sidebar, and the cookbook chapters; this menu answers the other
+        // question, which repository to clone.
         text: "Links",
         items: [
+          { text: "abap2UI5", link: "https://github.com/abap2UI5/abap2UI5" },
+          { text: "addons", link: "https://github.com/abap2UI5-addons" },
+          { text: "samples", link: "https://github.com/abap2UI5/samples" },
           {
-            // The three sample corpora publish a searchable page each, and
-            // those pages call each other Learn / Controls / Stack in a bar
-            // all three carry. Same three words here, so a reader arriving
-            // from one of them recognises where they are. The repositories are
-            // under "Project" below: a page is what you want when you are
-            // looking for a sample, the repository when you are installing it.
-            text: "Samples",
-            items: [
-              { text: "Learn", link: "https://abap2ui5.github.io/samples/" },
-              {
-                text: "Controls",
-                link: "https://abap2ui5.github.io/samples-controls/",
-              },
-              {
-                text: "Stack",
-                link: "https://abap2ui5.github.io/samples-stack/",
-              },
-              { text: "Which one to search", link: "/resources/samples" },
-            ],
+            text: "samples-controls",
+            link: "https://github.com/abap2UI5/samples-controls",
           },
           {
-            text: "Project",
-            items: [
-              {
-                text: "abap2UI5",
-                link: "https://github.com/abap2UI5/abap2UI5",
-              },
-              { text: "addons", link: "https://github.com/abap2UI5-addons" },
-              { text: "samples", link: "https://github.com/abap2UI5/samples" },
-              {
-                text: "samples-controls",
-                link: "https://github.com/abap2UI5/samples-controls",
-              },
-              {
-                text: "samples-stack",
-                link: "https://github.com/abap2UI5/samples-stack",
-              },
-              { text: "docs", link: "https://github.com/abap2UI5/docs" },
-              {
-                text: "issues",
-                link: "https://github.com/abap2UI5/abap2UI5/issues",
-              },
-            ],
+            text: "samples-stack",
+            link: "https://github.com/abap2UI5/samples-stack",
           },
+          { text: "docs", link: "https://github.com/abap2UI5/docs" },
+          { text: "issues", link: "https://github.com/abap2UI5/abap2UI5/issues" },
         ],
       },
       {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -386,3 +386,74 @@
     display: none;
   }
 }
+
+/* ------------------------------------ the home page, below the hero ---
+ *
+ * Five feature cards, not six. VPFeatures picks its column count from the
+ * NUMBER of cards — 6 gives `grid-6` and three per row, 5 gives `grid-4` and
+ * four in the first row with the fifth alone under it. Five cards is the
+ * decision (docs/index.md says why samples are not one of them), so the
+ * column count is set here instead of being an accident of the count.
+ * `.VPHome` in front only to outrank the component's own scoped rule without
+ * an `!important`. */
+@media (min-width: 768px) {
+  .VPHome .VPFeatures .item.grid-4 {
+    width: calc(100% / 3);
+  }
+}
+
+/* The three sample catalogues, under the grid and deliberately not part of it:
+ * they are pages published by three OTHER repositories, and every card above
+ * them stays on this site. A rule, small type and a row of pills — enough to
+ * read as "and, separately, over there" rather than as a sixth card.
+ *
+ * The selectors carry the block class twice because this sits inside
+ * `.vp-doc` — VPHomeContent wraps the markdown that follows the frontmatter —
+ * and `.vp-doc p` / `.vp-doc a` outrank a single class. */
+.a2ui5-catalogues {
+  margin: 40px auto 0;
+  max-width: 1152px;
+  padding-top: 28px;
+  border-top: 1px solid var(--vp-c-divider);
+  text-align: center;
+}
+
+.a2ui5-catalogues .a2ui5-catalogues-lead {
+  margin: 0;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  line-height: 22px;
+}
+
+.a2ui5-catalogues .a2ui5-catalogues-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 12px;
+  margin: 16px 0 0;
+}
+
+.a2ui5-catalogues .a2ui5-catalogues-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 20px;
+  padding: 5px 16px;
+  color: var(--vp-c-text-1);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: border-color 0.25s, color 0.25s;
+}
+
+.a2ui5-catalogues .a2ui5-catalogues-links a::after {
+  content: "↗";
+  font-size: 12px;
+  opacity: 0.55;
+}
+
+.a2ui5-catalogues .a2ui5-catalogues-links a:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}

--- a/docs/.vitepress/theme/support-link.js
+++ b/docs/.vitepress/theme/support-link.js
@@ -16,12 +16,22 @@
 import { h } from 'vue';
 import { withBase } from 'vitepress';
 
-/* A speech bubble: the Support page is "ask somebody" — an issue, or the Slack
- * channel — rather than a manual. Inline rather than one of Font Awesome's,
- * because that stylesheet comes from a CDN and an icon that is an empty square
- * until it arrives is worse than one that never needed it. */
-const SPEECH_BUBBLE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-  <path fill="currentColor" d="M12 3c5.52 0 10 3.36 10 7.5S17.52 18 12 18c-.86 0-1.7-.08-2.5-.24L4.5 20.5a.6.6 0 0 1-.88-.66l.86-3.3C2.9 15.2 2 13.44 2 11.5 2 6.36 6.48 3 12 3Z"/>
+/* A speech bubble with a smiling face: the Support page is "ask somebody" — an
+ * issue, or the Slack channel — rather than a manual, and the face says a
+ * person answers on the other side. Drawn as an outline so it reads as one
+ * shape at the 20px the nav bar gives it; the bubble stops short of the face
+ * instead of running behind it, because a stroke crossing a stroke turns into
+ * a smudge at that size.
+ *
+ * Inline rather than one of Font Awesome's, because that stylesheet comes from
+ * a CDN and an icon that is an empty square until it arrives is worse than one
+ * that never needed it. */
+const SPEECH_BUBBLE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <path d="M11.25 4.25H5A2.75 2.75 0 0 0 2.25 7v6.5A2.75 2.75 0 0 0 5 16.25h.93v2.63a.6.6 0 0 0 .97.47l4-3.1h7.6a2.75 2.75 0 0 0 2.75-2.75V12"/>
+  <circle cx="17.5" cy="6.5" r="4.9"/>
+  <circle cx="15.9" cy="5.3" r=".85" fill="currentColor" stroke="none"/>
+  <circle cx="19.1" cy="5.3" r=".85" fill="currentColor" stroke="none"/>
+  <path d="M15.6 8.2a2.45 2.45 0 0 0 3.8 0"/>
 </svg>`;
 
 /* Built rather than written as a path: the site is published under /docs/, and

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,10 +24,16 @@ hero:
       link: https://abap2ui5.github.io/playground/
 
 # One card per reader journey, in the order a newcomer meets them: install,
-# look things up, copy from working apps, take it to production, understand
-# it, join in. GitHub and LinkedIn are NOT cards — both already sit in the
-# nav bar as social icons, and a card spent on a link that is always visible
-# is a card not spent on a journey.
+# look things up, take it to production, understand it, join in. GitHub and
+# LinkedIn are NOT cards — both already sit in the nav bar as social icons,
+# and a card spent on a link that is always visible is a card not spent on a
+# journey.
+#
+# Samples are NOT a card either, and that is the one deliberate gap: the three
+# catalogues are somewhere else entirely — three published pages, not a page of
+# this site — and a card that looks like the five around it and then leaves the
+# site is the card people click by accident. They sit below the grid instead,
+# set apart, where leaving is the obvious thing to be doing.
 features:
   - title: Quickstart
     icon: <i class="fa-solid fa-rocket"></i>
@@ -37,10 +43,6 @@ features:
     icon: <i class="fa-solid fa-book"></i>
     details: Recipes for everyday tasks — views, binding, tables, events, popups, files.
     link: /cookbook/overview
-  - title: Samples
-    icon: <i class="fa-solid fa-shapes"></i>
-    details: Hundreds of small working apps to copy from — one per control or pattern.
-    link: /resources/samples
   - title: Configuration
     icon: <i class="fa-solid fa-gear"></i>
     details: Setup, security, performance, launchpad — the road to production use.
@@ -54,3 +56,17 @@ features:
     details: Browse the code, report issues, contribute — the project is built in the open.
     link: https://github.com/abap2UI5/abap2UI5/
 ---
+
+<!-- Below the feature grid, off on its own: the three sample catalogues, each
+     a page published by its own repository. No figure here on purpose —
+     check:counts verifies the counts on resources/samples.md against the
+     catalogues themselves, and a second copy on this page is one nothing
+     would check. -->
+<div class="a2ui5-catalogues">
+  <p class="a2ui5-catalogues-lead">Looking for a working app to copy? The sample catalogues are searchable in the browser — nothing to install.</p>
+  <p class="a2ui5-catalogues-links">
+    <a href="https://abap2ui5.github.io/samples/" target="_blank" rel="noreferrer">Learn</a>
+    <a href="https://abap2ui5.github.io/samples-controls/" target="_blank" rel="noreferrer">Controls</a>
+    <a href="https://abap2ui5.github.io/samples-stack/" target="_blank" rel="noreferrer">Stack</a>
+  </p>
+</div>


### PR DESCRIPTION
Four small things at the top of the site, all of them about what a reader has to read before they can act.

## The Support icon has a face

`docs/.vitepress/theme/support-link.js`

It was a filled speech bubble, which at the 20px the nav bar gives it is a blob. It now carries a smiling face — the page behind it is *ask somebody*, an issue or the Slack channel, and a face says a person answers on the other side.

Drawn as an outline, with the bubble stopping short of the face rather than running behind it: at that size a stroke crossing a stroke turns into a smudge. Still inline SVG, for the reason the file already gives — a CDN icon is an empty square until it arrives.

## The Links menu is the repositories

`docs/.vitepress/config.mjs`

It carried the three sample catalogues on top of the seven repositories, in two labelled groups. Nine entries, and somebody opening a menu called *Links* to find out where the code lives read past half of it first.

Seven entries now, flat, no group headings. The catalogues are still linked where somebody looks for one: `/resources/samples` in the sidebar, and the cookbook chapters.

## The Samples card is off the grid, and the catalogues sit under it

`docs/index.md`

Five cards, not six. The catalogues are pages published by three *other* repositories, and a card that looks like the five around it and then leaves the site is the card people click by accident.

They sit under the grid instead, behind a rule, as three small links that say where they go — separate on purpose. No count is repeated there: `check:counts` verifies the figures on `resources/samples.md` against the catalogues themselves, and a second copy on the home page is one nothing would check.

## Five cards needed a column count

`docs/.vitepress/theme/style.css`

`VPFeatures` picks its column count from the **number** of cards — six gives `grid-6` and three per row, five gives `grid-4` and four in the first row with the fifth alone under it. Five cards is the decision, so the override sets the column count rather than leaving the layout to the arithmetic.

## Verification

`npm run check` — green. `check:samples` and `check:counts` skip without the sample checkouts, as documented in AGENTS.md; CI has them.

Rendered and checked at 1440px and 390px, light and dark.

---
_Generated by [Claude Code](https://claude.ai/code/session_0114tsUfoCqYSia1HHSwnjXk)_