### PR TITLE
Document the tab icon next to the other things the exit sets

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -382,6 +382,7 @@ export default defineConfig({
               { text: "Bootstrapping", link: "/configuration/setup/ui5_bootstrapping" },
               { text: "Bootstrap Attributes", link: "/configuration/setup/bootstrap_attributes" },
               { text: "Style / CSS", link: "/configuration/setup/style_css" },
+              { text: "Favicon", link: "/configuration/setup/favicon" },
               { text: "Logon Language", link: "/configuration/setup/logon_language" },
             ],
           },

--- a/docs/configuration/setup.md
+++ b/docs/configuration/setup.md
@@ -32,6 +32,7 @@ ENDCLASS.
 | [Bootstrapping](/configuration/setup/ui5_bootstrapping)           | `src`                        | `src` of the bootstrap script (UI5 version + delivery channel) |
 | [Bootstrap Attributes](/configuration/setup/bootstrap_attributes) | `t_add_config`               | Additional `data-sap-ui-*` attributes |
 | [Style / CSS](/configuration/setup/style_css)                     | `styles_css`                 | Inline `<style>` block in the page `<head>` |
+| [Favicon](/configuration/setup/favicon)                           | `favicon`                    | `<link rel="icon">` in the page `<head>` — the tab icon |
 | [Language](/configuration/setup/logon_language)                   | URL parameter `sap-language` | SAP session language + UI5 locale |
 
 Security-relevant headers and the Content Security Policy meta tag are configured separately — see [Security](/configuration/security).

--- a/docs/configuration/setup/favicon.md
+++ b/docs/configuration/setup/favicon.md
@@ -1,0 +1,58 @@
+---
+outline: [2, 4]
+---
+# Favicon
+
+The favicon is the small icon a browser shows in the tab, in the bookmark list and on the history page. In a hand-written `index.html` it is a `<link rel="icon">` pointing at a file. In abap2UI5 you set it from ABAP:
+
+```abap
+METHOD z2ui5_if_exit~set_config_http_get.
+
+    cs_config-favicon = `/sap/public/bc/ui2/logo/company.png`.
+
+ENDMETHOD.
+```
+
+If you leave the field untouched, abap2UI5 uses its own mark — the same one this documentation and the sample pages show. Clear the field and the page carries no `<link rel="icon">` at all, which lets the browser fall back to `/favicon.ico` on your host:
+
+```abap
+CLEAR cs_config-favicon.
+```
+
+## What You Can Put In It
+
+Anything a browser accepts as an icon URL:
+
+| Value | Use it when |
+|---|---|
+| an absolute path on your system (`/sap/public/…`, a MIME repository object, a BSP resource) | the icon is already deployed somewhere on the host |
+| a full URL | the icon is served by another host — check your [Content Security Policy](/configuration/security) allows that origin |
+| a `data:` URI | you want no deployment step at all; the default CSP already allows `data:` |
+
+The framework's own default is a `data:` URI holding a two-element SVG, because the page is generated in ABAP and has no static resources of its own:
+
+```abap
+cs_config-favicon =
+  |data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' | &&
+  |viewBox='0 0 40 40' fill='%23fff'>| &&
+  |<circle cx='20' cy='20' r='20' fill='%23d03c4a'/></svg>|.
+```
+
+Two things to know about SVG data URIs: the markup must be **well-formed XML** (a stray unclosed tag gives you no icon and no error), and it may contain no double quotes, since it sits inside one — use single quotes for the attributes and `%23` for `#` in a colour.
+
+## Changing It While the App Runs
+
+`cs_config-favicon` is read once, when the browser asks for the page. To change the icon from inside a running app — a status indicator, a per-app icon in a multi-app system — use the `SET_FAVICON` frontend action instead:
+
+```abap
+client->follow_up_action(
+    val   = z2ui5_if_client=>cs_event-set_favicon
+    t_arg = VALUE #( ( `data:image/svg+xml,<svg …/></svg>` ) ) ).
+```
+
+See [Set the Tab Title and Favicon](/cookbook/browser_interaction/title) for the runnable sample.
+
+## See Also
+
+- [Setup](/configuration/setup) — every field on `cs_config` and the page that documents it.
+- [Security](/configuration/security) — the Content Security Policy, which decides what an icon URL may point at.


### PR DESCRIPTION
abap2UI5 gained `cs_config-favicon` ([abap2UI5/abap2UI5#2645](https://github.com/abap2UI5/abap2UI5/pull/2645)): the tab icon, set from the same exit method as the title, the theme and the bootstrap. Every other field on `cs_config` has a page and a row in the Setup table; this one would otherwise exist only in the framework's source.

The page answers what the field actually gets asked:

- what may go in it — a path on the system, a full URL (and then the CSP has a say), or a `data:` URI;
- why the shipped default is a data URI at all (the page is generated in ABAP and has no static resources of its own);
- the two things an SVG data URI gets wrong: it must be well-formed XML, and it may hold no double quotes since it sits inside a pair;
- how to clear it, and what the browser does then.

Changing the icon *while the app runs* is a different mechanism, so the page points at the `SET_FAVICON` action and the [cookbook sample](https://abap2ui5.github.io/docs/cookbook/browser_interaction/title) that already covers it rather than re-explaining it.

Wired into the sidebar under Configuration → Setup and into the field table on the Setup page, so `generate-llms.mjs` sees a page the navigation reaches.

Checked: `npm run docs:build`, `npm run check:examples`, `npm test` (20 passing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEQ6sewT1hd5KvrCKZrNEo)_