### PR TITLE
Compile the examples against the release, and gate the deploy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,14 +1,19 @@
 # What a pull request against this documentation gets checked for.
 #
-# There was nothing before this: deploy.yml runs on push to main, so a broken
-# build or a broken example reached the site and was found there. A docs
+# There was nothing before this: deploy.yml published without checking, so a
+# broken build or a broken example reached the site and was found there. A docs
 # repository has no compiler for its prose - but the fenced ABAP is code, and
 # the site build is a build, so both can be decided before a merge.
+#
+# deploy.yml now runs this same list before it publishes, so this file is the
+# pull-request half of one gate rather than a second opinion nothing acted on.
 name: check
 
 on:
-  push:
-    branches: [main]
+  # Pull requests only. The same list runs on main from inside deploy.yml, in
+  # the job that publishes - which is what makes a green deploy mean something.
+  # Running it here as well would be the same work twice, and the version of it
+  # that mattered was never the one connected to the deploy.
   pull_request:
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,16 @@
-# Sample workflow for building and deploying a VitePress site to GitHub Pages
+# Build and deploy the VitePress site to GitHub Pages.
 #
+# This used to build and publish without running a single check. check.yml ran
+# the six gates in parallel on the same push, which looks equivalent and is
+# not: nothing connected the two, so a red check and a green deploy simply both
+# happened, and the site went out with whatever the gates had objected to. The
+# gates are the ones that go stale WITHOUT anybody touching this repository -
+# a release is published elsewhere, a sample class is renamed elsewhere - so
+# "it was green when it merged" is not the same claim as "it is true now".
+#
+# So the gates run here, in the job that publishes, and the build only follows
+# a green one. check.yml keeps them for pull requests; it no longer runs on
+# main, because this is that run.
 name: Deploy VitePress site to Pages
 
 on:
@@ -46,8 +57,6 @@ jobs:
           ref: main
           path: .samples
           fetch-depth: 1
-          sparse-checkout: SAMPLES.md
-          sparse-checkout-cone-mode: false
       - name: Sample catalogues (controls)
         continue-on-error: true
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,6 +64,19 @@ jobs:
           repository: abap2UI5/samples-controls
           ref: main
           path: .samples-controls
+          fetch-depth: 1
+          sparse-checkout: SAMPLES.md
+          sparse-checkout-cone-mode: false
+      # samples-stack was missing here while generate-llms.mjs counts three
+      # catalogues and check:counts holds four figures against them. The deploy
+      # therefore published a total it had counted two thirds of.
+      - name: Sample catalogues (stack)
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: abap2UI5/samples-stack
+          ref: main
+          path: .samples-stack
           fetch-depth: 1
           sparse-checkout: SAMPLES.md
           sparse-checkout-cone-mode: false
@@ -67,9 +89,32 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Install dependencies
-        run: npm ci # or pnpm install / yarn install / bun install
+        run: npm ci
+
+      # The same list check.yml runs for a pull request, in the same order, and
+      # the reason each one is here is written above it there. `!cancelled()`
+      # so one failure still reports the others: a deploy that is going to be
+      # refused should say everything that is wrong with it in one run.
+      - name: unit tests
+        run: npm test
+      - name: release version
+        if: ${{ !cancelled() }}
+        run: npm run check:version
+      - name: ABAP examples
+        if: ${{ !cancelled() }}
+        run: npm run check:examples
+      - name: sample links
+        if: ${{ !cancelled() }}
+        run: npm run check:samples
+      - name: corpus counts
+        if: ${{ !cancelled() }}
+        run: npm run check:counts
+
+      # …and only then the thing that gets published. `docs:build` is itself
+      # one of the gates - a page that does not build is a page nobody can
+      # read - so it stays a build step rather than being listed twice.
       - name: Build with VitePress
-        run: npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
+        run: npm run docs:build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/.github/workflows/release-freshness.yml
+++ b/.github/workflows/release-freshness.yml
@@ -1,0 +1,67 @@
+name: release-freshness
+
+# check:version already fails when this site names a release that is not the
+# newest one. It runs on pull requests and on pushes to main, which answers
+# "did THIS change get the number right" - and not the question that actually
+# goes wrong: a release is published in another repository and nothing here
+# moves, so the site is stale from the moment the tag appears until somebody
+# happens to open a pull request.
+#
+# That is what the gate was written for. On 2026-08-14 abap2UI5 1.143.0 was
+# published at 12:20 and the site said 1.142.0 for the rest of the day, with
+# the deprecations page telling readers that z2ui5_cl_ui5_view_builder
+# "arrives with the next release" hours after it had shipped. A quiet week
+# without pull requests would have made that a quiet week of wrong answers.
+#
+# So: weekly, and an issue rather than a red badge on a branch nobody pushed.
+
+on:
+  schedule:
+    - cron: '31 6 * * 1'   # Mondays 06:31 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # No install: check-version reads three files and one API, and a
+      # freshness check that first spends two minutes on npm ci is a freshness
+      # check people turn off.
+      - name: Does the site still name the release that exists
+        run: node scripts/check-version.mjs | tee version.txt
+
+      - name: Open or update the stale-release issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -e
+          title="the documentation names a release that is no longer the newest"
+          body="scripts/check-version.mjs found the site naming a release other than the newest published one: ${RUN_URL}
+
+          \`\`\`
+          $(cat version.txt 2>/dev/null || echo 'see the run log')
+          \`\`\`
+
+          The number lives in three hand-maintained places and no tool moves it. Change them together — and read the prose around them: a sentence like \"arrives with the next release\" goes stale with the number.
+
+          This issue is updated by each stale weekly run; close it when the run is green again."
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still stale: ${RUN_URL}"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,6 @@ error), the app-only layout fix for a column narrower than 820px, and
 
 Node 22, matching the rest of the organisation. Actions are pinned to commits
 with the tag in a comment; `.github/dependabot.yml` moves both the npm packages
-and the action pins every Monday. The `@abap2ui5/linter` version decides what
+and the action pins monthly. The `@abap2ui5/linter` version decides what
 `check:examples` catches, so a bump there is a content decision, not just a
 dependency one — read what the new rules say before merging it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+All project guidance lives in **[AGENTS.md](AGENTS.md)** — the single source of
+truth for this repository (how the site is built, the six gates, the playground rule engine, and what may be written where).
+
+Read `AGENTS.md` before making any change.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ counts still match the sample repositories (`check:samples`, `check:counts`),
 the release number in the nav bar still matches the framework
 (`check:version`), and the catalogue parser still parses (`test`).
 `.github/workflows/check.yml` runs the same list in the same order, so a green
-`npm run check` locally is a green pull request.
+`npm run check` locally is a green pull request — and `deploy.yml` runs it
+again before it publishes, so the site is only ever built from a tree that
+passed. Several of these go stale without anybody touching this repository (a
+release is published elsewhere, a sample class is renamed elsewhere), which is
+why the deploy re-runs them rather than trusting the merge.
 
 **[AGENTS.md](AGENTS.md) describes each of the six**, what a failure means and
 which of them need a sibling checkout to say anything at all — read it before

--- a/docs/advanced/local.md
+++ b/docs/advanced/local.md
@@ -3,6 +3,6 @@ outline: [2, 4]
 ---
 # Local
 
-abap2UI5-local is a special build that bundles all framework classes into a single HTTP handler class. Besides that, you only need to create one additional database table. This gives you a self-contained copy of abap2UI5 that runs independently of any other abap2UI5 installation on the same system.
+abap2UI5-local is a special build that bundles all framework classes into a single HTTP handler class. Besides that, you only need to create two additional database tables (`z2ui5_t_99` and `z2ui5_t_98` — separate from a normal installation's, which is what keeps the two independent). This gives you a self-contained copy of abap2UI5 that runs independently of any other abap2UI5 installation on the same system.
 
 For full details, see the repository: [abap2UI5-local](https://github.com/abap2UI5/abap2UI5-local)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "name": "abap2ui5-docs",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "^0.2.1",
-        "@abaplint/cli": "^2.119.66",
+        "@abap2ui5/linter": "^0.2.2",
+        "@abaplint/cli": "^2.120.23",
         "vitepress": "^1.6.4"
       },
       "engines": {
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@abap2ui5/linter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.1.tgz",
-      "integrity": "sha512-48uMFctR78nogNai1w6kE7Ho4IXLuEnGPq5BJkstpWL69ToL1G+OJ1t4fDOBmOcJ36uFejDn2ofnoBqEkt+9sA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.2.tgz",
+      "integrity": "sha512-WegxIRN5M5gH13Ye5Mo13fbpjAZ183J0ei1iArCfEiKUPAGqHot20NnckpNnXHX+YPHCkehA+Z0QapXjaLK1Tw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -31,7 +31,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@abap2ui5/render-runtime": "^0.1.0"
+        "@abap2ui5/render-runtime": "^0.1.0 || ^0.2.0"
       },
       "peerDependenciesMeta": {
         "@abap2ui5/render-runtime": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "check:counts": "node scripts/check-corpus-counts.mjs"
   },
   "devDependencies": {
-    "@abap2ui5/linter": "^0.2.1",
-    "@abaplint/cli": "^2.119.66",
+    "@abap2ui5/linter": "^0.2.2",
+    "@abaplint/cli": "^2.120.23",
     "vitepress": "^1.6.4"
   },
   "engines": {

--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -38,10 +38,27 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, readdirSyn
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
+import { declaredRelease } from './lib/release.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const DOCS = join(ROOT, 'docs');
 const KEEP = process.argv.includes('--keep');
+
+/* WHICH framework do these examples have to compile against?
+ *
+ * Until now: whatever abap2UI5/abap2UI5 had on main. That is the wrong
+ * question asked of a documentation site. A reader installs a RELEASE, so an
+ * example is correct when it compiles against the release - and main is ahead
+ * of it by design. The gap is not theoretical: z2ui5_cl_ui5_view_builder sat
+ * on main from 2026-08-12 while the newest tag was 1.142.0 from 2026-07-20,
+ * so for three weeks a page could teach the view builder, compile green here,
+ * and not work for a single reader who had installed abap2UI5.
+ *
+ * So: the release the site itself names, read from the same three places
+ * check-version holds honest. A2UI5_REF overrides it - that is how the
+ * against-main canary runs, ahead of a release rather than instead of it.
+ */
+const REF = process.env.A2UI5_REF || declaredRelease(ROOT);
 
 /* `public` is static assets, and since scripts/generate-llms.mjs it also holds
  * a raw-markdown COPY of every page, written on each build. Walking into it
@@ -332,7 +349,7 @@ found.forEach((ex, i) => {
 writeFileSync(join(dir, 'abaplint.json'), JSON.stringify({
   global: { files: '/src/**/*.*' },
   dependencies: [
-    { url: 'https://github.com/abap2UI5/abap2UI5', files: '/src/**/*.*' },
+    { url: 'https://github.com/abap2UI5/abap2UI5', ...(REF ? { branch: REF } : {}), files: '/src/**/*.*' },
     // the SAP standard API an example may implement (if_http_extension and
     // friends); same mirror abap2UI5/samples-stack lints against
     { url: 'https://github.com/abapedia/steampunk-2305-api', folder: '/deps', files: '/src/**/*.*' },
@@ -353,6 +370,10 @@ writeFileSync(join(dir, 'abap2ui5lint.jsonc'), JSON.stringify({
 }, null, 2));
 
 console.log(`check-examples: ${found.length} view-building class example(s) from ${new Set(found.map((f) => f.file)).size} page(s)`);
+console.log(REF
+  ? `             compiled against abap2UI5 ${REF}${process.env.A2UI5_REF ? ' (A2UI5_REF)' : ' — the release this site names'}`
+  : '             compiled against abap2UI5 main — the three places naming the release DISAGREE,\n'
+    + '             so there is no release to pin to. Run npm run check:version.');
 for (const [name, file] of origin) console.log(`  ${name}  <-  ${file}`);
 if (pending.length) {
   console.log(`\nnot checked yet: ${pending.length} example(s) on ${pendingPages.size} page(s) still`);
@@ -382,7 +403,7 @@ if (failed) {
   console.error('a documentation example that does not compile is the defect it looks like.');
   process.exit(1);
 }
-console.log('\ncheck-examples: every view-building example compiles and names API that exists.');
+console.log(`\ncheck-examples: every view-building example compiles and names API that exists${REF ? ` in abap2UI5 ${REF}` : ''}.`);
 if (skipped.length) {
   const pages = [...new Set(skipped)];
   console.log(

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -35,6 +35,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { readSites } from './lib/release.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const API = 'https://api.github.com/repos/abap2UI5/abap2UI5/releases/latest';
@@ -49,53 +50,7 @@ const API = 'https://api.github.com/repos/abap2UI5/abap2UI5/releases/latest';
  * against the real API failed on a repository that had just been corrected. */
 const versionOf = (tag) => tag.replace(/-\w+$/, '');
 
-/** Where the version is written, and how to find it in each file. */
-const SITES = [
-  {
-    file: 'docs/.vitepress/config.mjs',
-    what: 'the version in the nav bar',
-    re: /text:\s*"(\d+\.\d+\.\d+)"/,
-  },
-  {
-    file: 'docs/resources/deprecations.md',
-    what: 'the "Version status" sentence',
-    re: /The released version is \*\*(\d+\.\d+\.\d+)\*\*/,
-  },
-  {
-    file: 'docs/resources/changelog.md',
-    what: 'the newest release heading',
-    /* Any heading level, because the LEVEL is not what this gate is about and
-     * pinning it made the gate fail for the wrong reason: closing up the
-     * heading-level gaps across the site turned these from `###` into `##`,
-     * and a check on the release NUMBER went red over a `#`. It reported that
-     * honestly - "the file changed shape, fix the pattern" - rather than
-     * silently matching nothing, which is the failure mode it was written to
-     * avoid. Still: a gate that fires on a change it does not care about is a
-     * gate people learn to route around. */
-    re: /^#{2,4}\s+(\d+\.\d+\.\d+)\s*$/m,
-  },
-];
-
-const problems = [];
-const found = [];
-
-for (const site of SITES) {
-  const full = path.join(ROOT, site.file);
-  if (!fs.existsSync(full)) {
-    problems.push(`${site.file}: gone — this gate names it as one of the places the version lives`);
-    continue;
-  }
-  const m = site.re.exec(fs.readFileSync(full, 'utf8'));
-  if (!m) {
-    problems.push(
-      `${site.file}: no version found where ${site.what} should be\n`
-      + '    the file changed shape — fix the pattern in scripts/check-version.mjs,\n'
-      + '    or this gate silently stops checking that place',
-    );
-    continue;
-  }
-  found.push({ ...site, version: m[1] });
-}
+const { found, problems } = readSites(ROOT);
 
 /* Half the check needs no network: three places naming three different
  * versions is wrong whatever the tag says. */

--- a/scripts/lib/release.mjs
+++ b/scripts/lib/release.mjs
@@ -1,0 +1,84 @@
+/*
+ * release — where this documentation writes the framework release number, and
+ * how to read it back.
+ *
+ * Two gates need the same answer and must not drift apart in how they get it:
+ *
+ *   check-version   holds the three places against each other and against the
+ *                   newest release tag of abap2UI5/abap2UI5
+ *   check-examples  compiles every documentation example against that release,
+ *                   so a page cannot teach API the reader's install does not
+ *                   have
+ *
+ * check-version is what keeps the number honest; check-examples is entitled to
+ * trust it because of that, and reads it from here rather than carrying a
+ * second copy of the pattern.
+ */
+import fs from 'fs';
+import path from 'path';
+
+/** Where the version is written, and how to find it in each file. */
+const SITES = [
+  {
+    file: 'docs/.vitepress/config.mjs',
+    what: 'the version in the nav bar',
+    re: /text:\s*"(\d+\.\d+\.\d+)"/,
+  },
+  {
+    file: 'docs/resources/deprecations.md',
+    what: 'the "Version status" sentence',
+    re: /The released version is \*\*(\d+\.\d+\.\d+)\*\*/,
+  },
+  {
+    file: 'docs/resources/changelog.md',
+    what: 'the newest release heading',
+    /* Any heading level, because the LEVEL is not what this gate is about and
+     * pinning it made the gate fail for the wrong reason: closing up the
+     * heading-level gaps across the site turned these from `###` into `##`,
+     * and a check on the release NUMBER went red over a `#`. It reported that
+     * honestly - "the file changed shape, fix the pattern" - rather than
+     * silently matching nothing, which is the failure mode it was written to
+     * avoid. Still: a gate that fires on a change it does not care about is a
+     * gate people learn to route around. */
+    re: /^#{2,4}\s+(\d+\.\d+\.\d+)\s*$/m,
+  },
+];
+
+/**
+ * Read the release number out of the three places above.
+ * @returns {{found: Array, problems: string[]}}
+ */
+export function readSites(ROOT) {
+  const problems = [];
+  const found = [];
+
+  for (const site of SITES) {
+    const full = path.join(ROOT, site.file);
+    if (!fs.existsSync(full)) {
+      problems.push(`${site.file}: gone — this gate names it as one of the places the version lives`);
+      continue;
+    }
+    const m = site.re.exec(fs.readFileSync(full, 'utf8'));
+    if (!m) {
+      problems.push(
+        `${site.file}: no version found where ${site.what} should be\n`
+        + '    the file changed shape — fix the pattern in scripts/check-version.mjs,\n'
+        + '    or this gate silently stops checking that place',
+      );
+      continue;
+    }
+    found.push({ ...site, version: m[1] });
+  }
+  return { found, problems };
+}
+
+/**
+ * The one release number this documentation names, or null when the three
+ * places disagree or cannot be read - the caller decides whether that is
+ * fatal. check-version reports it properly; check-examples falls back.
+ */
+export function declaredRelease(ROOT) {
+  const { found } = readSites(ROOT);
+  const distinct = [...new Set(found.map((f) => f.version))];
+  return distinct.length === 1 ? distinct[0] : null;
+}


### PR DESCRIPTION
## What changes

**`check-examples` compiles against the release, not against `main`.** A reader installs a *release*, so an example is correct when it compiles against one — and `main` is ahead of it by design. The gap is not theoretical: `z2ui5_cl_ui5_view_builder` sat on `main` from 2026-08-12 while the newest tag was 1.142.0 from 2026-07-20, so for three weeks a page could teach the view builder, pass this gate, and not work for a single reader.

The release comes from the three places `check:version` already holds honest, which is why it can be trusted here; both gates now read them through `scripts/lib/release.mjs` rather than carrying two copies of the pattern. `A2UI5_REF` overrides it — that is how an against-`main` canary runs, *ahead* of a release rather than instead of it. The run prints which framework it compiled against, so it cannot claim more than it checked.

**The deploy runs the gates.** `check.yml` ran the six gates and `deploy.yml` published, on the same push, with nothing connecting them: a red check and a green deploy simply both happened. The gates that matter most here go stale *without anybody touching this repository*, so "it was green when it merged" was never the same claim as "it is true now" — which is what a site published today asserts. The gates now run in the job that publishes; `check.yml` keeps them for pull requests and no longer runs on `main`, so this is one gate with two triggers rather than two opinions and no consequence.

Also fixes the catalogue set: `deploy.yml` checked out `samples` and `samples-controls` but not `samples-stack`, while `generate-llms.mjs` counts three catalogues and `check:counts` holds four figures against them — the published total had been counted from two thirds of its sources. And the `samples` checkout here was sparse to `SAMPLES.md`, which is not enough for `check:samples`.

**`release-freshness.yml`**: `check:version` fails when the site names a release that is not the newest, but it only ran on pull requests and pushes — so a release published in a quiet week went unnoticed. That is precisely the incident it was written for. Weekly now, as an issue rather than a red badge on a branch nobody pushed.

Two facts that were wrong about other repositories: `advanced/local.md` said abap2UI5-local needs "one additional database table" (it needs two, and their separateness is the whole point of that build), and AGENTS.md said Dependabot runs "every Monday" while `dependabot.yml` has always said monthly.

## How to test

- `npm run check:examples` — **all 46 examples compile and lint clean against 1.143.0**, and the run says so in its output.
- `npm run check:version` and `npm test` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fv6JYeoMYTAfwEaLupTgz5)_