### PR TITLE
Call the third hero button Live Demo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ hero:
       text: What's New?
       link: /resources/changelog
     - theme: alt
-      text: Playground
+      text: Live Demo
       link: https://abap2ui5.github.io/playground/
 
 # Three cards, one per thing a reader comes here to do: look a task up, take


### PR DESCRIPTION
The start page's third hero action said "Playground", which names the tool. What
a first-time reader is being offered there is the thing running — no system, no
installation — so the button now says **Live Demo**.

One line in `docs/index.md`. The link, the theme and the position among the
three actions are unchanged.

`node --test test/*.test.mjs` passes. The site itself was not built here
(`node_modules` is not installed in this container), but the change is frontmatter
text with no reference anywhere else in the repository — `grep` finds no other
occurrence of that label.

---
_Generated by [Claude Code](https://claude.ai/code/session_016eWdFZN8QTNCk9ijHP3NkA)_