### PR TITLE
Document 1.144.0 — prepared, merges with the release

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -162,7 +162,7 @@ export default defineConfig({
       {
         // the released framework version — z2ui5_if_app=>version in
         // abap2UI5/src/02/z2ui5_if_app.intf.abap is where it comes from
-        text: "1.143.0",
+        text: "1.144.0",
         items: [
           { text: "Release Notes", link: "/resources/changelog" },
           { text: "Support", link: "/resources/support" },

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -6,6 +6,25 @@ outline: [2, 4]
 See [Deprecations](/resources/deprecations) for what is superseded but still
 shipping, and for the full removal list with migration notes.
 
+## 1.144.0
+2026-08-30
+- Added `client->_event( arg = … )`, the one-value spelling of `t_arg`. `arg = x` is exactly `t_arg = VALUE #( ( x ) )` — the client folds it into the same table, so the wire and `get_event_arg( )` are unchanged — and it exists because most event wires carry a single value (a row key, a `${$source>/…}`, one event parameter), where the table constructor is longer than the value inside it. Passing both appends `arg` behind the `t_arg` rows. From two values on, `t_arg` stays the right parameter: there is deliberately no `arg2`/`arg3`
+- Added `client->_bind_path( val )`, the path form of `_bind( )` under a name of its own — what a bound aggregation, a `binding_call` filter/sorter and `bindElement` need. It is `_bind( val = … path = abap_true )`, byte for byte, and takes one parameter; combine `path` with `tab`/`tab_index`, `omit_initial`, `json` or `switch_default_model` and `_bind( )` is still the call. `path` stays on `_bind( )` and is not deprecated
+- Frontend actions: `expandSelected` / `collapseSelected` on a tree table, `setBadgeMinValue` / `setBadgeMaxValue`, `IconPool.registerFont` for a custom icon font (`sap.tnt`'s SAP-icons-TNT is the common one — without the registration such an icon renders no glyph and logs nothing), and `addCustomCurrencies`, which MERGES codes rather than replacing the whole registration the way `setCustomCurrencies` does
+- `NavContainer` `to( )` takes a typed page id plus an optional transition name, and `backToPage( )` no longer silently does nothing when handed a plain page id
+- Event arguments: an empty string arrives as an empty string, and a date-valued argument travels as the LOCAL date instead of shifting a day west of the system's timezone
+- `client->get( )-t_model_skipped` names the cells a model delta could not convert, instead of dropping them without a trace
+- The page-location block is latched when its request is confirmed rather than when it is built, so an aborted first request no longer suppresses it for the rest of the session
+- 7.02 / 7.31: a built-in function in a table-expression key no longer takes the whole class pool down at compile time (report #2664)
+- `MultiInputExt` gained the suggestion-row half of `addValidator`
+- Developer Tools: the cross-tab search moved onto a tab of its own
+
+**Renamed — the old name still ships**
+- `z2ui5_if_exit` is now `z2ui5_if_ui5_exit`. The old interface still ships and is still looked up and called, so every existing exit keeps working; rename at your leisure
+
+**Removed**
+- BREAKING: `z2ui5_if_types` is retired to `src/99` — every type it held now sits on the object that uses it (`ty_s_get` / `ty_s_event_control` / `ty_s_name_value` / `ty_t_name_value` / `cs_device` on `z2ui5_if_client`, the three HTTP config types on `z2ui5_if_ui5_exit`, `ty_s_draft` on `z2ui5_cl_ui5_srv_draft`). Nothing is deleted or reshaped: the interface ships unchanged from the frozen package, so `z2ui5_if_types=>…` still compiles, and every moved type is identical field for field
+
 ## 1.143.0
 2026-08-16
 - Added `z2ui5_cl_ui5_view_builder`, the view builder this documentation is written against: `factory( )` / `ele( )` / `tag( )` / `a( )` / `end( )` / `stringify( )`, with every UI5 control and property reachable because the builder knows none of them by name. `z2ui5_cl_xml_view` is frozen, not removed — it ships unchanged and keeps working

--- a/docs/resources/deprecations.md
+++ b/docs/resources/deprecations.md
@@ -35,7 +35,7 @@ What it cannot decide it leaves alone and reports, so a run is safe to repeat.
 
 ## Version status
 
-The released version is **1.143.0**. Entries marked *next release* are already
+The released version is **1.144.0**. Entries marked *next release* are already
 on `main` but not in a release yet — they matter if you pull `main`, and they
 tell you what is coming if you do not.
 
@@ -57,9 +57,9 @@ tell you what is coming if you do not.
 | `z2ui5_cl_xml_view` | `z2ui5_cl_ui5_view_builder` | 1.143.0 |
 | built-in popups | the [popups add-on](https://github.com/abap2UI5-addons/popups) | 1.142.0 |
 | `z2ui5.Util` | `z2ui5.Formatter` | 1.142.0 |
-| `cs_config-title` | `cs_event-set_title` | *next release* |
-| `z2ui5_if_types=>…` | the same type on the object that uses it | *next release* |
-| `z2ui5_if_exit` | `z2ui5_if_ui5_exit` | *next release* |
+| `cs_config-title` | `cs_event-set_title` | 1.144.0 |
+| `z2ui5_if_types=>…` | the same type on the object that uses it | 1.144.0 |
+| `z2ui5_if_exit` | `z2ui5_if_ui5_exit` | 1.144.0 |
 
 ## Obsolete: still compiles
 


### PR DESCRIPTION
The prose half of abap2UI5 **1.144.0**. The framework's `changelog.txt` and this site's release notes describe the same releases, and `check:changelog` over there fails on a version that is in one list and missing from the other — so this is a prerequisite of abap2UI5/abap2UI5#2683, not a follow-up to it.

**Draft on purpose:** it documents a release that has not been cut. It should merge as part of cutting 1.144.0, not before.

## What it adds

A `1.144.0` section covering `_event( arg = )` and `_bind_path( )`, the four new frontend actions (`expandSelected` / `collapseSelected`, the badge min/max setters, `IconPool.registerFont`, `addCustomCurrencies`), the `NavContainer` `to( )` / `backToPage( )` changes, the event-argument and `t_model_skipped` corrections, the 7.02/7.31 compile fix, the `MultiInputExt` validator half and the Developer Tools search tab — with the `z2ui5_if_exit` rename and the `z2ui5_if_types` retirement under headings of their own.

## What it drags with it

`check:version` holds **three** places to one number, so the nav-bar version and the "Version status" sentence in `deprecations.md` move together with the changelog heading. That in turn settles the three rows still marked *next release* in the deprecations table — `cs_config-title`, `z2ui5_if_types` and `z2ui5_if_exit` are exactly what 1.144.0 ships, so they now name it. That is the staleness the gate's own message warns about ("a sentence like *arrives with the next release* goes stale with the number").

`_bind( path = abap_true )` is deliberately **not** added to that table: it is not deprecated. `_bind_path( )` is a second spelling for the one-parameter case, and `path` stays on `_bind( )` for every call that combines it with `tab` / `tab_index`, `omit_initial`, `json` or `switch_default_model`.

## Checks

`npm run check` is green except `check:examples`, which compiles every documentation example against **the release the site names** — 1.144.0, which has no tag yet. That is the check doing its job: an example is correct when it compiles against what a reader can actually install. It goes green when the tag is pushed.

Verified in the meantime with the override the script provides for exactly this, the against-main canary:

```sh
A2UI5_REF=main npm run check:examples
# check-examples: every view-building example compiles and names API that exists in abap2UI5 main.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk511jLY6GBzgHcBS3ZorJ)_