### PR TITLE
Building with AI: the paste block hands out a command that does not resolve

### DIFF
--- a/docs/get_started/ai.md
+++ b/docs/get_started/ai.md
@@ -38,7 +38,8 @@ catalogue lists every app with the words to search it by, at
 https://github.com/abap2UI5/samples/blob/main/SAMPLES.md
 
 When you are done, check the result with the abap2UI5-linter
-(npx abap2ui5lint) - it reads the view your ABAP builds and needs no SAP system.
+(npx @abap2ui5/linter src) - it reads the view your ABAP builds and needs no
+SAP system.
 ```
 
 ## Point it at the right index


### PR DESCRIPTION
## What this changes

One line in `get_started/ai.md`. The block meant to be pasted into an assistant ended with `npx abap2ui5lint`; it now says `npx @abap2ui5/linter src`.

## Why

There is no package called `abap2ui5lint` on npm:

```
$ npm view abap2ui5lint version
npm error 404 Not Found - GET https://registry.npmjs.org/abap2ui5lint
$ npx --yes @abap2ui5/linter --version
abap2ui5lint 0.6.1
```

`abap2ui5lint` is the *bin* of `@abap2ui5/linter`, so the short form works only inside a project that already carries the devDependency — which is exactly what the reader of this page does not have. `advanced/linter.md` documents that distinction; this page had not caught up.

It matters more here than anywhere else on the site: this is the text handed to a model, and a model repeats it verbatim to the next person.

## Checks

`npm run check` was **not** run locally — no `node_modules` in this environment, and the gate pulls VitePress plus an `abap2UI5/samples` checkout. The edit is prose inside a ```text fence; `check:examples` only compiles ABAP fences. CI on this branch is the real verdict.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UciCQART3C34jTED7R14xg)_