### PR TITLE
Add low-code platform comparison, commercial support and QA info

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -556,6 +556,7 @@ export default defineConfig({
                 items: [
                   { text: "RAP", link: "/technical/technology/rap" },
                   { text: "UI5 Freestyle", link: "/technical/technology/ui5" },
+                  { text: "Low-Code Platforms", link: "/technical/technology/low_code" },
                 ],
               },
               {

--- a/docs/configuration/productive_usage.md
+++ b/docs/configuration/productive_usage.md
@@ -8,5 +8,12 @@ Technically, abap2UI5 is just an HTTP handler implementation — use it like any
 ## Stable Version
 The project evolves all the time, so there's no fixed "stable" version. But we keep changes to the public APIs minimal to avoid frequent app refactoring. Pin to a [release](https://github.com/abap2UI5/abap2UI5/releases/) instead of tracking the main branch, and update regularly to keep refactoring effort low.
 
+## Quality Assurance
+Every commit to the framework runs through CI before it reaches a release:
+
+- Builds and static checks against **NW 7.02, Standard ABAP, and ABAP Cloud** — one workflow per release line, so compatibility across the supported stacks is verified continuously, not per release
+- **Unit tests** executed on every commit via [open-abap](/technical/tools/open_abap), plus automated **browser tests** of the running framework
+- The sample catalogues double as a regression corpus: hundreds of apps that are validated against the framework
+
 ## Renaming
 If you're starting new development but already have abap2UI5 apps in production and want to avoid update risk, install multiple instances of abap2UI5 with the [renaming feature](/advanced/renaming). This lets you keep developing safely without disrupting your existing production apps.

--- a/docs/resources/support.md
+++ b/docs/resources/support.md
@@ -3,6 +3,8 @@ outline: [2, 4]
 ---
 # Support
 
+## Community Support
+
 The community offers support for abap2UI5 on a best-effort basis.
 
 If you hit a bug or unexpected behavior, please open an [issue](https://github.com/abap2UI5/abap2UI5/issues). A code snippet that reproduces the bug helps a lot — it lets others quickly test and locate the problem.
@@ -12,3 +14,9 @@ Join the abap2UI5 channel on [Slack](https://communityinviter.com/apps/abapgit/a
 ::: tip
 If you need a specific feature that isn't there yet, open an issue — a good way to discuss possible extensions to the project.
 :::
+
+## Commercial Support
+
+abap2UI5 is free and MIT-licensed — there is nothing to buy from the project itself. Companies and freelancers offer paid services around abap2UI5, such as implementation, app development, training, and support agreements. See [Who Uses abap2UI5?](/resources/who_uses) for companies active in the ecosystem.
+
+**Offering abap2UI5 services?** Add your company to that page or reach out at <contact@abap2UI5.org> to get listed.

--- a/docs/technical/technology/low_code.md
+++ b/docs/technical/technology/low_code.md
@@ -1,0 +1,46 @@
+---
+outline: [2, 4]
+---
+# Low-Code Platforms vs. abap2UI5
+_Two answers to the same question_
+
+Commercial low-code platforms and abap2UI5 address the same need — modern UIs for SAP systems without building a full frontend stack per app — with fundamentally different models: a visual designer on a licensed platform on one side, plain ABAP code in an open-source framework on the other. This page compares the two models, including the points where a commercial platform is ahead.
+
+## The Two Models
+
+| Aspect | Low-Code Platform | abap2UI5 |
+|--------|-------------------|----------|
+| **App Definition** | Visual designer, drag & drop, platform-specific format | ABAP classes, written in any ABAP IDE |
+| **App Storage** | Platform repository | Your system, like any other ABAP development object |
+| **Versioning & Transport** | Platform mechanisms | CTS or abapGit — the tools you already use |
+| **Testing** | Platform tooling | ABAP Unit, plus the project's [linter](/advanced/linter) |
+| **License** | Commercial, typically priced per end user | MIT, unlimited users, free |
+| **Installation** | Platform installation or add-on, plus client components | One abapGit pull ([installation](/configuration/installation)) |
+| **Release Coverage** | Defined by the vendor | NW 7.02 to ABAP Cloud ([downporting](/advanced/downporting)) |
+| **Exit Path** | Apps exist in the platform format | Apps remain plain ABAP classes in your system |
+
+## Where a Commercial Platform Is Ahead
+
+An honest comparison names both directions. A commercial low-code platform typically offers:
+
+- **Native mobile clients with offline support** — abap2UI5 apps run in the browser and cover [camera, barcode scanning, geolocation and file handling](/cookbook/device_capabilities/info) through web APIs, but offline-first scenarios with local storage and synchronization are out of scope
+- **Bundled suites** — workflow engines, API management and portal products in one package; abap2UI5 is deliberately only the UI layer
+- **Contractual support** — SLAs, certified trainings and a vendor to hold accountable; abap2UI5 offers [community and partner-based support](/resources/support)
+- **Citizen development** — visual tools aimed at non-developers; abap2UI5 is a framework for ABAP developers
+
+## Where abap2UI5 Is Ahead
+
+- **Apps are code.** Every app is a plain ABAP class — diffable, transportable, unit-testable, reviewable in a pull request. There is no second format to govern and no designer artifact that drifts from the system it describes.
+- **No per-user economics.** An app that serves ten users costs the same as one that serves ten thousand: nothing. The cost of an app is the time to build it — and nothing recurs per seat, per year.
+- **No platform between you and your apps.** The framework is a set of ABAP classes and one HTTP handler in your own system ([security](/configuration/security)). If the project disappeared tomorrow, your apps would keep running from your own repository — the MIT license makes the code permanently yours to fork.
+- **Full release range.** From NW 7.02 to ABAP Cloud, on-premise and BTP, with every commit CI-tested across the release lines ([productive usage](/configuration/productive_usage)).
+- **AI agents can operate it.** A visual designer needs a human. Code-first development is exactly what AI coding agents do best: with the [MCP server](/advanced/mcp_server) an agent writes an app class, validates the view with the [linter](/advanced/linter), runs the app and checks its own screenshot — without an SAP system. Several hundred ports of official UI5 demo kit samples were generated this way and are guarded by CI.
+- **Fiori Launchpad integration** without an intermediate portal product ([launchpad](/configuration/launchpad)).
+
+## Deciding Between the Two
+
+Choose a **commercial low-code platform** when you need offline-capable native mobile apps, a bundled workflow or portal suite, contractual SLAs, or app building by non-developers.
+
+Choose **abap2UI5** when you have ABAP developers (or AI agents assisting them), want apps to live in your system as ordinary code, and prefer paying for development once over licensing per user forever.
+
+The two also coexist: abap2UI5 is not a platform to migrate to, but a framework to adopt one app at a time — the first app costs an abapGit pull and an afternoon, and [trying it in the browser](https://abap2ui5.github.io/web-abap2UI5-build/) costs nothing at all.


### PR DESCRIPTION
Three additions for the evaluator-level story:

- **New page** `technical/technology/low_code.md`: an honest comparison of commercial low-code platforms and abap2UI5 in both directions (offline mobile, bundled suites, SLAs and citizen development named as platform strengths), sidebar entry next to the existing RAP comparison. No vendor is named.
- **resources/support.md**: commercial support section with an open call for service providers, pointing at the who-uses page
- **configuration/productive_usage.md**: quality assurance section naming the CI release matrix (NW 7.02 / Standard / Cloud), unit and browser tests

`npm run check` green (all eight gates, including docs:build, check:examples, check:api-names, check:samples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TopeaKy2JjZ8WrNwAGGZmo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TopeaKy2JjZ8WrNwAGGZmo)_