### PR TITLE
About: the supported floor is 7.02, the branch is an install detail

### DIFF
--- a/docs/get_started/about.md
+++ b/docs/get_started/about.md
@@ -108,9 +108,10 @@ By relying only on released APIs, abap2UI5 keeps your apps "cloud-ready" and "up
 Works with both ABAP Cloud and Standard ABAP:
 - S/4 Public Cloud and BTP ABAP Environment (ABAP for Cloud)
 - S/4 Private Cloud or On-Premise (ABAP for Cloud, Standard ABAP)
-- R/3 NetWeaver AS ABAP 7.50 or later (Standard ABAP)
+- R/3 NetWeaver AS ABAP 7.02 or later (Standard ABAP)
 
-For systems on releases before 7.50 (down to 7.02), a separate downported version is available.
+Below 7.50 you pull the `702` branch instead of `main` — same features, generated
+from it automatically. See [Downporting](/advanced/downporting).
 
 ### UI5 Versions
 The frontend is UI5 itself, loaded at bootstrap like it is for any other UI5 app. abap2UI5 bootstraps OpenUI5 from its public CDN by default; a single exit points it at SAPUI5, at a pinned version, or at the UI5 already delivered by your own system — which is what a system without internet access uses. `1.71` is the oldest supported release, and every change is tested against UI5 2.x as well.


### PR DESCRIPTION
## What this changes

`get_started/about.md`, *System Support*: the R/3 line now reads **7.02 or later** instead of 7.50, and the sentence below it says in one line that releases under 7.50 pull the `702` branch, pointing at [Downporting](https://abap2ui5.github.io/docs/advanced/downporting.html).

## Why

The README states **NW 7.02 → ABAP Cloud** in three places — badge, key features, stability. This page listed 7.50 as the supported release and mentioned 7.02 afterwards as a caveat, so the project answered its own most basic question two different ways depending on where you looked. That is exactly the kind of split a model resolves by picking one at random and repeating it.

7.02 is the answer, and which branch you pull below 7.50 is an installation detail, not a qualification of what the framework supports — so it now reads as one.

`configuration/installation.md` already leads with the action ("for R/3 NetWeaver versions below 7.50, install the downported version") and is left alone: on an installation page that ordering is right.

## Checks

Prose only, one file, no code fence touched — `check:examples` compiles ABAP fences and sees nothing here. The link target `/advanced/downporting` exists and is the page the sentence names; CI's `docs:build` is the verdict on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UciCQART3C34jTED7R14xg)_