### PR TITLE
Sample links follow the consolidation: 498/499 in, 141/321/322/323 out

### DIFF
--- a/docs/cookbook/event_navigation/routing.md
+++ b/docs/cookbook/event_navigation/routing.md
@@ -3,7 +3,7 @@ outline: [2, 4]
 samples:
   - z2ui5_cl_smp_app_468
   - z2ui5_cl_smp_app_480
-  - z2ui5_cl_smp_app_322
+  - z2ui5_cl_smp_app_499
 ---
 # Routing
 
@@ -88,8 +88,8 @@ that use what this page describes. Each is a single class — pull the repositor
 
 | Sample | Class |
 |---|---|
-| Navigation — Routing mode fresh | [`Z2UI5_CL_SMP_APP_468`](https://github.com/abap2UI5/samples/blob/main/src/00/97/z2ui5_cl_smp_app_468.clas.abap) |
-| Navigation — Routing mode keep | [`Z2UI5_CL_SMP_APP_480`](https://github.com/abap2UI5/samples/blob/main/src/00/97/z2ui5_cl_smp_app_480.clas.abap) |
-| Navigation — push state | [`Z2UI5_CL_SMP_APP_322`](https://github.com/abap2UI5/samples/blob/main/src/00/97/z2ui5_cl_smp_app_322.clas.abap) |
+| Routing mode fresh | [`Z2UI5_CL_SMP_APP_468`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_468.clas.abap) |
+| Routing mode keep | [`Z2UI5_CL_SMP_APP_480`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_480.clas.abap) |
+| App-Owned Routing (#/detail) | [`Z2UI5_CL_SMP_APP_499`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_499.clas.abap) |
 
 <!-- samples:end -->

--- a/docs/cookbook/expert_more/app_state_share.md
+++ b/docs/cookbook/expert_more/app_state_share.md
@@ -1,8 +1,7 @@
 ---
 outline: [2, 4]
 samples:
-  - z2ui5_cl_smp_app_321
-  - z2ui5_cl_smp_app_323
+  - z2ui5_cl_smp_app_498
 ---
 # App State, Share
 
@@ -118,7 +117,6 @@ that use what this page describes. Each is a single class — pull the repositor
 
 | Sample | Class |
 |---|---|
-| Navigation — app state | [`Z2UI5_CL_SMP_APP_321`](https://github.com/abap2UI5/samples/blob/main/src/00/97/z2ui5_cl_smp_app_321.clas.abap) |
-| Navigation — app state share | [`Z2UI5_CL_SMP_APP_323`](https://github.com/abap2UI5/samples/blob/main/src/00/97/z2ui5_cl_smp_app_323.clas.abap) |
+| App State, Bookmark and Share | [`Z2UI5_CL_SMP_APP_498`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_498.clas.abap) |
 
 <!-- samples:end -->

--- a/docs/cookbook/popup_popover/popup.md
+++ b/docs/cookbook/popup_popover/popup.md
@@ -6,7 +6,6 @@ samples:
   - z2ui5_cl_smp_app_161
   - z2ui5_cl_smp_app_170
   - z2ui5_cl_smp_app_470
-  - z2ui5_cl_smp_app_141
 ---
 # Popup
 
@@ -139,6 +138,5 @@ that use what this page describes. Each is a single class — pull the repositor
 | Dialog inside a Dialog | [`Z2UI5_CL_SMP_APP_161`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_161.clas.abap) |
 | Navigate between Dialogs (NavContainer) (A) | [`Z2UI5_CL_SMP_APP_170`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_170.clas.abap) |
 | Element Binding to the Selected Row (A) | [`Z2UI5_CL_SMP_APP_470`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_470.clas.abap) |
-| Popup — change a popup control from the backend | [`Z2UI5_CL_SMP_APP_141`](https://github.com/abap2UI5/samples/blob/main/src/00/97/z2ui5_cl_smp_app_141.clas.abap) |
 
 <!-- samples:end -->


### PR DESCRIPTION
samples merged the app-state/routing consolidation (abap2UI5/samples#813, abap2UI5/samples#814) and deleted app 141. This heals `check:docs-links` over in samples:

- the routing page names `z2ui5_cl_smp_app_499` (replaces the deleted 322),
- the app-state page names `z2ui5_cl_smp_app_498` (replaces 321/323),
- the popup page drops the deleted 141.

Tables regenerated via `link:samples`. The PROSE is untouched on purpose — it keeps teaching the released 1.144.0 API ("TRUTH is the release"); the `hash_*`/`app_state_*` modernization of these pages follows in a separate PR that merges together with the next framework release.

All docs gates green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fPP1D34PR85d9d4qCunyX

---
_Generated by [Claude Code](https://claude.ai/code/session_013fPP1D34PR85d9d4qCunyX)_