### PR TITLE
Keep the ABAP-versions tip off Hello World, where ef915db took it out

### DIFF
--- a/docs/get_started/hello_world.md
+++ b/docs/get_started/hello_world.md
@@ -53,12 +53,6 @@ roundtrip — is catalogued with symptom, cause and fix in
 Name your own apps in your customer namespace (`Z...`/`Y...`). The `Z2UI5_` prefix is reserved for the framework and its samples.
 :::
 
-::: tip ABAP Language Versions
-While the HTTP handler has to distinguish between Standard ABAP and ABAP for
-Cloud, the apps themselves are independent. You are free to choose whether to
-build your apps with ABAP Cloud compatibility.
-:::
-
 ## A Real Screen, an Event and Data Exchange
 
 A message box is not an app. This second class is still one class, and it has

--- a/docs/get_started/quickstart.md
+++ b/docs/get_started/quickstart.md
@@ -74,6 +74,12 @@ For ABAP Cloud environments, follow the [SAP HTTP service tutorial](https://deve
 abap2UI5 talks only to the HTTP service you define, giving you full control over accessibility, authentication, and other security aspects.
 :::
 
+::: tip **ABAP Language Versions**
+The handler above is the one place the distinction matters. Your *apps* are
+independent of it — you are free to choose whether to build them with ABAP
+Cloud compatibility, whichever handler this system runs.
+:::
+
 ## 3. First Launch
 Open the HTTP endpoint in your browser — in `SICF`, right-click your service node and choose **Test Service** (the URL looks like `https://<host>:<port>/sap/bc/<your_service>`). This startup page is also where you will launch your own apps later:
 <img width="800" alt="abap2UI5 startup page with check button and test app launcher" src="https://github.com/user-attachments/assets/c8962298-068d-4efb-a853-c44a9b9cda56">


### PR DESCRIPTION
Fixing something #191 broke, found while verifying that merge on `main`.

#191 moved Quickstart §4 wholesale onto Hello World. One of the four things it
carried was the **ABAP Language Versions** tip — which
[ef915db](https://github.com/abap2UI5/docs/commit/ef915db478c087f4ad453cf110db95c360f822ba)
("Update hello_world.md by removing ABAP versions section") had removed from
that exact page, in that exact spot, two hours earlier. The move put it
straight back.

The two instructions genuinely conflicted, and I read them the wrong way round
in #191. Resolved here as:

- **Off Hello World** — that is what ef915db decided, and it is still the right
  call: the page is about what an app *is* and how to start it.
- **Not deleted** — ef915db took it off Hello World, not out of the
  documentation, and it was still in Quickstart when that commit was written.
  Deleting it would have been a second decision nobody made.
- **Moved to §2 in Quickstart**, next to the handler it is actually about.
  Section 2 is where Standard ABAP and ABAP for Cloud are distinguished, and
  the tip's whole point is that apps do not inherit that distinction — so it
  reads better there than it did under §4 anyway:

  > The handler above is the one place the distinction matters. Your *apps* are
  > independent of it — you are free to choose whether to build them with ABAP
  > Cloud compatibility, whichever handler this system runs.

The other three things §4 carried — the `?app_start=<class>` URL, the
`does not exist in the system` case, the naming tip — stay on Hello World,
where they belong to starting an app.

`npm run check` green, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGUWV1krAgQTpnx5gKJtdv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGUWV1krAgQTpnx5gKJtdv)_