### PR TITLE
Let a figure out of the prose measure

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -282,6 +282,33 @@
   max-width: none;
 }
 
+/* …and neither is a paragraph that turns out to be a FIGURE.
+ *
+ * This is the hole the first version of the cap left, and it was invisible in
+ * the page I checked it on. Markdown has no figure element: `![alt](src)` on a
+ * line of its own compiles to `<p><img></p>`, so every screenshot on the site
+ * is, structurally, a paragraph — and the cap above put all 39 of them on
+ * `technical/how_it_all_works` at the prose measure. The result was a page
+ * with THREE right edges (prose at 600, screenshots at 600, code and tables at
+ * 830) where the whole point of the split was to have two, and a screenshot
+ * shrunk to 72% for no reason a reader could see.
+ *
+ * A figure is not prose. It is measured in pixels the author chose, not in
+ * characters, and it belongs on the same edge as the code block and the table.
+ *
+ * `:has()` is what makes this expressible — there is no parent selector
+ * otherwise, and the constraint lives on the `<p>`, not the `<img>`, so
+ * `.vp-doc p > img { max-width: none }` cannot reach it. Where `:has()` is
+ * unsupported the rule is simply dropped and images stay at 600px, which is
+ * what they do today: the fallback is the current behaviour, so nothing can
+ * break in a browser that does not understand it. */
+.vp-doc p:has(> img),
+.vp-doc p:has(> a > img),
+.vp-doc p:has(> video),
+.vp-doc p:has(> iframe) {
+  max-width: none;
+}
+
 /* The chrome around the page — sidebar, outline, nav, the prev/next footer —
  * at 13px. It is navigation, not text: it is scanned for a word that is
  * already known, never read, and at the size of the prose it competes with


### PR DESCRIPTION
#194 capped prose at 600px and said in as many words that images kept the full column. They did not.

Markdown has no figure element: `[alt](src)` on its own line compiles to `<p><img></p>`, so every screenshot on the site is structurally a paragraph, and the cap took all of them with it.

Measured on the deployed head, at a 1700px viewport:

| Page | images | at or below 600px |
|---|---:|---:|
| `technical/how_it_all_works` | 39 | 39 |
| `get_started/quickstart` | 6 | 5 |

So the page ended up with **three** right edges — prose at 600, screenshots at 600, code and tables at 830 — where the entire point of separating the column from the measure was to have two. A screenshot shrunk to 72% for no reason a reader can see is worse than one at either width, because it reads as a mistake rather than as a system.

A figure is not prose. It is measured in pixels its author chose, not in characters, and it belongs on the edge the code block and the table are already on.

After this change, same measurement:

| | before | after |
|---|---|---|
| `quickstart` images | 600–796px | 796–830px |
| `how_it_all_works` images | 400–600px | 400–830px |
| paragraphs | 600px | 600px (unchanged) |

## On `:has()`

It is what makes this expressible. There is no parent selector otherwise, and the constraint lives on the `<p>` rather than the `<img>`, so `.vp-doc p > img { max-width: none }` cannot reach it.

Where `:has()` is unsupported the rule is dropped and images stay at 600px — which is exactly what they do today. The fallback is the current behaviour, so no browser can be made worse by this. Baseline support is Chrome 105, Safari 15.4, Firefox 121.

`video` and `iframe` in a bare paragraph are covered by the same rule, so an embed added later does not reintroduce the bug.

## Verification

`npm run check` passes: test, `check:version`, `docs:build`, `check:examples`, `check:conventions`, `check:playground`, `check:api-names`, `check:api-reference`. `check:samples` skipped for want of an `abap2UI5/samples` checkout, as designed; CI checks it out explicitly.

Widths above were read back off the rendered pages rather than assumed, before and after.

One file, `docs/.vitepress/theme/style.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RnJUTpBQrU7mAWbhP6ZA6

---
_Generated by [Claude Code](https://claude.ai/code/session_014RnJUTpBQrU7mAWbhP6ZA6)_