### PR TITLE
Align three things with capire: one column, a descending sidebar, filenames

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitepress";
 import { playgroundButton } from "./playground.mjs";
+import { tableScroll, codeTitle } from "./markup.mjs";
 
 // Where the site is actually served from. Link previews (LinkedIn, Slack,
 // WhatsApp, X) only accept ABSOLUTE urls in og:image / og:url — a relative
@@ -15,7 +16,14 @@ export default defineConfig({
   // A Run button under every fenced example the playground can actually
   // start. Which ones those are is decided in ./playground.mjs.
   markdown: {
-    config: (md) => playgroundButton(md),
+    // Order matters: `codeTitle` wraps whatever the fence renderer before it
+    // produced, so the Run button ends up INSIDE the titled block rather than
+    // beside it.
+    config: (md) => {
+      tableScroll(md);
+      playgroundButton(md);
+      codeTitle(md);
+    },
   },
   lastUpdated: {
     text: "Updated at",

--- a/docs/.vitepress/markup.mjs
+++ b/docs/.vitepress/markup.mjs
@@ -1,0 +1,80 @@
+/*
+ * Two markdown-it rules that VitePress does not provide, and that this site
+ * turned out to need. Both are renderer overrides in the same shape as
+ * `playground.mjs`, and both exist because a claim made in CSS was not true of
+ * the HTML underneath it.
+ */
+
+/*
+ * 1. A scroll box around every table.
+ *
+ * VitePress 1.6.4 emits a bare `<table tabindex="0">` with no wrapper, and its
+ * own stylesheet handles a wide one with `display: block; overflow-x: auto` on
+ * the table itself. That scrolls, and it also makes the table shrink to its
+ * CONTENT width — which is why the four-column parameter tables on
+ * `resources/api.md` used to sit at about 40% of the column with the rest of
+ * the page empty beside them.
+ *
+ * The fix for that was `display: table; width: 100%`, and it came with a
+ * promise that the scroll had moved to a `.vp-doc-table` wrapper. It had not.
+ * No such wrapper exists in this version of VitePress; the selector matched
+ * nothing, and the tables simply lost their scroll. Nothing showed while the
+ * column was 830px wide, because no table was wider than that. At 640px the
+ * widest are, and a 900px window scrolled sideways.
+ *
+ * So the wrapper is made here, where it can actually be made, and the CSS rule
+ * that names it becomes true.
+ */
+export function tableScroll(md) {
+  md.renderer.rules.table_open = () => '<div class="vp-doc-table">\n<table>\n';
+  md.renderer.rules.table_close = () => '</table>\n</div>\n';
+}
+
+/*
+ * 2. A filename above a code block.
+ *
+ * ```cds [srv/travel-flows.cds] is valid VitePress markdown, and in a plain
+ * fence the title is parsed off the info string and then DROPPED — only
+ * `::: code-group` renders it, as a tab label. So a single block cannot say
+ * which file it is without being wrapped in a one-tab group, which is a lot of
+ * markup for a label.
+ *
+ * This renders it as the same tab the group would draw, so the two look alike
+ * and a block can be promoted into a group later without the page changing
+ * shape.
+ *
+ * Deliberately NOT applied to the ABAP examples, which are the overwhelming
+ * majority here: an abap2UI5 example is a global class, its name is the first
+ * token of its own first line, and it is pasted into a system rather than
+ * saved to a path. A tab reading `zcl_app_hello_world.clas.abap` over a block
+ * that opens `CLASS zcl_app_hello_world DEFINITION PUBLIC.` is the same word
+ * twice. The blocks that get one are the ones that really are files — a
+ * manifest, a controller, a workflow, a linter config — where the path is
+ * information the code itself does not carry.
+ */
+const TITLE = /\[(.+)\]/;
+
+export function codeTitle(md) {
+  /* The title has to be taken in the CORE phase, not in the fence renderer.
+   * VitePress strips `[…]` off `token.info` before its own fence rule runs —
+   * by the time any renderer override sees the token, `info` is just `xml`.
+   * Core rules all run before rendering, so one pushed here still sees the
+   * info string as it was written, and parks the title on `token.meta` where
+   * the renderer below can find it. */
+  md.core.ruler.push('a2ui5_code_title', (state) => {
+    for (const token of state.tokens) {
+      if (token.type !== 'fence') continue;
+      const match = TITLE.exec(token.info || '');
+      if (match) token.meta = { ...(token.meta || {}), a2ui5Title: match[1].trim() };
+    }
+    return true;
+  });
+
+  const fence = md.renderer.rules.fence;
+  md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+    const rendered = fence(tokens, idx, options, env, self);
+    const title = tokens[idx].meta?.a2ui5Title;
+    if (!title) return rendered;
+    return `<div class="a2ui5-titled"><div class="a2ui5-titled-name"><span>${md.utils.escapeHtml(title)}</span></div>${rendered}</div>`;
+  };
+}

--- a/docs/.vitepress/markup.mjs
+++ b/docs/.vitepress/markup.mjs
@@ -22,12 +22,38 @@
  * column was 830px wide, because no table was wider than that. At 640px the
  * widest are, and a 900px window scrolled sideways.
  *
- * So the wrapper is made here, where it can actually be made, and the CSS rule
- * that names it becomes true.
+ * So the wrapper is made here, where it can actually be made.
+ *
+ * The table is rendered through `self.renderToken` rather than written out as
+ * a literal `<table>`: a literal drops whatever attributes markdown-it and its
+ * plugins put on the token, and a rule that silently discards other people's
+ * output is a trap for whoever adds the next plugin.
+ *
+ * `tabindex` is the one attribute that deliberately MOVES. VitePress puts it
+ * on the table because in its layout the table is what scrolls, and a
+ * scrollable box has to be reachable from the keyboard or it can only be read
+ * with a mouse. Here the wrapper scrolls, so the wrapper is what needs to be
+ * focusable — and leaving it on both would put two tab stops on one table.
  */
 export function tableScroll(md) {
-  md.renderer.rules.table_open = () => '<div class="vp-doc-table">\n<table>\n';
-  md.renderer.rules.table_close = () => '</table>\n</div>\n';
+  const open = md.renderer.rules.table_open;
+  const close = md.renderer.rules.table_close;
+
+  md.renderer.rules.table_open = (tokens, idx, options, env, self) => {
+    const inner = open ? open(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
+    // The `tabindex` is not on the token — VitePress writes it in its own
+    // `table_open` renderer, so it arrives here already inside the string. It
+    // is taken off that string rather than left in place: two tab stops for
+    // one table is worse than one, and the inner one would land on an element
+    // that no longer scrolls. Anchored and single, so it can only ever touch
+    // the opening tag this function produced a line above.
+    return `<div class="vp-doc-table" tabindex="0">\n${inner.replace(/^<table tabindex="0"/, '<table')}`;
+  };
+
+  md.renderer.rules.table_close = (tokens, idx, options, env, self) => {
+    const inner = close ? close(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
+    return `${inner}</div>\n`;
+  };
 }
 
 /*
@@ -43,16 +69,29 @@ export function tableScroll(md) {
  * and a block can be promoted into a group later without the page changing
  * shape.
  *
- * Deliberately NOT applied to the ABAP examples, which are the overwhelming
- * majority here: an abap2UI5 example is a global class, its name is the first
- * token of its own first line, and it is pasted into a system rather than
- * saved to a path. A tab reading `zcl_app_hello_world.clas.abap` over a block
- * that opens `CLASS zcl_app_hello_world DEFINITION PUBLIC.` is the same word
- * twice. The blocks that get one are the ones that really are files — a
- * manifest, a controller, a workflow, a linter config — where the path is
- * information the code itself does not carry.
+ * Two things it must NOT do, and the first version of this did both:
+ *
+ *   - A fence inside a `::: code-group` already has its label drawn, as the
+ *     tab of the group. Wrapping it again printed `ABAP` twice on
+ *     `get_started/quickstart.md`, once as the group's tab and once as a title
+ *     bar inside it. So the core rule below tracks the container depth and
+ *     leaves anything inside a group alone.
+ *
+ *   - Not every bracketed title is a filename. This documentation also uses
+ *     them as plain labels — `[lcl_help]` over the local helper class on
+ *     `translation_i18n.md` — and a label is not a path. So a title only
+ *     becomes a filename tab if it looks like a file: a dot or a slash in it.
+ *     That also keeps this off the 838 ABAP examples for good, which is the
+ *     point: an abap2UI5 example is a global class whose name is the first
+ *     token of its own first line, pasted into a system rather than saved to a
+ *     path, so a tab repeating it is the same word twice.
+ *
+ * Both were caught in review rather than by any gate here, which is worth
+ * remembering: `check:examples` reads the ABAP, and nothing reads the shape of
+ * the HTML around it.
  */
-const TITLE = /\[(.+)\]/;
+const TITLE = /\[(.+?)\]/;
+const LOOKS_LIKE_A_FILE = /[./]/;
 
 export function codeTitle(md) {
   /* The title has to be taken in the CORE phase, not in the fence renderer.
@@ -62,10 +101,16 @@ export function codeTitle(md) {
    * info string as it was written, and parks the title on `token.meta` where
    * the renderer below can find it. */
   md.core.ruler.push('a2ui5_code_title', (state) => {
+    let insideGroup = 0;
     for (const token of state.tokens) {
-      if (token.type !== 'fence') continue;
+      if (token.type === 'container_code-group_open') insideGroup++;
+      else if (token.type === 'container_code-group_close') insideGroup--;
+      if (token.type !== 'fence' || insideGroup > 0) continue;
       const match = TITLE.exec(token.info || '');
-      if (match) token.meta = { ...(token.meta || {}), a2ui5Title: match[1].trim() };
+      if (!match) continue;
+      const title = match[1].trim();
+      if (!LOOKS_LIKE_A_FILE.test(title)) continue;
+      token.meta = { ...(token.meta || {}), a2ui5Title: title };
     }
     return true;
   });

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -108,10 +108,10 @@
  * modest; the visible win is that a code block now tends to CLOSE on screen
  * instead of running off the bottom.
  *
- * Not touched on purpose: the content column stays at its 688px. It looks
- * like the obvious lever and is not — 96% of the ABAP lines in this
- * repository are under 81 characters, so widening it buys three percentage
- * points and costs the line length that makes prose readable.
+ * The content column is set further down, in `one column, and a measure`.
+ * The 81-character figure quoted there — 96% of the ABAP lines in this
+ * organisation fit in it — is the reason the column can be narrow enough for
+ * prose without cutting the code in half.
  */
 
 /* Section headings. The top rule stays: on a long cookbook page it is what
@@ -226,89 +226,6 @@
   line-height: 24px;
 }
 
-/* ------------------------------------------------------- the measure ---
- *
- * The reading column and the MEASURE are two different decisions, and until
- * now they were one number. The column was widened to 830px for a reason that
- * still holds — an outline that truncated 12% of its entries, and a third of
- * a wide window carrying the text with the rest empty. What did not survive
- * the widening is the line length, and the smaller type made it worse rather
- * than better: at 16px the column ran about 105 characters a line, and at 15px
- * it runs about 120. The workable band for technical prose is 75 to 90.
- *
- * (Those are counted, not estimated: the median of eleven real paragraphs on
- * `technical/how_it_all_works`, measured with a Range binary-searched to the
- * last character that still sits on the first line. An average-character-width
- * calculation is off by ten characters either way on a proportional face.)
- *
- * So the two decisions are separated here. Prose is capped at 600px — about
- * 86 characters — and everything the width was actually widened FOR keeps the
- * full column: code blocks, tables, images, the Run frame. That is the whole
- * point of doing it this way round rather than narrowing the container: a
- * 236-line ABAP listing and a four-column parameter table both want 830px,
- * and a paragraph wants nothing of the sort.
- *
- * Headings are deliberately NOT capped. `h2` carries a rule along its top
- * edge, and that rule marks a section across the content area rather than
- * across the sentence under it; capping it would shorten the rule and leave
- * the code block below sticking out past it. The heading TEXT never comes
- * near 600px anyway, so this costs nothing and keeps the rule full width.
- *
- * The callout cap moves from 688px to 620px for the same reason — with the
- * 3px rule and 16px of padding, 620 puts its text on the same 600px measure
- * as the prose it interrupts.
- *
- * What this costs, stated rather than buried: the pages get TALLER again.
- * Measured against the same baseline as the leading block above, the height
- * savings roughly halve once this cap is in — how_it_all_works goes from -14%
- * to -2%, model/binding from -10% to -7%. Both numbers are real and the trade
- * is deliberate: length is cheap on a page nobody reads without scrolling,
- * and a 120-character line is expensive on every line of it. */
-.vp-doc p,
-.vp-doc li,
-.vp-doc blockquote,
-.vp-doc dd {
-  max-width: 600px;
-}
-
-/* A paragraph inside a table cell or a callout is already inside something
- * that sets its own width; a second cap there just makes a narrow column
- * narrower. */
-.vp-doc td p,
-.vp-doc th p,
-.vp-doc .custom-block:not(.details) p,
-.vp-doc .custom-block:not(.details) li,
-.vp-doc li li {
-  max-width: none;
-}
-
-/* …and neither is a paragraph that turns out to be a FIGURE.
- *
- * This is the hole the first version of the cap left, and it was invisible in
- * the page I checked it on. Markdown has no figure element: `![alt](src)` on a
- * line of its own compiles to `<p><img></p>`, so every screenshot on the site
- * is, structurally, a paragraph — and the cap above put all 39 of them on
- * `technical/how_it_all_works` at the prose measure. The result was a page
- * with THREE right edges (prose at 600, screenshots at 600, code and tables at
- * 830) where the whole point of the split was to have two, and a screenshot
- * shrunk to 72% for no reason a reader could see.
- *
- * A figure is not prose. It is measured in pixels the author chose, not in
- * characters, and it belongs on the same edge as the code block and the table.
- *
- * `:has()` is what makes this expressible — there is no parent selector
- * otherwise, and the constraint lives on the `<p>`, not the `<img>`, so
- * `.vp-doc p > img { max-width: none }` cannot reach it. Where `:has()` is
- * unsupported the rule is simply dropped and images stay at 600px, which is
- * what they do today: the fallback is the current behaviour, so nothing can
- * break in a browser that does not understand it. */
-.vp-doc p:has(> img),
-.vp-doc p:has(> a > img),
-.vp-doc p:has(> video),
-.vp-doc p:has(> iframe) {
-  max-width: none;
-}
-
 /* The chrome around the page — sidebar, outline, nav, the prev/next footer —
  * at 13px. It is navigation, not text: it is scanned for a word that is
  * already known, never read, and at the size of the prose it competes with
@@ -324,22 +241,24 @@
   font-size: 13px;
 }
 
-/* …and the group headings in the sidebar one step below the pages under them.
+/* …and the group headings in the sidebar back ABOVE the pages under them.
  *
- * `Getting Started`, `Cookbook`, `Configuration` are not peers of the pages
- * they contain — they are the LABEL over a list, and the theme sets them at
- * the same size as their children in weight 700, so six of them down the
- * column read as six competing headlines. 12px in the muted colour at weight
- * 600 puts the label under the thing it labels, which is the relationship
- * that actually holds; the indent and the divider rule already say where each
- * group ends, so the weight does not have to.
+ * The previous version of this rule put them at 12px muted, one step BELOW
+ * their own children, on a GitHub argument: a section label over a list. Set
+ * against capire — SAP's CAP documentation, VitePress like this one and the
+ * nearest comparable corpus — that reads as the odd choice. There the tree
+ * descends, `Develop` over `Domain Modeling` over `Status Flows`, each level
+ * a step smaller than the one it contains, which is what a navigation tree has
+ * always done and what makes its shape readable without being read.
  *
- * The size comes down, the ROW does not: `padding: 4px 0` and the 24px line
- * are the theme's, left alone on purpose. Every one of these headings is also
- * a link (each carries a `link:` in config.mjs alongside its `items`), and
- * shrinking the target along with the type is how a heading becomes a thing
- * you have to aim at. The hover rule the theme ships still turns them the
- * brand colour, so the affordance survives the smaller type.
+ * A sidebar is not a page of labelled lists. It is one tree, and the size of
+ * an entry is the reader's only cue to its depth: a group title smaller than
+ * its own children says the children outrank it, which is false.
+ *
+ * So 14px semibold in the full text colour, one step above the 13px of the
+ * entries under it. The row is the theme's, untouched, for the reason it was
+ * untouched before: every one of these headings is also a link, and a target
+ * that shrinks with its type is a target you have to aim at.
  *
  * Specificity: the theme's rule is `.VPSidebarItem.level-0 .text[data-v-…]`,
  * four units. `.VPSidebar` in front of the same three classes makes four
@@ -347,16 +266,8 @@
  * carries a fifth. Ties here are decided by load order, and load order is the
  * one thing in this file that is not allowed to be the reason a rule wins. */
 .VPSidebar .VPSidebarItem.level-0 > .item .text {
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 600;
-  letter-spacing: 0.01em;
-  color: var(--vp-c-text-2);
-}
-
-/* The open group keeps its heading legible: `has-active` is the group the
- * current page is in, and at 12px muted it was the one label on the column
- * that had to say "you are in here" and did not. */
-.VPSidebar .VPSidebarItem.level-0.has-active > .item .text {
   color: var(--vp-c-text-1);
 }
 
@@ -559,13 +470,33 @@
   overflow-x: auto;
 }
 
-/* ====================================================== a wider page ===
+/* ============================================ one column, and a measure ===
  *
- * The default gives the reading column 688px and the outline beside it 224px,
- * inside a 1440px layout. On a wide screen that leaves the middle third of the
- * window carrying the text and the rest empty.
+ * The theme gives the reading column 688px and the outline beside it 224px,
+ * inside a 1440px layout. Only ONE of those two numbers was ever wrong here.
  *
- * The outline is the clearer defect of the two, and it is measurable: this
+ * The column was widened to 830px, and then — because 830px of 15px type is
+ * about 120 characters a line — prose was capped back to 600px inside it,
+ * leaving code, tables and figures at the full width. That worked, and it cost
+ * more than it was worth: two right edges on every page, three separate
+ * follow-up fixes for the places the cap did not reach (a figure is a `<p>`, so
+ * is prose inside a details block), and a rule that had to name every exception
+ * to itself. A layout that needs an exception list is a layout that is fighting
+ * the document.
+ *
+ * So: one column, 640px, which is about 92 characters at this type size. That
+ * is the same measure SAP's capire — VitePress too, and the nearest comparable
+ * corpus — runs at: counted off its rendered pages, its lines come in at 84 to
+ * 91 characters. It is also enough for the ABAP: 96% of the ABAP lines in this
+ * organisation are under 81 characters, and 81 characters of the 13px mono face
+ * fits inside 640px. The 4% that do not, and the widest API tables, scroll
+ * inside their own box, which is what the `.vp-doc-table` wrapper is for.
+ *
+ * The layout width override goes with it. 1600px existed to make room for an
+ * 830px column beside a widened outline; at 640px the theme's own 1440px is
+ * more than enough, and one less number to keep true.
+ *
+ * The outline widening STAYS, because that defect was real and is unrelated: this
  * documentation has 627 entries in it, and at 224px about 12% of them are cut
  * off with an ellipsis - "Step 1 - State: Types a...", "Step 2 - The View:
  * Sel...". An outline entry that does not say what the section is fails at its
@@ -575,14 +506,9 @@
  *
  * Only from 1440px up, and that breakpoint was measured rather than picked:
  * at 1280px the window is the binding constraint, so a wider outline does not
- * come out of the empty margin - it comes out of the text. Applying this from
- * 1280 took the reading column from 624px DOWN to 576px, which is the opposite
- * of the point.
+ * come out of the empty margin - it comes out of the text.
  */
 @media (min-width: 1440px) {
-  :root {
-    --vp-layout-max-width: 1600px;
-  }
 
   /* `!important`, and not for want of trying. The theme rule is a Vue SCOPED
    * style, so it compiles to
@@ -602,7 +528,7 @@
    * normally. The difference is not obvious from reading the theme source,
    * which is why it is written down here. */
   .VPDoc.has-aside .content-container {
-    max-width: 830px !important;
+    max-width: 640px !important;
   }
 
   /* All three move together: `.aside` is the column, `.aside-container` the
@@ -644,28 +570,61 @@
   padding-bottom: 4px;
 }
 
-/* ------------------------------------------------- the callout boxes ---
+/* ------------------------------------------ the filename over a block ---
  *
- * The tip/warning/danger blocks keep the width the reading column had BEFORE
- * it was widened. A callout is an aside - a paragraph or two, set apart - and
- * the wider it gets the less it reads as one: at 830px a three-line note
- * becomes a two-line slab that competes with the prose it interrupts. Prose
- * and code got the extra width because they use it; a callout does not.
+ * Drawn as the tab a `::: code-group` draws, because that is what it is: the
+ * one-tab case of the same thing. A block promoted into a real group later
+ * keeps its shape, and a page mixing the two does not show the reader two
+ * different ways of saying which file this is.
  *
- * 688px is not a round number picked to look tidy: it is exactly what the
- * reading column was, so these boxes are unchanged from what they were rather
- * than newly narrowed.
- *
- * `::: details` is excluded, and the exclusion is the whole point of writing
- * `:not(.details)` rather than listing the three types. VitePress gives both
- * the same `custom-block` class, but they are opposite things: a callout holds
- * a REMARK about the text, a details block holds CONTENT the reader opened on
- * purpose - a screenshot, a long listing, the ABAP Cloud variant of a setup
- * step. Capping that at 688px put a narrow box under a full-width screenshot
- * on the quickstart page, which is where this was noticed. Content follows the
- * reading column; commentary does not. */
-.vp-doc .custom-block:not(.details) {
-  max-width: 620px;
+ * The rule is in `.vitepress/markup.mjs`, and it says there which blocks get
+ * one — not the ABAP, whose class name is already the first word of its own
+ * first line. */
+.vp-doc .a2ui5-titled {
+  margin: 16px 0;
+  border: 1px solid var(--a2ui5-c-hairline);
+  border-radius: 6px;
+  background-color: var(--a2ui5-c-surface);
+  overflow: hidden;
+}
+
+.vp-doc .a2ui5-titled-name {
+  padding: 8px 14px 0;
+  border-bottom: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  line-height: 20px;
+}
+
+/* The underline is the tab, and it is only as wide as the name — a full-width
+ * rule under a short filename reads as a section divider, which this is not. */
+.vp-doc .a2ui5-titled-name span {
+  display: inline-block;
+  padding-bottom: 7px;
+  border-bottom: 2px solid var(--vp-c-brand-1);
+  margin-bottom: -1px;
+}
+
+/* The block inside has already been drawn with its own edge and radius; here
+ * it is the body of a box that has both, so it gives them up. */
+.vp-doc .a2ui5-titled div[class*='language-'] {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+}
+
+.vp-doc .a2ui5-titled .a2ui5-play {
+  margin: 0;
+}
+
+.vp-doc .a2ui5-titled .a2ui5-play-run,
+.vp-doc .a2ui5-titled .a2ui5-play-bar,
+.vp-doc .a2ui5-titled .a2ui5-play-failed {
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  border-radius: 0;
 }
 
 /* ------------------------------------------------ the Run button ---

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -461,11 +461,17 @@
   font-weight: 600;
 }
 
-/* …and the escape hatch the `display: block` above used to provide. VitePress
- * wraps every table in `.vp-doc-table`; scrolling belongs on the wrapper, so
- * a table too wide for the column still scrolls instead of pushing the page
- * sideways. Without this line the widest table on the site takes the whole
- * document with it on a narrow window. */
+/* …and the escape hatch the `display: block` above used to provide.
+ *
+ * `.vp-doc-table` is NOT a VitePress class — 1.6.4 emits a bare `<table>` and
+ * puts the scroll on the table itself. The wrapper is made in
+ * `.vitepress/markup.mjs`, which is where to look when this rule appears to do
+ * nothing. It was written here first, against a wrapper that did not exist,
+ * and matched nothing for two releases; that is why the note is this loud.
+ *
+ * The wrapper also carries the `tabindex`, moved off the table by the same
+ * rule: whatever scrolls has to be reachable from a keyboard, and after this
+ * change the table is not the thing that scrolls. */
 .vp-doc .vp-doc-table {
   overflow-x: auto;
 }

--- a/docs/advanced/linter.md
+++ b/docs/advanced/linter.md
@@ -314,7 +314,7 @@ idea as `abaplint.jsonc`. `abap2ui5lint --init` writes a commented starter
 version; discovery is eslint-style, and precedence is CLI flag > config file >
 built-in default.
 
-```jsonc
+```jsonc [abap2ui5lint.jsonc]
 {
   "$schema": "./node_modules/@abap2ui5/linter/data/abap2ui5lint.schema.json",
   "paths": ["src"],          // used when the CLI got no positional paths

--- a/docs/advanced/renaming.md
+++ b/docs/advanced/renaming.md
@@ -184,7 +184,7 @@ instead of `z2ui5_if_app`.
 ### How It Works
 [abaplint](https://abaplint.org) can rename ABAP artifacts across a whole repository: you define rename patterns (old name → new name, including regular expressions) in an abaplint configuration, and `abaplint --rename` rewrites every class, interface, and reference consistently, writing the result to an output folder:
 
-```jsonc
+```jsonc [abaplint.json]
 "rename": {
   "output": "output",
   "patterns": [

--- a/docs/advanced/vscode.md
+++ b/docs/advanced/vscode.md
@@ -53,7 +53,7 @@ https://host:44300/sap/bc/z2ui5?app_start={class}&sap-client=100
 
 Working against several systems is the normal case, so name them instead:
 
-```jsonc
+```jsonc [settings.json]
 "abap2ui5.systems": [
   { "name": "DEV",     "url": "https://dev:44300/sap/bc/z2ui5?app_start={class}&sap-client=100" },
   { "name": "Sandbox", "url": "https://box:44300/sap/bc/z2ui5?app_start={class}" }


### PR DESCRIPTION
Measured against SAP's [capire](https://cap.cloud.sap/docs/) — VitePress too, and the nearest comparable corpus. Three differences were worth closing, and one of them turned out to expose a bug this repository already had.

## One column

capire runs **84 to 91 characters** a line, counted off its rendered pages. This site ran **86**, so the measure was already right — but it got there by widening the column to 830px and then capping prose back to 600px inside it.

That cost more than it was worth: two right edges on every page, three follow-up fixes for the places the cap did not reach (a figure is a `<p>`; so is prose inside a details block), and a rule that had to name every exception to itself. A layout that needs an exception list is fighting the document.

So: **one column at 640px**, about 92 characters, and every cap and exception deleted.

| | before | after |
|---|---|---|
| paragraph | 600px | 640px |
| image | 640–798px | 640px |
| code block | 830px | 640px |
| table | 640–798px | 640px, scrolls if wider |
| measure | 86 chars | 87–92 chars |

The code is not what pays for this: 96% of the ABAP lines in this organisation are under 81 characters, and 81 characters of the 13px mono face fit inside 640px. The `--vp-layout-max-width: 1600px` override goes too — it existed to make room for an 830px column. The outline widening **stays**; that defect was real and unrelated.

## A descending sidebar

Group headings went to 12px muted in #192, one step *below* their own children, on a GitHub argument about section labels. capire descends instead — `Develop` over `Domain Modeling` over `Status Flows` — which is what a navigation tree has always done.

A sidebar is one tree, not a page of labelled lists, and a group title smaller than its children says the children outrank it, which is false. Now 14px semibold in the full text colour, against 13px for the entries under it. The row keeps the theme's padding for the same reason as before: every one of these headings is also a link, and a target that shrinks with its type is a target you have to aim at.

## A filename over a block

This is the one that delivered least, and it is the easiest to drop.

` ```jsonc [abap2ui5lint.jsonc] ` is valid VitePress markdown whose title is parsed off `token.info` and then **dropped** — only `::: code-group` renders it, as a tab label. A core rule in the new `markup.mjs` parks the title on `token.meta` before that happens, and the fence renderer draws the same tab a group would, so a block promoted into a real group later keeps its shape.

It applies to **three** blocks, not to the 838 ABAP ones:

- An abap2UI5 example is a global class whose name is the first token of its own first line, pasted into a system rather than saved to a path. A tab reading `zcl_app_hello_world.clas.abap` over a block that opens `CLASS zcl_app_hello_world DEFINITION PUBLIC.` is the same word twice.
- Of the 16 file-shaped blocks that remain, most already carry their filename in the sentence directly above them ("the UI5 bootstrap script tag in `index.html`"), or are payloads rather than files (a response body, a view model, a remote service's `$metadata`), or are fragments with no canonical name.

What was left is `abap2ui5lint.jsonc`, `settings.json` and `abaplint.json` — three files whose canonical name the page did not otherwise state.

## And a bug

#194 replaced the theme's `display: block` on tables with `display: table; width: 100%`, to stop the four-column API tables sitting at 40% of the column, and said the scroll had moved to a `.vp-doc-table` wrapper.

It had not. VitePress 1.6.4 emits a bare `<table tabindex="0">`; no such wrapper exists, the selector matched nothing, and wide tables simply lost their scroll. Nothing showed while the column was 830px, because no table was wider than that. At 640px a 900px window scrolled sideways.

`markup.mjs` now creates the wrapper, so the rule that names it is true.

| viewport | page scrolls sideways | tables scrolling in their own box |
|---|---|---|
| 1700px | no | 1 / 32 |
| 1440px | no | 1 / 32 |
| 1280px | no | 1 / 32 |
| 900px | no (was **yes**) | 1 / 32 |
| 640px | no | 2 / 32 |

## Verification

`npm run check` passes: test, `check:version`, `docs:build`, `check:examples`, `check:conventions`, `check:playground`, `check:api-names`, `check:api-reference`. `check:samples` skipped for want of an `abap2UI5/samples` checkout, as designed; CI checks it out explicitly.

Character counts, element widths and the overflow table above were all read off rendered pages. capire's numbers were counted by hand from its pages — the site is not reachable from the build environment, so they are counts of visible text rather than measurements of its CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RnJUTpBQrU7mAWbhP6ZA6

---
_Generated by [Claude Code](https://claude.ai/code/session_014RnJUTpBQrU7mAWbhP6ZA6)_