### PR TITLE
Reorganize sidebar: promote Toolchain, fix Walkthrough label

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -204,7 +204,6 @@ export default defineConfig({
         link: "/tutorials/walkthrough/",
         collapsed: true,
         items: [
-          { text: "Overview", link: "/tutorials/walkthrough/" }, // sidebar
           {
             // No `collapsed` key at all, like Quickstart above: that is what
             // makes a group a plain labelled list instead of a collapsible
@@ -212,7 +211,14 @@ export default defineConfig({
             // let the steps be folded away - and the sequence IS the tutorial,
             // so a reader working through it has to see where they are on
             // every page.
+            //
+            // The group label itself opens the walkthrough's index page.
+            // That page used to stand above the group as a separate
+            // "Overview" entry, which put two lines in front of the reader
+            // for one page - the label they were looking for and the entry
+            // that actually opened it.
             text: "Walkthrough",
+            link: "/tutorials/walkthrough/",
             items: [
               { text: "1. The App Class", link: "/tutorials/walkthrough/step-1" },
               { text: "2. A First View", link: "/tutorials/walkthrough/step-2" },
@@ -541,10 +547,10 @@ export default defineConfig({
           },
           // A section of its own until now, next to Advanced Topics rather
           // than inside it. It is the same kind of reading - what the
-          // framework does under the app, and the tools it stands on - and
-          // it is read after the app runs, not on the way in, so it sits
-          // here as the last entry instead of as a second top-level heading
-          // competing with this one.
+          // framework does under the app - and it is read after the app
+          // runs, not on the way in, so it sits here instead of as a second
+          // top-level heading competing with this one. The toolchain it
+          // stands on follows as a group of its own, below.
           {
             text: "Technical Insight",
             link: "/technical/concept",
@@ -564,26 +570,33 @@ export default defineConfig({
                   { text: "Low-Code Platforms", link: "/technical/technology/low_code" },
                 ],
               },
-              {
-                text: "Toolchain",
-                collapsed: true,
-                items: [
-                  // Every one of these is somebody else's project, which is
-                  // what this group is: the toolchain abap2UI5 stands on.
-                  // The project's own linter used to head the list, pointing
-                  // at the same page as Developer Setup > Project Tools two
-                  // groups up. One entry standing twice in one sidebar makes
-                  // its own search results ambiguous, and here it also made
-                  // the group claim something it no longer holds.
-                  { text: "abapGit", link: "/technical/tools/abapgit" },
-                  { text: "ajson", link: "/technical/tools/ajson" },
-                  { text: "S-RTTI", link: "/technical/tools/srtti" },
-                  { text: "abaplint", link: "/technical/tools/abaplint" },
-                  { text: "open-abap", link: "/technical/tools/open_abap" },
-                  { text: "abap-cleaner", link: "/technical/tools/abap_cleaner" },
-                  { text: "abapmerge", link: "/technical/tools/abapmerge" },
-                ],
-              },
+            ],
+          },
+          {
+            // Every one of these is somebody else's project, which is what
+            // this group is: the toolchain abap2UI5 stands on. It used to be
+            // the last entry INSIDE Technical Insight, one level further
+            // down, where a reader looking for "how does abapGit fit in" had
+            // to open a group about the framework's internals first. Next to
+            // Developer Setup - the tools you develop WITH - and Technical
+            // Insight - what the framework does under the app - it is one of
+            // the things this section is for, and reachable in one click.
+            //
+            // The project's own linter used to head the list, pointing at
+            // the same page as Developer Setup > Project Tools above. One
+            // entry standing twice in one sidebar makes its own search
+            // results ambiguous, and here it also made the group claim
+            // something it no longer holds.
+            text: "Toolchain",
+            collapsed: true,
+            items: [
+              { text: "abapGit", link: "/technical/tools/abapgit" },
+              { text: "ajson", link: "/technical/tools/ajson" },
+              { text: "S-RTTI", link: "/technical/tools/srtti" },
+              { text: "abaplint", link: "/technical/tools/abaplint" },
+              { text: "open-abap", link: "/technical/tools/open_abap" },
+              { text: "abap-cleaner", link: "/technical/tools/abap_cleaner" },
+              { text: "abapmerge", link: "/technical/tools/abapmerge" },
             ],
           },
         ],

--- a/docs/resources/references.md
+++ b/docs/resources/references.md
@@ -5,6 +5,11 @@ outline: [2, 4]
 
 ## Videos, Links, and Other Media
 
+### 2026
+- Field Service Management Mobile Logging using abap2UI5 [(Decabase Blog - 22.08.2026)](https://blog.decabase.com/field-service-management-mobile-logging-using-abap2ui5-2c18e4ed455d)
+- UI5 in ABAP Cloud (without RAP or Fiori Elements) [(Decabase Blog - 17.08.2026)](https://blog.decabase.com/ui5-in-abap-cloud-without-rap-or-fiori-elements-4e8a70d961c3)
+- Fiori-type Apps built 100% with ABAP [(Logali Group - 23.04.2026)](https://logaligroup.com/magia-en-el-servidor-local-apps-tipo-fiori-creadas-100-con-codigo-abap/)
+
 ### 2025
 - Webinar on Launchpad Integration [(YouTube - 30.07.2025)](https://www.youtube.com/watch?v=t5g3F3PHsbw&list=PLLpkZ_86h4quGSfsjohDHt9CrpjXdeA1P)
 - Featured on SAP Developer News [(YouTube - 21.03.2025)](https://www.youtube.com/watch?v=vKrpkDe2mkU&list=PL6RpkC85SLQAVBSQXN9522_1jNvPavBgg&t=90s)

--- a/docs/tutorials/walkthrough/index.md
+++ b/docs/tutorials/walkthrough/index.md
@@ -2,7 +2,7 @@
 outline: [2, 4]
 description: Learn abap2UI5 by building — a step-by-step walkthrough where every step is a complete class you can run in the browser.
 ---
-# Tutorial
+# Walkthrough
 
 Learn abap2UI5 by building something. The **Walkthrough** grows a small invoice
 app from a single message box into a complete application, one concept per


### PR DESCRIPTION
## Summary

This PR reorganizes the documentation sidebar structure to improve navigation clarity and fix labeling inconsistencies.

## Key Changes

- **Walkthrough tutorial**: Removed redundant "Overview" entry and made the group label itself link to the index page (`/tutorials/walkthrough/`). Changed the page title from "Tutorial" to "Walkthrough" for consistency. This eliminates duplicate entries for the same page.

- **Toolchain section**: Promoted from a nested group inside "Technical Insight" to a top-level item under the "Technical" section. This makes toolchain documentation more discoverable and reflects its importance as a peer to "Developer Setup" and "Technical Insight" rather than a sub-topic of framework internals.

- **Documentation comments**: Updated and expanded comments explaining the sidebar structure rationale, particularly around why the Toolchain was moved and why duplicate entries should be avoided.

- **References page**: Added 2026 section with three new resource links (Decabase blog posts and Logali Group article) documenting recent abap2UI5 usage and integrations.

## Implementation Details

The sidebar reorganization reduces cognitive load by:
- Eliminating the need to open "Technical Insight" to access toolchain information
- Removing duplicate sidebar entries that could confuse search results
- Making the Walkthrough entry more direct (one click instead of two to reach the index)

All changes maintain the existing URL structure and page content—only navigation hierarchy and labels were adjusted.

https://claude.ai/code/session_01Wsd5vfu2NfvPZi3XYa44Ca