### PR TITLE
Clarify frozen-view-builder linter rule documentation

### DIFF
--- a/docs/advanced/linter.md
+++ b/docs/advanced/linter.md
@@ -152,7 +152,7 @@ them:
 | Rule | What it catches |
 | --- | --- |
 | `unknown-binding-path` | a hand-written `{/TYPO}` the derived model has no path for — the field just stays empty. Inside a bound aggregation a relative `{TYPO}` is resolved against the **row**, so a misspelled column is caught too |
-| `frozen-view-builder` | the class still builds its view with `z2ui5_cl_xml_view`, the frozen predecessor. It matters more than it looks: that API is what nearly all public abap2UI5 material shows, and therefore what a language model writes when asked for an app |
+| `frozen-view-builder` | the class builds its view with `z2ui5_cl_xml_view`, the predecessor. That is fine to keep — it works, and is headed for an addon of its own — but no rule above can read it, so none of them ran: switching to `z2ui5_cl_ui5_view_builder` is what buys the whole gate |
 | `binding-to-nonpublic` | a `PROTECTED`/`PRIVATE` attribute bound — only `PUBLIC` attributes are serialized into the model, so the first roundtrip fails with `BINDING_ERROR` |
 | `binding-to-local` | a local variable bound — the instance is serialized across the roundtrip, the method stack is not, so the value is lost |
 | `unconverted-abap-boolean` | an ABAP boolean written straight into the view: it arrives as `'X'`/`' '` and UI5 reads any non-empty string as true, so `visible = abap_false` makes the control **visible** |


### PR DESCRIPTION
## Summary
Updated the documentation for the `frozen-view-builder` linter rule to better explain its purpose and the implications of using the older API.

## Changes
- Revised the rule description to clarify that using `z2ui5_cl_xml_view` is acceptable and maintained, but prevents other linter rules from running
- Emphasized that switching to `z2ui5_cl_ui5_view_builder` is necessary to enable the full suite of linter checks
- Removed reference to language model behavior as the primary concern, focusing instead on the technical gating mechanism

## Details
The updated description more accurately reflects the rule's role in the linter gate system: it's not about discouraging use of the older API, but rather documenting that its use bypasses downstream validation rules. This helps users understand the trade-off when choosing between the two view builder approaches.

https://claude.ai/code/session_011qkUxU6fypKKwy1WE8kmDA