### PR TITLE
Move playground from hero buttons to dedicated section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ explicitly for this reason.
 
 There used to be one more, `check:counts`, holding four figures on a
 `resources/samples.md` page against the catalogues themselves. That page is
-gone — the home page opens [the samples page](https://abap2ui5.github.io/samples/)
-directly and each catalogue introduces itself — and with it the only prose
+gone — the cookbook links [the samples page](https://abap2ui5.github.io/samples/)
+and each catalogue introduces itself — and with it the only prose
 copy of a number this repository does not own. `generate-llms.mjs` still counts
 the sample catalogues into `llms.txt`, which is why CI sparse-checks out
 `SAMPLES.md` from `samples-controls` and `samples-stack`; both are

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -141,8 +141,8 @@ export default defineConfig({
         // sample catalogues on top of them, which meant nine entries in two
         // groups and a reader scanning for "where is the code" reading past
         // half of it first. The catalogues are a reading destination and are
-        // linked where a reader looks for one — the button under the home
-        // page grid, and the cookbook chapters; this menu answers the other
+        // linked where a reader looks for one — the cookbook chapters, and
+        // the playground the home page opens; this menu answers the other
         // question, which repository to clone.
         text: "Links",
         items: [

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -860,11 +860,12 @@
  * here existed to prevent.
  */
 
-/* The sample catalogues, under the grid and deliberately not part of it: a
- * corpus of working apps is a different kind of destination from the cards
- * above, and a fourth card would read as one of them. A rule, small type and
- * a single button — enough to read as "and, separately, over there" rather
- * than as another card.
+/* The playground, under the grid and deliberately not part of it: a place to
+ * try the thing is a different kind of destination from the cards above, and
+ * a fourth card would read as one of them. A rule, small type and a single
+ * button — enough to read as "and, separately, over there" rather than as
+ * another card. (The block class still says catalogues: it carried the
+ * samples button before the playground took its place.)
  *
  * The selectors carry the block class twice because this sits inside
  * `.vp-doc` — VPHomeContent wraps the markdown that follows the frontmatter —
@@ -1091,8 +1092,8 @@
     line-height: 22px;
   }
 
-  /* The samples block is this file's own, further up — same treatment, so it
-   * shrinks with the grid it sits under instead of growing relative to it. */
+  /* The playground block is this file's own, further up — same treatment, so
+   * it shrinks with the grid it sits under instead of growing relative to it. */
   .Layout .VPHome .a2ui5-catalogues {
     margin-top: 36px;
     padding-top: 25px;

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,6 @@ hero:
     - theme: alt
       text: What's New?
       link: /resources/changelog
-    - theme: alt
-      text: Live Demo
-      link: https://abap2ui5.github.io/playground/
 
 # Three cards, one per thing a reader comes here to do: learn it, take it to
 # production, join in. The Cookbook is not one of them any more: it answers a
@@ -35,11 +32,15 @@ hero:
 # bar as social icons, and a card spent on a link that is always visible is a
 # card not spent on a journey.
 #
-# Samples are NOT a card either, and that is the one deliberate gap: the
-# catalogue is a reading destination of its own, and a card that looks like
-# the three around it and then hands you a corpus is the card people click by
-# accident. It sits below the grid instead, as a single button, set apart,
-# where leaving the grid — and this site — is the obvious thing to be doing.
+# The playground is not a card, and that is the one deliberate gap: it is
+# not a page to read but a thing to try, and a card that looks like the three
+# around it and then opens an editor is the card people click by accident.
+# It sits below the grid instead, as a single button, set apart, where
+# leaving the grid — and this site — is the obvious thing to be doing. It
+# used to be the hero's third button, "Live Demo", next to Quickstart and
+# What's New; three buttons in a row read as three equal choices, and the
+# one that lets you try the thing before reading a word deserves a line of
+# its own.
 features:
   - title: Tutorial
     icon: <i class="fa-solid fa-graduation-cap"></i>
@@ -55,19 +56,17 @@ features:
     link: https://github.com/abap2UI5/abap2UI5/
 ---
 
-<!-- Below the feature grid, off on its own: one button, straight to the
-     sample page itself rather than to a page here describing it. That page
-     names its own corpus, carries the search and the filters, and links the
-     other two catalogues in the bar at its top — everything the page here
-     used to say, said where the samples are. No figure on purpose: the count
-     is on that page, kept by the repository that owns it, and a second copy
-     here is one nothing would check. -->
+<!-- Below the feature grid, off on its own: one button, straight into the
+     playground. The invitation carries what the hero cannot in five words:
+     nothing to install, nothing to sign up for, the app runs in the browser
+     next to the code. The samples are a click away from there, and from the
+     cookbook chapters, so they need no button here. -->
 <div class="a2ui5-catalogues">
 
-Looking for a working app to copy? Hundreds of them are searchable in the browser — nothing to install.
+Curious what an app looks like? Write ABAP in the browser and watch it run — nothing to install, nothing to sign up for.
 {.a2ui5-catalogues-lead}
 
-[Browse the Samples](https://abap2ui5.github.io/samples/)
+[Try it in the Playground](https://abap2ui5.github.io/playground/)
 {.a2ui5-catalogues-links}
 
 </div>


### PR DESCRIPTION
## Summary
Reorganizes the home page to feature the playground as a dedicated call-to-action below the feature grid, rather than as a third button in the hero section alongside Quickstart and What's New.

## Changes
- **docs/index.md**: Removed "Live Demo" button from hero section; updated comments explaining the rationale for separating the playground as its own section below the grid
- **docs/.vitepress/theme/style.css**: Updated comments to reflect that the catalogues section now hosts the playground button instead of samples
- **docs/.vitepress/config.mjs**: Updated navigation menu comments to clarify that the playground is linked from the home page, not the main menu
- **AGENTS.md**: Updated documentation to reflect that the home page now opens the playground directly (rather than the samples page), with samples linked from cookbook chapters

## Rationale
Three hero buttons read as three equal choices. The playground deserves visual separation because it's an interactive experience ("try before reading"), not a reading destination like Quickstart and What's New. Placing it as a standalone section below the grid signals that leaving the site to try the tool is the obvious next step, while keeping the feature cards focused on learning paths and community engagement.

https://claude.ai/code/session_019iAtCouteSHhaWmdN5WFqM