### PR TITLE
Give the home page a second row of cards: Community, LinkedIn, Playground

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -64,6 +64,11 @@
    * gains on hover carries the hover state (see `.vp-doc a:hover`). */
   --a2ui5-c-link: var(--vp-c-brand-1);
   --a2ui5-c-link-hover: var(--a2ui5-c-link);
+  /* The fill of the home page's second row of cards: the brand, at a tint.
+   * Not the theme's `--vp-c-brand-soft`, which this site never redefined
+   * and which is still VitePress's own indigo - a lavender card on a red
+   * site. The dark value is the dark link colour below at a tint. */
+  --a2ui5-c-out-tint: rgb(208 60 74 / 0.07);
   /* The one-pixel edge on code blocks, tables and the Run bar. */
   --a2ui5-c-hairline: #d1d9e0;
 
@@ -95,6 +100,7 @@
    * fails AA. Same hue, lifted until it reads. */
   --a2ui5-c-link: #e8707c;
   --a2ui5-c-link-hover: var(--a2ui5-c-link);
+  --a2ui5-c-out-tint: rgb(232 112 124 / 0.12);
   --a2ui5-c-hairline: #3d444d;
   --a2ui5-c-surface: #161b22;
 }
@@ -817,69 +823,113 @@
 
 /* ------------------------------------ the home page, below the hero ---
  *
- * Three feature cards. VPFeatures picks its column count from the NUMBER of
- * cards, and three gives `grid-3` — three per row, which is the row this page
- * wants — so nothing has to be overridden here any more. Change the count in
- * docs/index.md and the row changes with it: five would give `grid-4` and a
- * lone fifth card under four, which is what the override that used to live
- * here existed to prevent.
+ * Two feature cards, and a second row of three below them that is this
+ * file's own. VPFeatures picks its column count from the NUMBER of cards,
+ * and two gives `grid-2` — two per row, the line break above the second row
+ * — so nothing has to be overridden here. Change the count in docs/index.md
+ * and the row changes with it: five would give `grid-4` and a lone fifth
+ * card under four, which is what the override that used to live here
+ * existed to prevent.
  */
 
-/* The playground, under the grid and deliberately not part of it: a place to
- * try the thing is a different kind of destination from the cards above, and
- * a fourth card would read as one of them. A rule, small type and a single
- * button — enough to read as "and, separately, over there" rather than as
- * another card. (The block class still says catalogues: it carried the
- * samples button before the playground took its place.)
+/* The second row of cards - the repository, LinkedIn, the playground - under
+ * the theme's two and on the same grid: the same 1152px, the same 16px
+ * gutters, the same padding, so the two rows read as one grid with a line
+ * break in it. What sets the row apart is the drawing: the cards above are
+ * outlined, these are filled with the brand's soft tint and carry the mark
+ * in the brand colour, with an arrow after the title that says "elsewhere"
+ * - and on hover the border turns brand, the card lifts a couple of pixels
+ * and the arrow moves. A card that leaves this site should look like one
+ * before it is clicked, and like something to click rather than to read.
  *
  * The selectors carry the block class twice because this sits inside
  * `.vp-doc` — VPHomeContent wraps the markdown that follows the frontmatter —
- * and `.vp-doc p` / `.vp-doc a` outrank a single class. */
-.a2ui5-catalogues {
-  margin: 40px auto 0;
+ * and `.vp-doc a` outranks a single class. */
+.a2ui5-out {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin: 16px auto 0;
   max-width: 1152px;
-  padding-top: 28px;
-  border-top: 1px solid var(--vp-c-divider);
-  text-align: center;
 }
 
-.a2ui5-catalogues .a2ui5-catalogues-lead {
-  margin: 0;
-  color: var(--vp-c-text-2);
-  font-size: 14px;
-  line-height: 22px;
+@media (min-width: 640px) {
+  .a2ui5-out {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
-.a2ui5-catalogues .a2ui5-catalogues-links {
+@media (min-width: 960px) {
+  .a2ui5-out {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.a2ui5-out .a2ui5-out-card {
   display: flex;
-  justify-content: center;
-  margin: 20px 0 0;
+  flex-direction: column;
+  align-items: flex-start;
+  height: 100%;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 24px;
+  background-color: var(--a2ui5-c-out-tint);
+  color: var(--vp-c-text-1);
+  text-decoration: none;
+  transition: border-color 0.25s, transform 0.25s, box-shadow 0.25s;
 }
 
-.a2ui5-catalogues .a2ui5-catalogues-links a {
-  display: inline-flex;
+/* `.vp-doc a:hover` above would turn the whole card red and underline it:
+ * the answer to "is this a link" is the card itself here, so the text stays
+ * as it is and the card moves instead. */
+.a2ui5-out .a2ui5-out-card:hover {
+  border-color: var(--a2ui5-c-link);
+  transform: translateY(-2px);
+  box-shadow: var(--vp-shadow-2);
+  color: var(--vp-c-text-1);
+  text-decoration: none;
+}
+
+.a2ui5-out .a2ui5-out-icon {
+  display: block;
+  margin-bottom: 14px;
+  color: var(--a2ui5-c-link);
+}
+
+.a2ui5-out .a2ui5-out-icon svg {
+  display: block;
+  width: 22px;
+  height: 22px;
+}
+
+.a2ui5-out .a2ui5-out-title {
+  display: flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid var(--vp-c-brand-1);
-  border-radius: 6px;
-  padding: 7px 18px;
-  color: var(--vp-c-brand-1);
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 600;
-  text-decoration: none;
-  transition: border-color 0.25s, color 0.25s, background-color 0.25s;
+  line-height: 24px;
 }
 
-.a2ui5-catalogues .a2ui5-catalogues-links a::after {
-  content: "→";
-  font-size: 13px;
-  opacity: 0.7;
+.a2ui5-out .a2ui5-out-title::after {
+  content: "↗";
+  color: var(--a2ui5-c-link);
+  font-size: 14px;
+  font-weight: 400;
+  transition: transform 0.25s;
 }
 
-.a2ui5-catalogues .a2ui5-catalogues-links a:hover {
-  border-color: var(--vp-c-brand-2);
-  background-color: var(--vp-c-brand-soft);
-  color: var(--vp-c-brand-2);
+.a2ui5-out .a2ui5-out-card:hover .a2ui5-out-title::after {
+  transform: translate(2px, -2px);
+}
+
+.a2ui5-out .a2ui5-out-details {
+  display: block;
+  padding-top: 8px;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 24px;
 }
 
 /* ==================================== the home page, in the same register ===
@@ -904,7 +954,7 @@
  * ancestors below are counted against the real compiled selectors —
  * `.VPButton.medium[data-v-x]` is three, so the button rules carry four. */
 
-/* The three feature cards. The theme draws them with `background-color` and
+/* The two feature cards. The theme draws them with `background-color` and
  * `border-color` both set to `--vp-c-bg-soft`: a filled tile whose border is
  * invisible because it is the same colour as its fill. Swapping the fill for
  * the divider colour turns the same element into an outlined card and costs
@@ -1057,25 +1107,30 @@
     line-height: 22px;
   }
 
-  /* The playground block is this file's own, further up — same treatment, so
-   * it shrinks with the grid it sits under instead of growing relative to it. */
-  .Layout .VPHome .a2ui5-catalogues {
-    margin-top: 36px;
-    padding-top: 25px;
+  /* The second row of cards is this file's own, further up — the same
+   * treatment as the theme's cards, so the two rows stay one grid. */
+  .Layout .VPHome .a2ui5-out .a2ui5-out-card {
+    padding: 22px;
   }
 
-  .Layout .VPHome .a2ui5-catalogues .a2ui5-catalogues-lead {
+  .Layout .VPHome .a2ui5-out .a2ui5-out-icon {
+    margin-bottom: 12px;
+  }
+
+  .Layout .VPHome .a2ui5-out .a2ui5-out-icon svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .Layout .VPHome .a2ui5-out .a2ui5-out-title {
+    font-size: 15px;
+    line-height: 22px;
+  }
+
+  .Layout .VPHome .a2ui5-out .a2ui5-out-details {
+    padding-top: 7px;
     font-size: 13px;
-    line-height: 20px;
-  }
-
-  .Layout .VPHome .a2ui5-catalogues .a2ui5-catalogues-links {
-    margin-top: 18px;
-  }
-
-  .Layout .VPHome .a2ui5-catalogues .a2ui5-catalogues-links a {
-    padding: 7px 20px;
-    font-size: 13px;
+    line-height: 22px;
   }
 
   /* And the gap below all of it — the one number that is not nine tenths of

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,27 +20,27 @@ hero:
       text: What's New?
       link: /resources/changelog
 
-# Three cards, one per thing a reader comes here to do: learn it, take it to
-# production, join in. The Cookbook is not one of them any more: it answers a
-# question you already have, and someone on the home page does not have it
-# yet — the Tutorial is what a first visit is for, and the Cookbook is a click
-# away in the nav the moment it is wanted. Quickstart is not a card either —
-# the hero's first button is already that jump, and a card repeating it is a
-# card spent twice.
-# Technical Insight is not one either: it is what you read after the thing
-# runs, not a way in. GitHub and LinkedIn are not cards — both sit in the nav
-# bar as social icons, and a card spent on a link that is always visible is a
-# card not spent on a journey.
+# Two rows of cards. This row, the theme's own, is the two things a reader
+# comes here to READ: learn it, take it to production. Two cards, on purpose —
+# VPFeatures picks its column count from the number of cards, and two gives
+# a row of two, which is the line break before the second row below. The
+# Cookbook is not one of them: it answers a question you already have, and
+# someone on the home page does not have it yet — the Tutorial is what a
+# first visit is for, and the Cookbook is a click away in the nav the moment
+# it is wanted. Quickstart is not a card either — the hero's first button is
+# already that jump, and a card repeating it is a card spent twice. Technical
+# Insight is not one either: it is what you read after the thing runs, not a
+# way in.
 #
-# The playground is not a card, and that is the one deliberate gap: it is
-# not a page to read but a thing to try, and a card that looks like the three
-# around it and then opens an editor is the card people click by accident.
-# It sits below the grid instead, as a single button, set apart, where
-# leaving the grid — and this site — is the obvious thing to be doing. It
-# used to be the hero's third button, "Live Demo", next to Quickstart and
-# What's New; three buttons in a row read as three equal choices, and the
-# one that lets you try the thing before reading a word deserves a line of
-# its own.
+# The second row, in the markdown below the frontmatter, is the three places
+# that are not pages of this site: the repository, LinkedIn and the
+# playground. They used to be scattered — Community was a third card up here,
+# the playground a lone button under a rule, LinkedIn only an icon in the nav
+# bar — and a reader who had finished the two cards above had nowhere
+# obvious to go next. Now they are a row of their own, drawn differently
+# from the two above (a tinted fill where these are outlined), so that a
+# card that leaves this site is recognisable as one before it is clicked,
+# and looks like something to click rather than something to read.
 features:
   - title: Tutorial
     icon: <i class="fa-solid fa-graduation-cap"></i>
@@ -50,23 +50,27 @@ features:
     icon: <i class="fa-solid fa-gear"></i>
     details: Setup, security, performance, launchpad — the road to production use.
     link: /configuration/setup
-  - title: Community
-    icon: <i class="fa-brands fa-github"></i>
-    details: Browse the code, report issues, contribute — the project is built in the open.
-    link: https://github.com/abap2UI5/abap2UI5/
 ---
 
-<!-- Below the feature grid, off on its own: one button, straight into the
-     playground. The invitation carries what the hero cannot in five words:
-     nothing to install, nothing to sign up for, the app runs in the browser
-     next to the code. The samples are a click away from there, and from the
-     cookbook chapters, so they need no button here. -->
-<div class="a2ui5-catalogues">
-
-Curious what an app looks like? Write ABAP in the browser and watch it run — nothing to install, nothing to sign up for.
-{.a2ui5-catalogues-lead}
-
-[Try it in the Playground](https://abap2ui5.github.io/playground/)
-{.a2ui5-catalogues-links}
-
+<!-- The second row of cards - see the note above the features. Every card is
+     one link, opened in a new tab: all three are somewhere else. The marks
+     are inline rather than Font Awesome's, the same three the nav bar
+     carries: an icon that is an empty square until a stylesheet from a CDN
+     arrives is worse than one that never needed it. -->
+<div class="a2ui5-out">
+  <a class="a2ui5-out-card" href="https://github.com/abap2UI5/abap2UI5/" target="_blank" rel="noreferrer">
+    <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg></span>
+    <span class="a2ui5-out-title">Community</span>
+    <span class="a2ui5-out-details">Browse the code, report issues, contribute — the project is built in the open on GitHub.</span>
+  </a>
+  <a class="a2ui5-out-card" href="https://www.linkedin.com/company/abap2ui5/" target="_blank" rel="noreferrer">
+    <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg></span>
+    <span class="a2ui5-out-title">LinkedIn</span>
+    <span class="a2ui5-out-details">Follow along — releases, articles and what people are building with it.</span>
+  </a>
+  <a class="a2ui5-out-card" href="https://abap2ui5.github.io/playground/" target="_blank" rel="noreferrer">
+    <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9.75" fill="none" stroke="currentColor" stroke-width="1.7"/><path d="M9.6 7.9v8.2a.5.5 0 0 0 .76.43l6.6-4.1a.5.5 0 0 0 0-.86l-6.6-4.1a.5.5 0 0 0-.76.43z" fill="currentColor"/></svg></span>
+    <span class="a2ui5-out-title">Playground</span>
+    <span class="a2ui5-out-details">Write ABAP in the browser and watch it run — nothing to install, nothing to sign up for.</span>
+  </a>
 </div>


### PR DESCRIPTION
## What changes

The three places that are not pages of this site were scattered: Community a third card beside Tutorial and Configuration, the playground a lone button under a rule, LinkedIn only an icon in the nav bar.

- The theme's feature row is now the two things a reader comes here to read, Tutorial and Configuration (two cards give `grid-2`, which is the line break).
- Under it, on the same grid, a row of its own for the three that lead out: Community (GitHub), LinkedIn, Playground. It replaces the "Try it in the Playground" button block.
- The row is drawn differently on purpose: filled with the brand red at a tint where the cards above are outlined, the mark and an arrow after the title in the brand colour, and on hover a brand border plus a slight lift. The tint is a token of this file's own, because `--vp-c-brand-soft` was never redefined here and is still VitePress's indigo.
- The marks are inline SVG, the same three the nav bar carries, so nothing depends on the Font Awesome CDN.

## Verification

- `npm run docs:build` passes.
- Rendered and checked in light, dark and at phone width, including the hover state (the site's `.vp-doc a:hover` would otherwise underline and recolour the whole card; overridden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZDkQj7bdQJAjCVd6TQ71r

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZDkQj7bdQJAjCVd6TQ71r)_