### PR TITLE
Replace Font Awesome icons with inline SVGs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -39,19 +39,24 @@ export default defineConfig({
       "link",
       { rel: "apple-touch-icon", sizes: "180x180", href: "/docs/favicon.ico" },
     ],
-    [
-      "link",
-      {
-        rel: "stylesheet",
-        href: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css",
-      },
-    ],
-    // No webfonts. Montserrat and Fira Code were requested here and applied
-    // by nothing — no rule in theme/style.css, or anywhere else, ever named
-    // either one — so the site paid for two render-blocking stylesheets and
-    // four font files it never showed a glyph from. The type is now the
-    // system stack, set in theme/style.css. Font Awesome below STAYS: the
-    // three home-page feature icons are `fa-solid`/`fa-brands` classes.
+    // No third-party stylesheets at all, and none of them render-blocking.
+    // Montserrat and Fira Code were requested here and applied by nothing —
+    // no rule in theme/style.css, or anywhere else, ever named either one —
+    // so the site paid for two stylesheets and four font files it never
+    // showed a glyph from. The type is the system stack, set in
+    // theme/style.css.
+    //
+    // Font Awesome went the same way, one release later. It was loaded on
+    // EVERY page of the site — a render-blocking stylesheet plus the webfont
+    // behind whichever glyph was used — to draw four icons: the three on the
+    // home page's feature cards and one GitHub mark on configuration/
+    // launchpad. All four are inline SVG now, in the markdown that shows
+    // them, next to the marks in the home page's second row of cards that
+    // were already drawn that way. The argument is the one written over
+    // those: an icon that is an empty square until a stylesheet from a CDN
+    // arrives is worse than one that never needed it — and on a blocked or
+    // slow CDN the feature icons did not degrade to a square, they were
+    // simply not there. Adding an icon means adding an `<svg>`, not a class.
     // Link preview card — the per-page og:title, og:description and og:url are
     // added in transformPageData below.
     ["meta", { property: "og:type", content: "website" }],

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -665,6 +665,21 @@
   border-radius: 0;
 }
 
+/* ------------------------------------------- a mark inside a sentence ---
+ *
+ * One page puts an icon in front of a link (the GitHub mark before the
+ * Launchpad KPI repository on configuration/launchpad). It used to be a
+ * Font Awesome `<i>`; it is an inline `<svg>` now, like every other mark on
+ * the site, and this is the rule that makes an `<svg>` behave like the glyph
+ * it replaced: the size and colour of the text around it, on its baseline. */
+.vp-doc .a2ui5-mark {
+  display: inline-block;
+  width: 1.05em;
+  height: 1.05em;
+  vertical-align: -0.16em;
+  color: var(--vp-c-text-1);
+}
+
 /* ------------------------------------------------ the Run button ---
  *
  * Under a fenced example the playground can start (docs/.vitepress/
@@ -968,11 +983,16 @@
 }
 
 /* The icon loses its 48px grey plate. The plate is a container drawn for a
- * glyph that does not need containing — three of them across the row read as
- * three empty squares before they read as an icon, which is exactly how they
- * render on any visit where the Font Awesome stylesheet is slow or blocked.
- * The glyph alone, at the size of a heading and in the muted text colour,
- * says the same thing and says nothing when it is missing. */
+ * mark that does not need containing — three of them across the row read as
+ * three empty squares before they read as an icon. The mark alone, at the
+ * size of a heading and in the muted text colour, says the same thing.
+ *
+ * The mark is an inline `<svg>` in the frontmatter, sized here rather than
+ * by `font-size`: these were Font Awesome classes until the stylesheet came
+ * off the site, and on a visit where that CDN was slow or blocked they did
+ * not degrade to the empty square above — there was nothing in the box at
+ * all. `font-size` stays for the same reason `.icon` still exists: VitePress
+ * accepts any HTML here, and a future icon that is text again inherits it. */
 .Layout .VPHome .VPFeature .icon {
   width: auto;
   height: auto;
@@ -982,6 +1002,12 @@
   color: var(--vp-c-text-2);
   font-size: 20px;
   justify-content: flex-start;
+}
+
+.Layout .VPHome .VPFeature .icon svg {
+  display: block;
+  width: 22px;
+  height: 22px;
 }
 
 /* The buttons. 20px on a 34px-tall button is a pill, and a pill is a control
@@ -1090,10 +1116,15 @@
   }
 
   /* No width or height any more — the plate above is gone, so there is
-   * nothing to size; only the glyph and the gap under it. */
+   * nothing to size; only the mark and the gap under it. */
   .Layout .VPHome .VPFeature .icon {
     margin-bottom: 12px;
     font-size: 19px;
+  }
+
+  .Layout .VPHome .VPFeature .icon svg {
+    width: 21px;
+    height: 21px;
   }
 
   .Layout .VPHome .VPFeature .title {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -823,17 +823,18 @@
 
 /* ------------------------------------ the home page, below the hero ---
  *
- * Two feature cards, and a second row of three below them that is this
+ * Three feature cards, and a second row of three below them that is this
  * file's own. VPFeatures picks its column count from the NUMBER of cards,
- * and two gives `grid-2` — two per row, the line break above the second row
- * — so nothing has to be overridden here. Change the count in docs/index.md
- * and the row changes with it: five would give `grid-4` and a lone fifth
- * card under four, which is what the override that used to live here
- * existed to prevent.
+ * and three gives `grid-3` — full width below 768px, a third of the row
+ * above it — so nothing has to be overridden for the first row. Change the
+ * count in docs/index.md and that row changes with it: five would give
+ * `grid-4` and a lone fifth card under four, which is what the override that
+ * used to live here existed to prevent — and the second row below, whose
+ * breakpoint is written out by hand, would no longer line up with it.
  */
 
 /* The second row of cards - the repository, LinkedIn, the playground - under
- * the theme's two and on the same grid: the same 1152px, the same 16px
+ * the theme's three and on the same grid: the same 1152px, the same 16px
  * gutters, the same padding, so the two rows read as one grid with a line
  * break in it. What sets the row apart is the drawing: the cards above are
  * outlined, these are filled with the brand's soft tint and carry the mark
@@ -853,13 +854,12 @@
   max-width: 1152px;
 }
 
-@media (min-width: 640px) {
-  .a2ui5-out {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (min-width: 960px) {
+/* One breakpoint, and it is `grid-3`'s: the row above goes from stacked to
+ * three-across at 768px, and a second row that broke to two columns at 640px
+ * and to three at 960px spent the two widths in between disagreeing with it
+ * — three cards over two, then two over three. Two rows of three, changing
+ * together, is the whole point of drawing them on one grid. */
+@media (min-width: 768px) {
   .a2ui5-out {
     grid-template-columns: repeat(3, 1fr);
   }
@@ -954,7 +954,7 @@
  * ancestors below are counted against the real compiled selectors —
  * `.VPButton.medium[data-v-x]` is three, so the button rules carry four. */
 
-/* The two feature cards. The theme draws them with `background-color` and
+/* The three feature cards. The theme draws them with `background-color` and
  * `border-color` both set to `--vp-c-bg-soft`: a filled tile whose border is
  * invisible because it is the same colour as its fill. Swapping the fill for
  * the divider colour turns the same element into an outlined card and costs

--- a/docs/configuration/launchpad.md
+++ b/docs/configuration/launchpad.md
@@ -84,7 +84,7 @@ If clearing caches doesn't fix it, push the frontend app manually:
 
 Extend your Fiori Launchpad with Key Performance Indicators (KPIs) via the abap2UI5 Launchpad KPI add-on.
 
-<i class="fa-brands fa-github"></i> [Repository](https://github.com/abap2UI5-addons/launchpad-kpi)
+<svg class="a2ui5-mark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> [Repository](https://github.com/abap2UI5-addons/launchpad-kpi)
 
 ### Functionality
 <img width="800" alt="Launchpad KPI tiles showing dynamic count values" src="https://github.com/abap2UI5/abap2UI5-connector_launchpad_kpi/assets/102328295/c7db9e46-6876-40d8-a632-be79e2fbcb91">

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,15 +44,15 @@ hero:
 # the search box.
 features:
   - title: Tutorial
-    icon: <i class="fa-solid fa-graduation-cap"></i>
+    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 3 1.4 7.6 12 12.2l10.6-4.6z"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M5.6 10.3v4.8c0 1.8 2.9 3.2 6.4 3.2s6.4-1.4 6.4-3.2v-4.8"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M21.4 8.7v5.6"/></svg>
     details: Start here — one app you build step by step, from a first message box to a tested app running in production.
     link: /tutorials/walkthrough/
   - title: Cookbook
-    icon: <i class="fa-solid fa-book-open"></i>
+    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" d="M12 6.9C10.4 5.5 8.2 4.8 5.4 4.8H2.4v12.6h3c2.8 0 5 .7 6.6 2.1 1.6-1.4 3.8-2.1 6.6-2.1h3V4.8h-3c-2.8 0-5 .7-6.6 2.1z"/><path fill="none" stroke="currentColor" stroke-width="1.7" d="M12 6.9v12.6"/></svg>
     details: Look it up — tables, popups, navigation, file upload and download. One page per problem, each with code to copy.
     link: /cookbook/view/definition
   - title: Configuration
-    icon: <i class="fa-solid fa-gear"></i>
+    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" d="M9.89 4.65 10.11 1.82h3.78l.22 2.83 1.6.66 2.15-1.84 2.67 2.67-1.84 2.15.66 1.6 2.83.22v3.78l-2.83.22-.66 1.6 1.84 2.15-2.67 2.67-2.15-1.84-1.6.66-.22 2.83h-3.78l-.22-2.83-1.6-.66-2.15 1.84-2.67-2.67 1.84-2.15-.66-1.6-2.83-.22v-3.78l2.83-.22.66-1.6-1.84-2.15 2.67-2.67 2.15 1.84z"/><circle cx="12" cy="12" r="3.2" fill="none" stroke="currentColor" stroke-width="1.7"/></svg>
     details: Go live — setup, security, performance, transport and the launchpad. Everything between your first app and real users.
     link: /configuration/setup
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,35 +20,40 @@ hero:
       text: What's New?
       link: /resources/changelog
 
-# Two rows of cards. This row, the theme's own, is the two things a reader
-# comes here to READ: learn it, take it to production. Two cards, on purpose —
-# VPFeatures picks its column count from the number of cards, and two gives
-# a row of two, which is the line break before the second row below. The
-# Cookbook is not one of them: it answers a question you already have, and
-# someone on the home page does not have it yet — the Tutorial is what a
-# first visit is for, and the Cookbook is a click away in the nav the moment
-# it is wanted. Quickstart is not a card either — the hero's first button is
-# already that jump, and a card repeating it is a card spent twice. Technical
-# Insight is not one either: it is what you read after the thing runs, not a
-# way in.
+# Two rows of three. The first, the theme's own, is the three ways INTO the
+# documentation, in the order a reader meets them: learn it, look things up
+# while building, take it to production. The Cookbook is the middle one on
+# purpose — it used to be left off on the argument that it answers a question
+# a first-time visitor does not have yet, but most visits here are not first
+# visits, and the reader who arrives already stuck was being sent through a
+# nav dropdown to find the page written for them. Quickstart is still not a
+# card: the hero's first button is that jump, and a card repeating it is a
+# card spent twice. Technical Insight is not one either — it is what you read
+# after the thing runs, not a way in.
 #
-# The second row, in the markdown below the frontmatter, is the three places
-# that are not pages of this site: the repository, LinkedIn and the
-# playground. They used to be scattered — Community was a third card up here,
-# the playground a lone button under a rule, LinkedIn only an icon in the nav
-# bar — and a reader who had finished the two cards above had nowhere
-# obvious to go next. Now they are a row of their own, drawn differently
-# from the two above (a tinted fill where these are outlined), so that a
-# card that leaves this site is recognisable as one before it is clicked,
-# and looks like something to click rather than something to read.
+# Three cards give VPFeatures `grid-3`, which is why the second row below —
+# the three places that are NOT pages of this site: the repository, LinkedIn
+# and the playground — is set to the same three columns at the same
+# breakpoint. Two rows of three, one grid. They are drawn differently (a
+# tinted fill where these are outlined) so that a card which leaves this site
+# is recognisable as one before it is clicked.
+#
+# Every `details` line is written to be clicked rather than read: it opens on
+# what the reader gets to DO there, and names the concrete things they came
+# looking for. A card that only describes its section is a card that loses to
+# the search box.
 features:
   - title: Tutorial
     icon: <i class="fa-solid fa-graduation-cap"></i>
-    details: Learn by building — steps that grow one runnable app, from a message box to a tested app in production.
+    details: Start here — one app you build step by step, from a first message box to a tested app running in production.
     link: /tutorials/walkthrough/
+  - title: Cookbook
+    icon: <i class="fa-solid fa-book-open"></i>
+    details: Look it up — tables, popups, navigation, file upload and download. One page per problem, each with code to copy.
+    link: /cookbook/view/definition
   - title: Configuration
     icon: <i class="fa-solid fa-gear"></i>
-    details: Setup, security, performance, launchpad — the road to production use.
+    details: Go live — setup, security, performance, transport and the launchpad. Everything between your first app and real users.
     link: /configuration/setup
 ---
 
@@ -61,16 +66,16 @@ features:
   <a class="a2ui5-out-card" href="https://github.com/abap2UI5/abap2UI5/" target="_blank" rel="noreferrer">
     <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg></span>
     <span class="a2ui5-out-title">Community</span>
-    <span class="a2ui5-out-details">Browse the code, report issues, contribute — the project is built in the open on GitHub.</span>
+    <span class="a2ui5-out-details">Read the code, open an issue, send a pull request — abap2UI5 is built in the open, and contributions are welcome.</span>
   </a>
   <a class="a2ui5-out-card" href="https://www.linkedin.com/company/abap2ui5/" target="_blank" rel="noreferrer">
     <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg></span>
     <span class="a2ui5-out-title">LinkedIn</span>
-    <span class="a2ui5-out-details">Follow along — releases, articles and what people are building with it.</span>
+    <span class="a2ui5-out-details">Follow along — new releases, articles, and what people are building with it right now.</span>
   </a>
   <a class="a2ui5-out-card" href="https://abap2ui5.github.io/playground/" target="_blank" rel="noreferrer">
     <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9.75" fill="none" stroke="currentColor" stroke-width="1.7"/><path d="M9.6 7.9v8.2a.5.5 0 0 0 .76.43l6.6-4.1a.5.5 0 0 0 0-.86l-6.6-4.1a.5.5 0 0 0-.76.43z" fill="currentColor"/></svg></span>
     <span class="a2ui5-out-title">Playground</span>
-    <span class="a2ui5-out-details">Write ABAP in the browser and watch it run — nothing to install, nothing to sign up for.</span>
+    <span class="a2ui5-out-details">Try it right now — write ABAP in the browser and watch it run. Nothing to install, nothing to sign up for.</span>
   </a>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,13 +12,22 @@ hero:
     alt: abap2UI5 Logo
     width: 200px
     height: 200px
+  # Two buttons: install it, and understand what it is. The second one was
+  # "What's New?" on the changelog — a page for the reader who is already
+  # here every month, reached from the hero of the page written for the one
+  # who is not. It is not lost: the version number in the nav bar opens a
+  # menu whose first entry is Release Notes, which is where somebody looking
+  # for what changed goes anyway. "In a Nutshell" was the gap — the page
+  # that answers "what IS this" had no path from the home page at all, only
+  # the Guide dropdown. It carries the label the sidebar gives it, so a
+  # reader who clicks knows where they landed.
   actions:
     - theme: brand
       text: Quickstart
       link: /get_started/quickstart
     - theme: alt
-      text: What's New?
-      link: /resources/changelog
+      text: In a Nutshell
+      link: /get_started/about
 
 # Two rows of three. The first, the theme's own, is the three ways INTO the
 # documentation, in the order a reader meets them: learn it, look things up


### PR DESCRIPTION
Removes the Font Awesome CDN dependency and replaces all icon usage with inline SVG markup. This eliminates a render-blocking stylesheet that was loaded on every page to display only four icons.

## Summary

Font Awesome was loaded site-wide to render three feature card icons on the home page and one GitHub mark on the configuration/launchpad page. All four icons are now inline SVGs embedded directly in the markdown, matching the approach already used for other icons on the site.

## Key Changes

- **Removed Font Awesome CDN link** from `docs/.vitepress/config.mjs` with detailed explanation of why the dependency was unnecessary
- **Replaced home page feature icons** in `docs/index.md`:
  - Tutorial: graduation cap → custom SVG
  - Cookbook: book → custom SVG (new card added to make three)
  - Configuration: gear → custom SVG
- **Replaced GitHub icon** in `docs/configuration/launchpad.md` with inline SVG and added `.a2ui5-mark` class for styling
- **Added CSS rule** for `.a2ui5-mark` in `docs/.vitepress/theme/style.css` to style inline SVGs like text glyphs (size, color, baseline alignment)
- **Added SVG styling** for feature card icons at both desktop and mobile breakpoints
- **Updated home page layout** from 2 feature cards to 3, adjusting grid breakpoints and comments accordingly
- **Updated second row of cards** (Community, LinkedIn, Playground) to use matching 3-column grid at 768px breakpoint
- **Refreshed card descriptions** in `docs/index.md` to be more action-oriented and reflect the new three-card layout

## Implementation Details

The inline SVGs use `currentColor` to inherit text color and are sized via CSS rather than attributes, ensuring consistent styling with the rest of the site. The `.a2ui5-mark` class handles vertical alignment (`vertical-align: -0.16em`) to keep marks on the baseline with surrounding text, matching the behavior of the Font Awesome glyphs they replaced.

The home page now features a coherent three-column grid for both the primary feature cards (Tutorial, Cookbook, Configuration) and the secondary row (Community, LinkedIn, Playground), creating a unified visual structure.

https://claude.ai/code/session_01NRmHFuzitJ2tpug3xXBwLj