### PR TITLE
Regenerate the client API reference, and give the Run-button measurement its worklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `scripts/lib/client-interface.mjs` | Where `z2ui5_if_client` is fetched from (the ref comes from `lib/release.mjs`, shared with `check-api-names.mjs`) and the full parser `generate-api-reference.mjs` renders from |
 | `scripts/check-version.mjs` | The release number in the nav bar, the deprecations page and the changelog, against the newest release tag of the framework |
 | `docs/.vitepress/playground.mjs` | Decides which fenced ABAP example gets a **Run** button, and wraps the fence; `theme/playground.js` is the browser half |
+| `scripts/list-runnable.mjs` | The measurement's worklist: every fenced example that carries a Run button, out of the same `playground.mjs` that decides the button. `--json` adds each example's ABAP verbatim - what the button sends - so the measurement below can be driven rather than clicked |
 | `scripts/check-playground.mjs` | The Run-button bookkeeping: every complete app class either gets a button from `playground.mjs` or carries a `<!-- playground: no Run button — … -->` marker above its fence saying why it cannot run; a stale marker fails as loudly as a missing one. `--list` prints the deliberate exclusions with both reasons |
 | `scripts/check-conventions.mjs` | The two house conventions the sample corpora gate and this one did not: the view-chain layout in every fenced chain (the linter's `chain-house-layout`, which is opt-in — `check-examples.mjs` writes its config without a `rules` block, so the rule was never emitted), and the three class section blocks in every fenced app class. `--fix` (`npm run fmt:chains`) reformats a drifted chain; the sections are a judgement and stay by hand |
 | `scripts/lib/catalogue.mjs` | Parses and counts a sample catalogue, for `link-samples.mjs` and for the figures `generate-llms.mjs` writes into `llms.txt` — from a sibling checkout when one is here, else from the `catalogue.json` each sample repository commits at its root; pinned by `test/catalogue.test.mjs`, because it has stopped matching twice and both times answered wrongly instead of failing |
@@ -239,15 +240,24 @@ says so, is whether a buttoned example actually starts; that stays a
 measurement.
 
 **To redo the measurement** — after adding examples, or after the playground
-changes — build the playground, serve it, and open each fenced example in an
-embedded one, checking that the status line reaches `running` and that the app
-frame contains something:
+changes — take the worklist from `npm run runnable`, build the playground,
+serve it, and open each example in it, checking that the status line reaches
+`running` and that the app frame contains something:
 
 ```sh
+npm run runnable -- --json > /tmp/runnable.json   # 63 examples, ABAP included
 git clone https://github.com/abap2UI5/playground && cd playground
 npm ci && npm run build && npm run serve      # the first build is a few minutes
-# then, for each example: /?embed=1&view=app#<the deflated fragment>
+# then, per example: put its ABAP in the editor and press Run - or open
+# /?embed=1&view=app#<the deflated fragment>. The playground's own Playwright
+# helpers (tests/helpers.mjs: open, setSource, run) drive that loop on one
+# page, which is the difference between an afternoon and twenty minutes.
 ```
+
+The class in the example has to match the file it goes into: the playground
+refuses the pair when they disagree, exactly as a system does. Renaming the
+class to the open file's is enough — nothing in these examples depends on
+its name.
 
 The last full measurement: **61 complete app classes, 39 with a button, all 39
 started and rendered.** The site has since grown, and the hand-kept copy of

--- a/docs/public/api/client-api.json
+++ b/docs/public/api/client-api.json
@@ -266,6 +266,9 @@
     {
       "name": "message_box_display",
       "group": "Messages",
+      "doc": [
+        "Show a sap.m.MessageBox. `text` is TYPE any and takes whatever the app has: a text, a message structure or table (BAPIRET2, T100, RAP, symsg, a log object, an exception), an HTML string, a business table, a nested structure or tree, an object, a number. Messages are recognized first and set the box's severity and title themselves; everything else is rendered - a headline in the box, the data itself in the details. The one case that shows nothing at all is complex data that is initial (an empty message table stays as silent as it always was)."
+      ],
       "parameters": [
         {
           "name": "text",

--- a/docs/resources/api.md
+++ b/docs/resources/api.md
@@ -197,6 +197,8 @@ Returns `string`.
 
 ### `message_box_display`
 
+Show a sap.m.MessageBox. `text` is TYPE any and takes whatever the app has: a text, a message structure or table (BAPIRET2, T100, RAP, symsg, a log object, an exception), an HTML string, a business table, a nested structure or tree, an object, a number. Messages are recognized first and set the box's severity and title themselves; everything else is rendered - a headline in the box, the data itself in the details. The one case that shows nothing at all is complex data that is initial (an empty message table stays as silent as it always was).
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `text` | `any` |  |  |

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:conventions": "node scripts/check-conventions.mjs",
     "fmt:chains": "node scripts/check-conventions.mjs --fix",
     "check:playground": "node scripts/check-playground.mjs",
+    "runnable": "node scripts/list-runnable.mjs",
     "check:api-names": "node scripts/check-api-names.mjs",
     "generate:api": "node scripts/generate-api-reference.mjs",
     "check:api-reference": "node scripts/generate-api-reference.mjs --check",

--- a/scripts/list-runnable.mjs
+++ b/scripts/list-runnable.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/*
+ * The worklist for the Run-button measurement: every fenced example on the
+ * site that carries a Run button, with the ABAP the button would hand the
+ * playground.
+ *
+ * WHY THIS EXISTS. `check:playground` decides the bookkeeping - every complete
+ * app class either gets a button or carries a marker saying why it cannot run
+ * - and says plainly what it cannot decide: whether a BUTTONED example
+ * actually starts. That stays a measurement in a browser, and AGENTS.md
+ * describes it as one. What it did not have was its input: whoever redoes it
+ * had to find the examples by hand, and "63 with a button" is a number the
+ * gate prints rather than a list anybody can act on.
+ *
+ * So this prints the list, out of the same `playground.mjs` that decides the
+ * button - never a second copy of those rules. With `--json` it prints the
+ * examples with their ABAP, ready to drive a served playground with; the
+ * driving half lives where the browser harness already is (abap2UI5/playground
+ * has one), not in a documentation repository that would need Playwright as a
+ * dependency to run it once a quarter.
+ *
+ *   npm run runnable            the list, one line per example
+ *   npm run runnable -- --json  the same plus each example's ABAP, as JSON
+ *
+ * The ABAP is the fence VERBATIM, which is what the Run button sends: the
+ * client reads `pre code`'s textContent off the rendered page. Not
+ * `abapOnly( )` - that one blanks every literal so a rule cannot be tripped by
+ * prose, and a view built from blanked literals has no control names left in
+ * it at all.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { isRunnable, playgroundExample } from '../docs/.vitepress/playground.mjs';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS = path.join(ROOT, 'docs');
+const JSON_OUT = process.argv.includes('--json');
+
+/** Every page under docs/, minus the two directories that hold no pages. */
+function pages(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== 'public' && entry.name !== '.vitepress') pages(full, found);
+    } else if (entry.name.endsWith('.md')) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+const examples = [];
+for (const file of pages(DOCS)) {
+  const md = fs.readFileSync(file, 'utf8');
+  for (const fence of md.matchAll(/```abap\n([\s\S]*?)```/g)) {
+    const code = fence[1];
+    if (!isRunnable(code)) continue;
+    examples.push({
+      page: path.relative(DOCS, file),
+      class: playgroundExample(code).name,
+      abap: code,
+    });
+  }
+}
+
+if (JSON_OUT) {
+  process.stdout.write(`${JSON.stringify(examples, null, 1)}\n`);
+} else {
+  for (const e of examples) {
+    console.log(`${e.page}  ${e.class}`);
+  }
+  const onPages = new Set(examples.map((e) => e.page)).size;
+  console.log(`\nlist-runnable: ${examples.length} example(s) with a Run button on ${onPages} page(s)`);
+  console.log('These are what the measurement opens - see AGENTS.md, "The Run button".');
+}


### PR DESCRIPTION
### `check:api-reference` was red

The framework gave `message_box_display` an abapdoc block — what `TYPE any` accepts, which shapes set the box's severity themselves, and the one case that shows nothing at all — and the committed reference still showed the method with no prose. Regenerated with `npm run generate:api`; no other entry moved.

### The measurement that CI cannot make now has an input

`check:playground` decides the bookkeeping and says plainly what it cannot decide: whether a BUTTONED example actually starts. That stays a measurement in a browser, and AGENTS.md describes it as one — but it had no input. Whoever redid it had to find the examples by hand, because "63 with a button" is a number the gate prints, not a list anybody can act on.

`npm run runnable` prints the list, out of the same `playground.mjs` that decides the button, so there is no second copy of those rules. `--json` adds each example's ABAP **verbatim** — which is what the Run button sends (`pre code`'s textContent off the rendered page), not `abapOnly( )`: that one blanks every literal so a rule cannot be tripped by prose, and a view built from blanked literals has no control names left in it at all.

AGENTS.md's procedure now starts from that list and says the two things somebody redoing it finds out the hard way: the playground's own Playwright helpers drive the loop on ONE page (booting it is the expensive part), and the class in an example has to be renamed to the open file's, because the playground refuses a file and class that disagree.

Both were learned by actually driving it here. The full 63-example run did not complete in this sandbox — the renderer wedges after the first example — so **no new measurement result is claimed**; the numbers in AGENTS.md are untouched.

### Checks

`npm run check` green — all nine gates, including the docs build and `check:playground` (82 complete app classes, 63 with a button, 19 excluded, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ)_