### PR TITLE
Unify theme and bar across three deployments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,9 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `scripts/lib/client-interface.mjs` | Where `z2ui5_if_client` is fetched from (the ref comes from `lib/release.mjs`, shared with `check-api-names.mjs`) and the full parser `generate-api-reference.mjs` renders from |
 | `scripts/check-version.mjs` | The release number in the nav bar, the deprecations page and the changelog, against the newest release tag of the framework |
 | `docs/.vitepress/playground.mjs` | Decides which fenced ABAP example gets a **Run** button, and wraps the fence; `theme/playground.js` is the browser half |
+| `docs/.vitepress/theme/style.css` | Everything this site looks like. Its palette is the playground's, copied — see *One site in three places* below |
+| `docs/.vitepress/theme/SiteBar.vue` | The right-hand end of the bar: the three sites, and the light/dark button. Rendered into `nav-bar-content-after` by `theme/index.js` |
+| `docs/.vitepress/theme/site-memory.js` | Where the reader was, on each site, so the bar comes back to it; pinned by `test/site-memory.test.mjs` |
 | `scripts/check-playground.mjs` | The Run-button bookkeeping: every complete app class either gets a button from `playground.mjs` or carries a `<!-- playground: no Run button — … -->` marker above its fence saying why it cannot run; a stale marker fails as loudly as a missing one. `--list` prints the deliberate exclusions with both reasons |
 | `scripts/check-conventions.mjs` | The two house conventions the sample corpora gate and this one did not: the view-chain layout in every fenced chain (the linter's `chain-house-layout`, which is opt-in — `check-examples.mjs` writes its config without a `rules` block, so the rule was never emitted), and the three class section blocks in every fenced app class. `--fix` (`npm run fmt:chains`) reformats a drifted chain; the sections are a judgement and stay by hand |
 | `scripts/lib/catalogue.mjs` | Parses and counts a sample catalogue, for `link-samples.mjs` and for the figures `generate-llms.mjs` writes into `llms.txt` — from a sibling checkout when one is here, else from the `catalogue.json` each sample repository commits at its root; pinned by `test/catalogue.test.mjs`, because it has stopped matching twice and both times answered wrongly instead of failing |
@@ -36,7 +39,7 @@ it are decidable, and all nine are decided before a merge:
 
 | | |
 |---|---|
-| `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate |
+| `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate — and the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow |
 | `check:version` | the release number in the nav bar, the deprecations page and the changelog, against the newest release tag of the framework — this one goes stale without anybody touching this repository |
 | `docs:build` | a page that does not build is a page nobody can read |
 | `check:examples` | the ABAP in the fenced blocks, against the real framework: does it compile, and does the view it builds name controls and properties that exist on the UI5 floor this documentation targets |
@@ -111,6 +114,46 @@ maintained by hand because it names URLs and nothing else. Do not "fix" it by
 committing the generated files instead: they would be stale on every commit
 that touches a page, and a wrong committed copy outranks a right generated one
 in every tool that reads the tree.
+
+## One site in three places
+
+This documentation, the [playground](https://abap2ui5.github.io/playground/)
+and the [sample catalogue](https://abap2ui5.github.io/playground/samples/) are
+three deployments on **one origin**, and from 2026-09-04 they are meant to be
+read as one site: the same bar, the same palette, the same measure. The other
+two live in [abap2UI5/playground](https://github.com/abap2UI5/playground)
+(`src/shell/`, `src/catalogue/` and the per-sample pages
+`tools/sample-pages.mjs` writes).
+
+**The palette is copied, not imported.** The seven values at the top of
+`theme/style.css` are `src/catalogue/catalogue.css`'s, written out. Three
+repositories deploy separately, and a stylesheet fetched across them would be a
+request in front of the first paint. Change them together — the same applies to
+the bar's markup, which exists four times by hand for the same reason.
+
+**The accent is SAP blue, and the mark is still red.** `#0a6ed1` / `#4aa3ff` is
+what a link, a button and the hero name are set in; `#d03c4a` is the circle in
+the wordmark and belongs to the mark alone. `resources/logo.md` is the page
+that says so and the one place either value is quoted to a reader — if you move
+an accent, move that table with it.
+
+**One origin means one localStorage**, which is what two things here rely on:
+
+| | |
+|---|---|
+| the theme | The key is the playground's (`abap2ui5-playground:theme`). A head script in `config.mjs` reads it before the first paint and hands it to VitePress's own appearance handling; `SiteBar.vue` writes it back when the button is pressed. A reader crossing from a dark playground gets a dark page, with no flash |
+| where you were | `theme/site-memory.js`. Every page writes its own path down; the Samples item is lifted to whatever the catalogue last wrote. A stored value is **checked, not followed** — resolved against this origin and kept only if it is still inside the href the markup carries, which is what makes a poisoned or stale key cost a restored position and nothing else. The eleven cases are `test/site-memory.test.mjs` |
+
+The playground is consulted by both and remembered by neither: its URL carries
+the code in the editor, so an item that reopened yesterday's sample would be a
+different promise from the one the word makes.
+
+**What a browser test in this repository cannot reach.** `vitepress preview`
+serves this site on localhost while the catalogue link points at
+abap2ui5.github.io, so every path through `lastVisited( )` takes the
+different-origin branch and falls back. That is why the same-origin cases are a
+unit test with a stubbed `location` rather than an end-to-end one. The round
+trip itself is held over there, in `tests/site-memory.spec.js`.
 
 ## Things that will trip you up
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -74,6 +74,32 @@ export default defineConfig({
     ],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
     ["meta", { name: "twitter:image", content: OG_IMAGE }],
+    // One theme across the three deployments on this origin - this site, the
+    // playground and the sample catalogue (abap2ui5.github.io/docs and
+    // /playground). They share a localStorage, and now that all three wear
+    // the same bar, a switch that only turned half of them dark would read as
+    // a broken switch rather than as three sites.
+    //
+    // The playground's key is the one that carries it; VitePress's own is
+    // written from it here so that everything downstream - its runtime, its
+    // `appearance` handling, the `.dark` class - goes on believing it is in
+    // charge. In the head and synchronous, after VitePress's own appearance
+    // script and still before the first paint, so a reader arriving from a
+    // dark playground gets a dark page rather than a white flash.
+    //
+    // theme/SiteBar.vue writes the playground key back when the button here
+    // is pressed. Its two lines and these are one mechanism.
+    [
+      "script",
+      {},
+      `try {
+  var t = localStorage.getItem("abap2ui5-playground:theme");
+  if (t === "dark" || t === "light") {
+    localStorage.setItem("vitepress-theme-appearance", t);
+    document.documentElement.classList.toggle("dark", t === "dark");
+  }
+} catch (e) { /* a browser that refuses storage keeps this site's own theme */ }`,
+    ],
   ],
   title: "abap2UI5",
   description: "Build UI5 Apps Purely in ABAP",
@@ -108,6 +134,13 @@ export default defineConfig({
   },
   themeConfig: {
     logo: "/logo.png",
+    // The mark, then the site in the ordinary weight and the part of it you
+    // are in in the heavy one - the brand the playground and the sample
+    // catalogue wear (src/shell/index.html, src/catalogue/index.html over
+    // there), so somebody moving between the three reads one bar rather than
+    // three. `siteTitle` is rendered with v-html, which is what lets the
+    // second word carry the weight.
+    siteTitle: "abap2UI5 <b>docs</b>",
     footer: {
       message: `
       <a href="/docs/resources/license">License</a> |
@@ -693,28 +726,37 @@ export default defineConfig({
       },
     ],
     outline: [2, 6],
+    // The two marks, as inline SVG rather than by name. VitePress draws a
+    // named icon from a CSS mask and, if that mask has not been generated,
+    // falls back to fetching the glyph from api.iconify.design - a CDN, which
+    // is the one thing every other mark on this site was taken off. These are
+    // the exact paths the playground's bar and the catalogue's carry
+    // (src/shell/index.html, src/catalogue/index.html), so the end of the bar
+    // is the same two shapes on all four documents rather than two drawings of
+    // the same two brands.
     socialLinks: [
-      { icon: "linkedin", link: "https://www.linkedin.com/company/abap2ui5/" },
-      { icon: "github", link: "https://github.com/abap2UI5/abap2UI5" },
-      // The playground, at the right-hand end of the bar: try the thing from
-      // any page, not only from the home page button. It belongs in this row
-      // because VPSocialLink opens in a new tab and passes the link through
-      // verbatim - right for a site of its own, which is exactly why the
-      // Support page could NOT sit here (it lived in a custom component in
-      // the `nav-bar-content-after` slot until this icon took its place;
-      // Support stays under the version menu and in the sidebar). The glyph
-      // is inline rather than one of Font Awesome's: that stylesheet comes
-      // from a CDN, and an icon that is an empty square until it arrives is
-      // worse than one that never needed it. A play triangle in a ring, at
-      // the 20px the row gives it; the ring is a stroke so it reads as one
-      // shape next to the two solid marks and not as a third blob.
       {
         icon: {
-          svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9.75" fill="none" stroke="currentColor" stroke-width="1.7"/><path d="M9.6 7.9v8.2a.5.5 0 0 0 .76.43l6.6-4.1a.5.5 0 0 0 0-.86l-6.6-4.1a.5.5 0 0 0-.76.43z" fill="currentColor"/></svg>',
+          svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>',
         },
-        link: "https://abap2ui5.github.io/playground/",
-        ariaLabel: "Playground",
+        link: "https://www.linkedin.com/company/abap2ui5/",
+        ariaLabel: "abap2UI5 on LinkedIn",
       },
+      {
+        icon: {
+          svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>',
+        },
+        link: "https://github.com/abap2UI5/abap2UI5",
+        ariaLabel: "abap2UI5 on GitHub",
+      },
+      // Two marks and no more, which is what the playground's bar and the
+      // catalogue's each carry. The playground used to be a third one here -
+      // a play triangle in a ring - and it is a NAV ITEM now
+      // (theme/SiteBar.vue), beside Samples and Docs: it is one of the three
+      // places this project lives, and naming it beats a glyph somebody has
+      // to hover. The Support page could never sit in this row for the
+      // opposite reason and still cannot; it stays under the version menu and
+      // in the sidebar.
     ],
   },
 });

--- a/docs/.vitepress/theme/SiteBar.vue
+++ b/docs/.vitepress/theme/SiteBar.vue
@@ -1,0 +1,79 @@
+<script setup>
+/*
+ * The right-hand end of the bar, which is the playground's right-hand end and
+ * the sample catalogue's (src/shell/index.html, src/catalogue/catalogue.css in
+ * abap2UI5/playground) down to the numbers: where in this project you are, a
+ * button for light and dark, one hairline, then the two marks. Four documents
+ * carry that group now - this one, the playground, the catalogue and the
+ * per-sample pages - and somebody moving between them reads ONE bar, so it is
+ * kept identical by hand rather than left to four interpretations of a house
+ * style.
+ *
+ * The two marks are not here: they are VitePress's own `socialLinks`, which
+ * draws the same LinkedIn and GitHub inline. The hairline in front of them is
+ * in style.css, where the ordering that puts this group before them also is.
+ */
+import { inject, onMounted, ref, watch } from "vue";
+import { useData } from "vitepress";
+import { lastVisited } from "./site-memory.js";
+
+const { isDark } = useData();
+
+/* The same three items serve the bar and the menu a phone opens instead of it
+ * (`nav-screen-content-after`). Only the button differs: down there VitePress
+ * draws its own appearance control, and two of them in one menu is one too
+ * many. */
+defineProps({ theme: { type: Boolean, default: true } });
+
+const PLAYGROUND = "https://abap2ui5.github.io/playground/";
+const SAMPLES = "https://abap2ui5.github.io/playground/samples/";
+
+/* The catalogue's front page until the browser says otherwise. This is what
+ * the server renders, what a crawler is given and what a first visit follows;
+ * onMounted only ever replaces it with a deeper page of the same site. */
+const samplesHref = ref(SAMPLES);
+onMounted(() => {
+  samplesHref.value = lastVisited("samples", SAMPLES);
+});
+
+/* VitePress's own toggle, so a site that provides one (the appearance
+ * transition) keeps it; the fallback is what VPSwitchAppearance does. */
+const toggleAppearance = inject("toggle-appearance", () => {
+  isDark.value = !isDark.value;
+});
+
+/* And the choice, handed to the other two deployments. The head script in
+ * config.mjs reads this key back before the first paint; the two halves are
+ * one mechanism. Not on the server, and not on the first render either - only
+ * when the reader actually changes it. */
+watch(isDark, (dark) => {
+  try {
+    localStorage.setItem("abap2ui5-playground:theme", dark ? "dark" : "light");
+  } catch {
+    /* A refused or full storage. This tab is dark; the next site is not. */
+  }
+});
+</script>
+
+<template>
+  <nav class="bar-nav" aria-label="abap2UI5 sites">
+    <a :href="PLAYGROUND" title="Write ABAP and run it in the browser">Playground</a>
+    <a :href="samplesHref" data-site="samples" title="Every abap2UI5 sample, searchable">Samples</a>
+    <!-- The one you are on, which is why it is a span and not a link - the
+         look aria-current gets on the other three bars. -->
+    <span class="here" aria-current="page">Docs</span>
+  </nav>
+  <button
+    v-if="theme"
+    class="theme"
+    type="button"
+    role="switch"
+    :aria-checked="isDark"
+    :aria-label="isDark ? 'Switch to light theme' : 'Switch to dark theme'"
+    :title="isDark ? 'Switch to light theme' : 'Switch to dark theme'"
+    @click="toggleAppearance"
+  >
+    <span class="theme-sun" aria-hidden="true">☀</span>
+    <span class="theme-moon" aria-hidden="true">☾</span>
+  </button>
+</template>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,14 +1,42 @@
 // https://vitepress.dev/guide/custom-theme
+import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
 import { setUpPlayground } from './playground.js'
+import SiteBar from './SiteBar.vue'
+import { rememberHere } from './site-memory.js'
 
 /** @type {import('vitepress').Theme} */
 export default {
   extends: DefaultTheme,
+  // The bar's right-hand end - the three sites, and the light/dark button -
+  // injected into the nav bar and into the menu a phone opens instead of it.
+  // See SiteBar.vue for what the group is and style.css for where in the row
+  // it lands: the slot renders after VitePress's own appearance switch and
+  // social links, and CSS orders it back in front of them.
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'nav-bar-content-after': () => h(SiteBar),
+      'nav-screen-content-after': () => h(SiteBar, { theme: false }),
+    })
+  },
   enhanceApp({ app, router, siteData }) {
     // The Run button under a runnable ABAP example. One delegated listener for
     // the whole site — the browser half of docs/.vitepress/playground.mjs.
     if (!import.meta.env.SSR) setUpPlayground()
+
+    // Where the reader is, for the Docs item on the other three bars to come
+    // back to (site-memory.js). On every route change, because this site is a
+    // single page application: the first page would otherwise be the only one
+    // ever written down. `onAfterRouteChange` rather than `onBeforeRouteChange`
+    // - the location is the new one only after the change has happened.
+    if (!import.meta.env.SSR) {
+      rememberHere('docs')
+      const onAfter = router.onAfterRouteChange
+      router.onAfterRouteChange = (to) => {
+        rememberHere('docs')
+        onAfter?.(to)
+      }
+    }
   }
 }

--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -1,0 +1,80 @@
+// Where you were, on each of the two sites the bar moves between.
+//
+// The documentation, the playground and the sample catalogue are three
+// deployments on ONE origin (abap2ui5.github.io/docs, /playground and
+// /playground/samples), which is what makes this possible at all: they share a
+// localStorage the way they now share the theme. Each page writes down where
+// it is, and the nav item pointing at the OTHER site is lifted to whatever
+// that site wrote last. Docs -> Samples -> Docs comes back to the page you
+// left rather than to the front of the manual, and because the catalogue keeps
+// its filters in its URL (?q=table&lib=sap.m), a filtered catalogue comes back
+// filtered.
+//
+// This is the documentation's half. The other half is src/shell/site-memory.mjs
+// in abap2UI5/playground, which the playground and the catalogue import and
+// the per-sample pages carry as an inline copy - same two keys, same checks.
+// Three deployments, three copies, kept in step by hand, for the reason the
+// bar's own markup is: a shared package between two repositories that deploy
+// separately would have to be versioned to say something this simple.
+//
+// The href written into the markup stays the section's front page. That is
+// what a crawler, a reader with no JavaScript and a first visit all get, and
+// it is what every step below falls back to - nothing here ever returns a link
+// worse than the one it was given.
+//
+// THE PLAYGROUND IS NOT REMEMBERED, only consulted. Its URL carries the code
+// in the editor (?src=...), and a Playground item that reopened yesterday's
+// sample instead of an empty editor would be a different promise from the one
+// the word makes. Samples and docs are places; the playground is a workbench.
+
+/* The playground's namespace, for keys this site writes too. It is the wrong
+ * word for a value shared by three deployments and it is the namespace every
+ * other key on this origin already uses - including the theme, which crossed
+ * the same line first. One slightly misnamed prefix beats two prefixes that
+ * have to be remembered separately. */
+const KEY = {
+  samples: "abap2ui5-playground:last-samples",
+  docs: "abap2ui5-playground:last-docs",
+};
+
+/** Write down that the reader is on this site's page. */
+export function rememberHere(site = "docs") {
+  if (typeof localStorage === "undefined" || !KEY[site]) return;
+  try {
+    localStorage.setItem(KEY[site], location.pathname + location.search + location.hash);
+  } catch {
+    /* A refused or full storage. The reader simply is not remembered. */
+  }
+}
+
+/**
+ * The page `site` was last left on, as something an href can be set to - or
+ * `fallback`, which is the link as it was written.
+ *
+ * A stored value is untrusted: anything running on this origin can put
+ * anything in it, and a stale one outlives the page it named. So it is not
+ * returned, it is CHECKED - resolved against this origin first, and kept only
+ * if what comes back is still inside `fallback`'s own path. That is what turns
+ * "//elsewhere/x" (a different origin), "/docs/../x" (a path that normalises
+ * out of the section) and "javascript:…" (an origin of "null") into three
+ * values that are simply ignored.
+ */
+export function lastVisited(site, fallback) {
+  if (typeof localStorage === "undefined") return fallback;
+  try {
+    const last = localStorage.getItem(KEY[site]);
+    if (!last) return fallback;
+    /* The section, from the link that is already written, so this works
+     * unchanged on a dev server where the three sites sit at other paths - and
+     * so a link to another HOST, which shares no storage and therefore has
+     * nothing to restore, falls through the origin test. */
+    const base = new URL(fallback, location.href);
+    if (base.origin !== location.origin) return fallback;
+    const target = new URL(last, location.origin);
+    if (target.origin !== location.origin) return fallback;
+    if (!target.pathname.startsWith(base.pathname)) return fallback;
+    return target.pathname + target.search + target.hash;
+  } catch {
+    return fallback;
+  }
+}

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1297,21 +1297,45 @@
  * bar being shared with two other documents. `:not(.screen-open)` is not a
  * condition, it is a fourth unit of specificity — the theme's own rule for an
  * open mobile menu paints the same colour anyway. */
-.Layout .VPNav .VPNavBar:not(.screen-open),
-.Layout .VPNav .VPNavBar .title,
-.Layout .VPNav .VPNavBar .content-body {
+.Layout .VPNav .VPNavBar:not(.screen-open) {
   background-color: var(--bg-sunken);
 }
 
-/* One hairline under it, always — the theme draws it as a `.divider-line`
- * element that is only there on a page with a sidebar, so the home page had
- * none and the bar ran into the hero. */
+/* NOTHING INSIDE IT CARRIES A FILL. The theme draws this bar in pieces — a
+ * transparent bar with a painted brand and a painted content strip, so that
+ * the strip can fade in over the home page's hero — and both pieces are
+ * `var(--vp-nav-height)` tall, which is one pixel MORE than the bar's content
+ * box now that the bar carries the hairline as its own bottom border. Each of
+ * them therefore painted over that pixel: the fill under the brand hid the
+ * line beneath the mark, the fill under the content hid it from the search box
+ * rightwards, and what was left read as a rule with two gaps in it. With the
+ * whole bar painted above, neither fill has anything left to do. */
+.Layout .VPNav .VPNavBar .title,
+.Layout .VPNav .VPNavBar .content-body {
+  background-color: transparent;
+}
+
+/* And the content strip is held INSIDE the bar's content box, one pixel short
+ * of it, rather than only asked not to paint. The theme's own fill for that
+ * strip is `.VPNavBar:not(.home.top) .content-body` — five units against the
+ * four above it, so it wins the colour argument on a page that is not the home
+ * page at the top, and the hairline came back missing from the sidebar's edge
+ * rightwards. It cannot cover a row it does not reach; the height rule is two
+ * units in the theme, so this one wins it outright. */
+.Layout .VPNav .VPNavBar .content-body {
+  height: calc(var(--vp-nav-height) - 1px);
+}
+
+/* One hairline under the bar, and one only. The theme draws its own as a
+ * `.divider` element BELOW the 46px — so the bar came to 47px and the line was
+ * two pixels thick everywhere the brand did not cover it. The border is inside
+ * the 46, which is where the catalogue's is. */
 .Layout .VPNav .VPNavBar {
   border-bottom: 1px solid var(--line);
 }
 
-.Layout .VPNav .VPNavBar .divider-line {
-  background-color: transparent;
+.Layout .VPNav .VPNavBar .divider {
+  display: none;
 }
 
 /* The brand: the mark, then the site in the ordinary weight and the part of it

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,22 +1,88 @@
-/* One red. The brand has a single red — the circle in the mark, #d03c4a —
- * and every brand token below is that one value, the hover tokens included.
- * There used to be a second, darker red (#a83232) for the hover state of
- * links and buttons; next to the mark it read as a second brand colour, and
- * the page that documents the palette (resources/logo.md) had to list two
- * reds to stay honest. A link already answers "is this one a link" with the
- * underline it gains on hover (see `.vp-doc a:hover` below), so the shade
- * bought nothing the underline does not. */
+/* ========================================================== the palette ===
+ *
+ * ONE PALETTE ACROSS THREE SITES. These seven values are the playground's and
+ * the sample catalogue's, copied out of src/shell/shell.css and
+ * src/catalogue/catalogue.css in abap2UI5/playground rather than approximated:
+ * the three deployments sit on one origin, wear one bar, and are read as one
+ * site by anybody moving between them. A reader who crosses from the catalogue
+ * to a page here should not be able to tell that they changed sites - which
+ * they could, when this file's greys were half a step bluer and its accent was
+ * a different colour entirely.
+ *
+ * They are written out rather than imported. Three repositories deploy
+ * separately and a stylesheet fetched across them would be a request in front
+ * of the first paint; the copies are kept in step by hand, as the bar's own
+ * markup is. Change them together.
+ *
+ * THE ACCENT IS SAP BLUE, not the brand red this site used to set every link
+ * and button in. That red is the circle in the mark and it stays the mark's -
+ * see the note under the logo rules on the home page, and resources/logo.md,
+ * which documents the press kit and is the one page that still names it. What
+ * changed is what a LINK is coloured with, and it is now the same blue the
+ * playground fills its Run button with and the catalogue marks a matching card
+ * with. The measurements: #0a6ed1 on white is 5.04:1 and #4aa3ff on #16171a is
+ * 6.81:1, so both clear AA for body text - the red cleared it on white at
+ * 4.74:1 and FAILED in dark at 3.62:1, which is why it needed a second, lifted
+ * value there. One value per theme now does the whole job. */
 :root {
-    --vp-home-hero-name-color: #d03c4a;
-    --vp-c-brand-1: #d03c4a;
-    --vp-c-brand-2: #d03c4a;
-    --vp-c-brand-3: #d03c4a;
-    --vp-button-brand-bg: #d03c4a;
-    --vp-button-brand-border: #d03c4a;
-    --vp-button-brand-text: #ffffff;
-    --vp-button-brand-bg-hover: #d03c4a;
-    --vp-button-brand-border-hover: #d03c4a;
+  --bg: #ffffff;
+  --bg-sunken: #f4f5f7;
+  --fg: #1c1d21;
+  --fg-dim: #6a6d76;
+  --line: #d9dbe0;
+  --accent: #0a6ed1;
+  --accent-fg: #ffffff;
+  color-scheme: light;
 }
+
+/* VitePress keys everything off `.dark` on the root element, so there is no
+ * media query here and no `[data-theme]`: its own appearance script decides,
+ * and the head script in config.mjs hands it the choice the other two sites
+ * were left on. */
+.dark {
+  --bg: #16171a;
+  --bg-sunken: #1e2024;
+  --fg: #e6e7ea;
+  --fg-dim: #9a9da6;
+  --line: #303338;
+  --accent: #4aa3ff;
+  --accent-fg: #0b1620;
+  color-scheme: dark;
+}
+
+/* …and the theme's own tokens, pointed at them. Everything below this line in
+ * this file, and everything in VitePress's default theme, goes on reading the
+ * `--vp-*` names; this is the one place the two vocabularies meet. */
+:root,
+.dark {
+  --vp-c-bg: var(--bg);
+  --vp-c-bg-alt: var(--bg-sunken);
+  --vp-c-bg-soft: var(--bg-sunken);
+  --vp-c-bg-elv: var(--bg);
+  --vp-c-divider: var(--line);
+  --vp-c-border: var(--line);
+  --vp-c-gutter: var(--line);
+  --vp-c-text-1: var(--fg);
+  --vp-c-text-2: var(--fg-dim);
+
+  --vp-home-hero-name-color: var(--accent);
+  --vp-c-brand-1: var(--accent);
+  --vp-c-brand-2: var(--accent);
+  --vp-c-brand-3: var(--accent);
+  --vp-button-brand-bg: var(--accent);
+  --vp-button-brand-border: var(--accent);
+  --vp-button-brand-text: var(--accent-fg);
+  --vp-button-brand-bg-hover: var(--accent);
+  --vp-button-brand-border-hover: var(--accent);
+}
+
+/* The third text colour is the one the catalogue does not have: it carries two
+ * greys and this site needs a fainter one still, for a placeholder and for the
+ * rule down the side of a remark. So the two themes lend each other theirs -
+ * light takes the dark theme's dim grey, dark takes the light theme's - which
+ * keeps even the faintest step inside the same seven values. */
+:root { --vp-c-text-3: #9a9da6; }
+.dark { --vp-c-text-3: #6a6d76; }
 
 /* ============================================================ the type ===
  *
@@ -44,33 +110,32 @@
   --vp-font-family-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
                          Consolas, "Liberation Mono", monospace;
 
-  /* Body links in the brand colour.
+  /* Body links in the accent.
    *
-   * These were blue for a while, on the argument that red in running text
-   * reads as an error rather than as a brand. That argument is not wrong —
-   * it is why inline CODE is still neutral, and that half stays — but it lost
-   * to the simpler one: a site with a red mark and blue links carries two
-   * accents, and the reader has to learn which of them means anything. One
-   * accent, used for the project and for the things you can click, is the
-   * commoner arrangement and the one capire uses (theirs is teal, for both).
+   * These were red for a while, and before that blue, and the argument that
+   * settled it then still holds: one accent, used for the project and for the
+   * things you can click, beats two the reader has to learn to tell apart.
+   * What changed is WHICH one — see the palette at the top of this file. The
+   * exception stays what it was: inline CODE is neutral, because an identifier
+   * is not a link.
    *
-   * `--vp-c-brand-1` on white measures 4.74:1, which clears AA for body text
-   * — but only just, and in DARK it is 3.62:1 against `#1b1b1f`, which fails.
-   * So the dark theme lightens it rather than inheriting it; the value below
-   * is the same hue at 5.76:1. That is the whole reason this is a token
-   * and not `var(--vp-c-brand-1)` written out at each use.
-   *
-   * The hover colour is the link colour: one red, and the underline a link
-   * gains on hover carries the hover state (see `.vp-doc a:hover`). */
-  --a2ui5-c-link: var(--vp-c-brand-1);
+   * Both themes inherit now. The red needed a lifted value in dark to clear AA
+   * at all; `--accent` is already two values, one per theme, and both clear it,
+   * so there is nothing left for this token to correct. It stays a token
+   * because the rules below name it and because the hover colour is defined
+   * against it: the link colour, with the underline a link gains on hover
+   * carrying the state (see `.vp-doc a:hover`). */
+  --a2ui5-c-link: var(--accent);
   --a2ui5-c-link-hover: var(--a2ui5-c-link);
-  /* The fill of the home page's second row of cards: the brand, at a tint.
-   * Not the theme's `--vp-c-brand-soft`, which this site never redefined
-   * and which is still VitePress's own indigo - a lavender card on a red
-   * site. The dark value is the dark link colour below at a tint. */
-  --a2ui5-c-out-tint: rgb(208 60 74 / 0.07);
-  /* The one-pixel edge on code blocks, tables and the Run bar. */
-  --a2ui5-c-hairline: #d1d9e0;
+  /* The fill of the home page's second row of cards: the accent, at a tint.
+   * Not the theme's `--vp-c-brand-soft`, which this site never redefined and
+   * which is still VitePress's own indigo. Written out rather than mixed from
+   * `--accent`, because the two themes want different alphas. */
+  --a2ui5-c-out-tint: rgb(10 110 209 / 0.07);
+  /* The one-pixel edge on code blocks, tables and the Run bar — the same
+   * hairline the bar above them is drawn with, which is the catalogue's
+   * `--line`. It used to be its own blue-grey, half a step off. */
+  --a2ui5-c-hairline: var(--line);
 
   /* …and the flat grey behind them. ONE value, because the theme ships two
    * and they do not match: a code block is an opaque `#f6f6f7`, while a
@@ -80,10 +145,11 @@
    * — the details block reads a shade darker and a shade bluer than the code
    * block inside it, which looks like a mistake because it is one.
    *
-   * The value is the lighter of the two, and it is #f6f8fa rather than the
-   * theme's #f6f6f7: the borders on these panels are `--a2ui5-c-hairline`,
-   * a blue-grey, and a neutral fill inside a blue-grey edge is the same
-   * half-step mismatch one level down. In dark the two diverge in OPPOSITE
+   * The value is the catalogue's `--bg-sunken`, which is the grey the bar and
+   * the sidebar are already drawn in: a panel inside the page is the same
+   * surface as the frame around it, one level in. It used to be a blue-grey of
+   * its own (#f6f8fa), picked to match a hairline that was also its own — both
+   * come out of the shared palette now. In dark the two diverge in OPPOSITE
    * directions — the code block is darker than the page, the details block is
    * a lighter overlay on it — so the unification matters more there, not less.
    *
@@ -92,17 +158,13 @@
    * needs more separation from its background than a panel the size of a
    * paragraph does, and because at this value it would vanish entirely inside
    * one of the panels above. GitHub splits the two for the same reason. */
-  --a2ui5-c-surface: #f6f8fa;
+  --a2ui5-c-surface: var(--bg-sunken);
 }
 
+/* Two of the four still differ by theme; the other two now come out of the
+ * palette and need no second value at all. */
 .dark {
-  /* 5.76:1 on the dark ground, where the brand red itself manages 3.62 and
-   * fails AA. Same hue, lifted until it reads. */
-  --a2ui5-c-link: #e8707c;
-  --a2ui5-c-link-hover: var(--a2ui5-c-link);
-  --a2ui5-c-out-tint: rgb(232 112 124 / 0.12);
-  --a2ui5-c-hairline: #3d444d;
-  --a2ui5-c-surface: #161b22;
+  --a2ui5-c-out-tint: rgb(74 163 255 / 0.12);
 }
 
 /* ============================================================== compact ===
@@ -144,8 +206,8 @@
 /* Section headings. The top rule stays: on a long cookbook page it is what
  * lets the eye find the next section while scrolling. Its padding does not. */
 .vp-doc h2 {
-  font-size: 17px;
-  line-height: 24px;
+  font-size: 16px;
+  line-height: 22px;
   margin: 32px 0 12px;
   padding-top: 12px;
   letter-spacing: -0.01em;
@@ -159,7 +221,7 @@
 
 .vp-doc h3 {
   font-size: 15px;
-  line-height: 22px;
+  line-height: 21px;
   margin: 24px 0 0;
 }
 
@@ -169,23 +231,28 @@
   margin: 20px 0 0;
 }
 
-/* The page title keeps its rank — it is the one heading that should be
- * unmistakable — but loses some of its size and the air beneath it.
+/* The page title, at the size a sample's own page sets its title in over in
+ * the catalogue (26px/1.25, tools/sample-pages.mjs). It went the other way
+ * from everything else in this pass — 22px up to 26px — and that is the shape
+ * of the catalogue's scale rather than an exception to it: the body is tight
+ * and the one heading that says WHICH PAGE THIS IS is generous, because those
+ * two decisions are about different things. At 22px over a 15px body it was
+ * one and a half steps from the prose under it.
  *
- * The default raises h1 to 32px inside `@media (min-width: 768px)`. A rule
- * without that media query would win only by source order, which is the kind
- * of thing that quietly stops being true after a dependency bump — so the
- * breakpoint is mirrored rather than relied upon. */
+ * One size at both widths now, and the breakpoint is still mirrored: the
+ * theme raises h1 to 32px inside `@media (min-width: 768px)`, and a rule
+ * without that media query would win only by source order — the kind of thing
+ * that quietly stops being true after a dependency bump. */
 .vp-doc h1 {
-  font-size: 22px;
-  line-height: 30px;
+  font-size: 26px;
+  line-height: 34px;
   margin-bottom: 16px;
 }
 
 @media (min-width: 768px) {
   .vp-doc h1 {
-    font-size: 24px;
-    line-height: 32px;
+    font-size: 26px;
+    line-height: 34px;
   }
 }
 
@@ -220,9 +287,19 @@
   margin: 12px 0;
 }
 
-/* Body text at 15/24 rather than the theme's 16/28.
+/* Body text at 14px/1.55 — the catalogue's own `font: 14px/1.55`, which the
+ * playground's shell now sets too, so the three sites set running text at one
+ * size. It was 15/24 here, itself already down from the theme's 16/28, and the
+ * last step is the one that makes a paragraph here and a card's blurb over
+ * there the same text rather than nearly the same text.
  *
- * The line-height is the bigger half of this. 1.75 is a magazine setting — it
+ * 22px carries the 1.55 (14 × 1.55 = 21.7), written as a length for the reason
+ * the sizes below it are: a unitless line-height is inherited by every nested
+ * element and re-multiplied against ITS size, so a 13px caption inside a
+ * paragraph would silently get a different measure from the one meant here.
+ *
+ * The line-height was the bigger half of the earlier move and the reasoning
+ * still holds. 1.75 is a magazine setting — it
  * is right for a column of uninterrupted prose and wrong for a page that
  * breaks every third line for a code block, a table or an identifier in a
  * box: the extra leading pulls the paragraph apart without any run of text
@@ -249,8 +326,8 @@
 .vp-doc summary,
 .vp-doc blockquote,
 .vp-doc dd {
-  font-size: 15px;
-  line-height: 24px;
+  font-size: 14px;
+  line-height: 22px;
 }
 
 /* The chrome around the page — sidebar, outline, nav, the prev/next footer —
@@ -958,10 +1035,13 @@
  * edges instead of fills, a 6px radius — and only the SCALE stays generous,
  * because a signpost may be read from further away than a paragraph.
  *
- * What deliberately does not change: the logo stays a 200px red disc, and
- * the Quickstart button stays a filled red block. Those two are the identity
- * and the one action the page exists to offer; a page with nothing filled on
- * it has no primary action, only a list of links.
+ * What deliberately does not change: the logo stays a 200px disc — and it
+ * stays RED, which is now the one red thing on the page, because it is the
+ * mark and the mark is not the interface (see the palette at the top of this
+ * file, and resources/logo.md) — and the Quickstart button stays a filled
+ * block. Those two are the identity and the one action the page exists to
+ * offer; a page with nothing filled on it has no primary action, only a list
+ * of links.
  *
  * Specificity, as everywhere in this file: the theme's rules are Vue SCOPED
  * styles and compile with a `[data-v-…]` attribute, so `.VPFeature[data-v-x]`
@@ -1169,4 +1249,249 @@
   .Layout .VPContent .VPHome {
     margin-bottom: 48px;
   }
+}
+
+/* ============================================== the bar the three sites share ===
+ *
+ * The playground, the sample catalogue and this site are three deployments on
+ * one origin, and from here on they wear ONE bar: the mark and the site, the
+ * part of it you are in, a button for light and dark, one hairline, then
+ * LinkedIn and GitHub. The numbers below are the catalogue's own
+ * (src/catalogue/catalogue.css in abap2UI5/playground) — 46px tall on the
+ * sunken grey, 5px pills, a 30x26 theme button, 18px marks in a 30px box —
+ * because a reader crossing between them should read one bar and not three
+ * interpretations of a house style.
+ *
+ * What is NOT the catalogue's is everything this site has that a catalogue
+ * does not: the search box, the Guide and Cookbook menus, the version menu.
+ * Those keep VitePress's own drawing and only lose their size, so they sit in
+ * the row rather than setting its height.
+ *
+ * The three items and the button are theme/SiteBar.vue, rendered into the
+ * `nav-bar-content-after` slot — which is the LAST thing in the row, after
+ * VitePress's own appearance switch and social links. `order` puts it back
+ * where it belongs; see below.
+ *
+ * Specificity, as everywhere in this file: the theme's rules are Vue SCOPED
+ * styles and compile with a `[data-v-…]` attribute, so a bare class here would
+ * lose to them. `.Layout .VPNav` in front of a rule takes it to three units
+ * and past most of them; where the theme's own selector is longer than that,
+ * the rule below says so and carries more.
+ */
+
+:root {
+  /* 46px, the catalogue's bar height. Everything the theme lays out under the
+   * bar — the sidebar's top, the scroll offset a `#hash` lands at, the home
+   * page's hero padding — is written against this variable, so the one number
+   * moves all of it. */
+  --vp-nav-height: 46px;
+  --vp-nav-bg-color: var(--bg-sunken);
+  /* The mark, at the size the other three bars draw it. */
+  --vp-nav-logo-height: 20px;
+}
+
+/* The bar is the sunken grey at every width and on every page, the home page
+ * included. The theme leaves it TRANSPARENT at the top of the home page and
+ * paints only the `.content-body` strip on a page with a sidebar; both are
+ * good decisions for a site whose bar is its own, and neither survives the
+ * bar being shared with two other documents. `:not(.screen-open)` is not a
+ * condition, it is a fourth unit of specificity — the theme's own rule for an
+ * open mobile menu paints the same colour anyway. */
+.Layout .VPNav .VPNavBar:not(.screen-open),
+.Layout .VPNav .VPNavBar .title,
+.Layout .VPNav .VPNavBar .content-body {
+  background-color: var(--bg-sunken);
+}
+
+/* One hairline under it, always — the theme draws it as a `.divider-line`
+ * element that is only there on a page with a sidebar, so the home page had
+ * none and the bar ran into the hero. */
+.Layout .VPNav .VPNavBar {
+  border-bottom: 1px solid var(--line);
+}
+
+.Layout .VPNav .VPNavBar .divider-line {
+  background-color: transparent;
+}
+
+/* The brand: the mark, then the site in the ordinary weight and the part of it
+ * you are in in the heavy one (`siteTitle` in config.mjs carries the `<b>`).
+ * The theme sets 16px semibold, which is a heading; over there it is body
+ * text with one word emphasised. */
+.Layout .VPNav .VPNavBar .title {
+  font-size: 14px;
+  font-weight: 400;
+  gap: 8px;
+}
+
+.Layout .VPNav .VPNavBar .title b {
+  font-weight: 600;
+}
+
+.Layout .VPNav .VPNavBar .title .logo {
+  margin-right: 0;
+}
+
+/* ---------------------------------------------------- the row's order ---
+ *
+ * `.content-body` is a flex row, so the slot's content can be moved without
+ * moving it in the DOM: search and the menus keep the default 0, the three
+ * sites come next, then the theme button, the hairline and the marks. The
+ * hamburger stays last. */
+.Layout .VPNav .VPNavBar .bar-nav { order: 1; }
+.Layout .VPNav .VPNavBar .theme { order: 2; }
+.Layout .VPNav .VPNavBar .social-links { order: 3; }
+.Layout .VPNav .VPNavBar .extra { order: 4; }
+.Layout .VPNav .VPNavBar .hamburger { order: 5; }
+
+/* The theme's own appearance switch, which SiteBar.vue replaces with the
+ * button the other three bars carry. It is still mounted and still doing the
+ * work — `isDark` is read and written through it — it is simply not drawn. */
+.Layout .VPNav .VPNavBar .appearance {
+  display: none;
+}
+
+/* The theme's dividers between the groups it knows about. They are drawn from
+ * `.menu + .appearance::before` and friends, and with the appearance switch
+ * gone they land in the wrong places; the one hairline this bar has is the
+ * one in front of the marks, below. */
+.Layout .VPNav .VPNavBar .menu + .translations::before,
+.Layout .VPNav .VPNavBar .menu + .appearance::before,
+.Layout .VPNav .VPNavBar .menu + .social-links::before,
+.Layout .VPNav .VPNavBar .translations + .appearance::before,
+.Layout .VPNav .VPNavBar .appearance + .social-links::before {
+  display: none;
+}
+
+/* ------------------------------------------------------- the three sites ---
+ *
+ * The catalogue's `.bar-nav`, to the pixel: 5px pills in the dim colour, the
+ * hover filling with the PAGE background — lighter than the bar it sits on,
+ * which is what makes the pill read as raised rather than as a hole — and the
+ * one you are on in full colour and semibold. */
+.Layout .VPNav .bar-nav {
+  display: flex;
+  gap: 4px;
+  margin-left: 16px;
+  line-height: 1.55;
+}
+
+.Layout .VPNav .bar-nav a,
+.Layout .VPNav .bar-nav .here {
+  padding: 5px 10px;
+  border-radius: 5px;
+  color: var(--fg-dim);
+  font-size: 14px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.Layout .VPNav .bar-nav a:hover {
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.Layout .VPNav .bar-nav .here {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+/* ---------------------------------------------------- light and dark ---
+ *
+ * The catalogue's button, and the same trick: the sun and the moon are both in
+ * the markup and CSS shows one of them, so the button says the right thing
+ * before any of this site's JavaScript has run. Over there the swap keys off
+ * `[data-theme]` and a media query; here VitePress has already resolved both
+ * into a single class on the root element. */
+.Layout .VPNav .theme {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 16px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--fg-dim);
+  font-family: var(--vp-font-family-base);
+  font-size: 13px;
+  line-height: 1;
+  width: 30px;
+  height: 26px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.Layout .VPNav .theme:hover { color: var(--fg); }
+.Layout .VPNav .theme-moon { display: none; }
+.dark .Layout .VPNav .theme-sun { display: none; }
+.dark .Layout .VPNav .theme-moon { display: inline; }
+
+/* ------------------------------------------------------------ the marks ---
+ *
+ * One hairline, then the two of them — the end of the bar on all four
+ * documents. The theme draws a `.VPSocialLink` at 36px with a 20px glyph; the
+ * catalogue draws 30px with an 18px glyph, and the slow colour change on hover
+ * is its own. */
+.Layout .VPNav .VPNavBar .social-links::before {
+  content: "";
+  width: 1px;
+  height: 22px;
+  margin: 0 6px 0 12px;
+  background: var(--line);
+}
+
+.Layout .VPNav .VPNavBar .social-links {
+  display: flex;
+  align-items: center;
+  margin-right: -6px;
+}
+
+.Layout .VPNav .VPSocialLink {
+  width: 30px;
+  height: 30px;
+  color: var(--fg-dim);
+  transition: color 0.5s;
+}
+
+.Layout .VPNav .VPSocialLink:hover { color: var(--fg); }
+
+.Layout .VPNav .VPSocialLink svg,
+.Layout .VPNav .VPSocialLink > span {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+/* -------------------------------------------------------- and narrower ---
+ *
+ * The theme folds its menu into a hamburger below 768px, and the three sites
+ * go with it rather than wrapping the row: they are in the menu that opens
+ * instead (`nav-screen-content-after`), where they are a list rather than a
+ * strip. The marks go at the same width, as they go from the catalogue's bar
+ * at 620px and the playground's at 820px — on a phone the bar is what is paid
+ * for before anything is read. The theme button stays: it is the one item in
+ * the group that is not reachable any other way. */
+@media (max-width: 767px) {
+  .Layout .VPNav .VPNavBar .bar-nav,
+  .Layout .VPNav .VPNavBar .social-links {
+    display: none;
+  }
+
+  .Layout .VPNav .VPNavBar .theme {
+    margin-left: 8px;
+  }
+}
+
+/* In the menu itself the three sites are a row of the same pills, given room
+ * to be touched. */
+.Layout .VPNavScreen .bar-nav {
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 12px 0;
+  border-top: 1px solid var(--line);
+}
+
+.Layout .VPNavScreen .bar-nav a,
+.Layout .VPNavScreen .bar-nav .here {
+  padding: 8px 12px;
 }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1263,7 +1263,7 @@
  * interpretations of a house style.
  *
  * What is NOT the catalogue's is everything this site has that a catalogue
- * does not: the search box, the Guide and Cookbook menus, the version menu.
+ * does not: the search box, the Guide and Links menus, the version menu.
  * Those keep VitePress's own drawing and only lose their size, so they sit in
  * the row rather than setting its height.
  *

--- a/docs/resources/logo.md
+++ b/docs/resources/logo.md
@@ -173,19 +173,34 @@ drawing and not the surface behind it.
 
 ## Colours
 
-One red and white. The mark, every mascot above and this site use that red
-and nothing else. There is no second shade for interface states: a link under
-a cursor gains an underline, not a darker red, and a button keeps its colour.
+**One red, and it is the mark's.** The circle in the wordmark, the red ink of
+every mascot above — one value, and no second shade for a hover or a pressed
+state anywhere it is used.
+
+The mark is not the same thing as the interface around it, and the two carry
+different colours on purpose. The three sites this project publishes — this
+documentation, the [playground](https://abap2ui5.github.io/playground/) and the
+[sample catalogue](https://abap2ui5.github.io/playground/samples/) — share one
+bar, one palette and one accent, and that accent is **SAP blue**: it is the
+colour of the platform these apps run on, it is what the playground fills its
+Run button with, and it clears AA for body text in both themes, which the red
+does not do on a dark ground. So a link on this page is blue and the mark at
+the top of it is red, and neither is a mistake.
 
 | | Hex | Where |
 | --- | --- | --- |
-| <span style="display:inline-block;width:1.15em;height:1.15em;vertical-align:-0.2em;border-radius:3px;background:#D03C4A"></span> Red | `#D03C4A` | the circle in the mark, the red ink of the mascots, and every brand token of this site — links, buttons, the hero name, and their hover states |
+| <span style="display:inline-block;width:1.15em;height:1.15em;vertical-align:-0.2em;border-radius:3px;background:#D03C4A"></span> Red | `#D03C4A` | the circle in the mark, and the red ink of the mascots |
 | <span style="display:inline-block;width:1.15em;height:1.15em;vertical-align:-0.2em;border:1px solid var(--vp-c-divider);border-radius:3px;background:#FFFFFF"></span> White | `#FFFFFF` | the wordmark knocked out of the circle |
+| <span style="display:inline-block;width:1.15em;height:1.15em;vertical-align:-0.2em;border-radius:3px;background:#0A6ED1"></span> Blue | `#0A6ED1` | the accent of all three sites — links, buttons, the hero name; `#4AA3FF` in dark |
 
-The site's own tokens are set in `docs/.vitepress/theme/style.css`. Take the hex
-values from this table rather than picking them out of a screenshot with a
-colour dropper: a PNG scaled in a browser hands you an interpolated pixel,
-which is a red that appears nowhere in the brand.
+A link under a cursor still gains an underline rather than a second shade, and
+a button still keeps its colour: that rule was never about which colour it was.
+
+The site's own tokens are set in `docs/.vitepress/theme/style.css`, which takes
+its seven values from the playground's stylesheet so that the three stay one
+palette. Take the hex values from this table rather than picking them out of a
+screenshot with a colour dropper: a PNG scaled in a browser hands you an
+interpolated pixel, which is a colour that appears nowhere in the brand.
 
 ## Using the Mark
 

--- a/test/site-memory.test.mjs
+++ b/test/site-memory.test.mjs
@@ -1,0 +1,115 @@
+/*
+ * The cross-site position memory, and specifically the half of it that decides
+ * whether a STORED value may be used at all.
+ *
+ * The bar's Samples item is lifted to whatever the sample catalogue was last
+ * left on, and that value comes out of a localStorage shared by three
+ * deployments on one origin. Anything running on that origin can write to it,
+ * and a stale value outlives the page it named — so `lastVisited` does not
+ * return what it reads, it returns the FALLBACK unless what it reads resolves,
+ * on this origin, to somewhere still inside the link that was written.
+ *
+ * That is the part a browser test on this repository cannot reach: `vitepress
+ * preview` serves this site on localhost and the catalogue link points at
+ * abap2ui5.github.io, so every case below takes the different-origin branch
+ * and nothing else is ever exercised. Here `location` is a stub, which is what
+ * lets the same-origin cases be the ones that are checked.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const KEY = 'abap2ui5-playground:last-samples';
+const SAMPLES = 'https://abap2ui5.github.io/playground/samples/';
+
+/** The globals the module reads, as this origin and one stored value. */
+function on(origin, stored, run) {
+  const before = {
+    location: globalThis.location,
+    localStorage: globalThis.localStorage,
+  };
+  globalThis.location = { href: origin + '/docs/get_started/about.html', origin };
+  globalThis.localStorage = {
+    getItem: (k) => (k === KEY && stored !== undefined ? stored : null),
+    setItem: () => {},
+  };
+  try {
+    return run();
+  } finally {
+    globalThis.location = before.location;
+    globalThis.localStorage = before.localStorage;
+  }
+}
+
+const { lastVisited, rememberHere } = await import('../docs/.vitepress/theme/site-memory.js');
+
+const SITE = 'https://abap2ui5.github.io';
+
+test('nothing stored keeps the link that was written', () => {
+  assert.equal(on(SITE, undefined, () => lastVisited('samples', SAMPLES)), SAMPLES);
+});
+
+test('a page of the catalogue is followed, filters and all', () => {
+  const last = '/playground/samples/?q=table&lib=sap.m';
+  assert.equal(on(SITE, last, () => lastVisited('samples', SAMPLES)), last);
+});
+
+test("a sample's own page is followed", () => {
+  const last = '/playground/samples/z2ui5_cl_smp_app_001/';
+  assert.equal(on(SITE, last, () => lastVisited('samples', SAMPLES)), last);
+});
+
+test('a hash and a query survive the round trip', () => {
+  const last = '/playground/samples/all/?src=samples#z2ui5_cl_smp_app_042';
+  assert.equal(on(SITE, last, () => lastVisited('samples', SAMPLES)), last);
+});
+
+/* The four that must NOT be followed. Each one resolves to something outside
+ * the link that was written, and each one is a link the bar would otherwise
+ * have handed a reader. */
+test('a protocol-relative value cannot move the link to another host', () => {
+  assert.equal(on(SITE, '//example.invalid/x', () => lastVisited('samples', SAMPLES)), SAMPLES);
+});
+
+test('a value that normalises out of the section is refused', () => {
+  assert.equal(on(SITE, '/playground/samples/../../evil', () => lastVisited('samples', SAMPLES)), SAMPLES);
+});
+
+test('a value outside the section is refused even without traversal', () => {
+  assert.equal(on(SITE, '/docs/resources/logo.html', () => lastVisited('samples', SAMPLES)), SAMPLES);
+});
+
+test('a javascript: value is refused', () => {
+  assert.equal(on(SITE, 'javascript:alert(1)', () => lastVisited('samples', SAMPLES)), SAMPLES);
+});
+
+/* And the case the preview server is always in: a link to another host shares
+ * no storage, so there is nothing of that site to restore. */
+test('a link on another origin keeps the link that was written', () => {
+  const last = '/playground/samples/?q=table';
+  assert.equal(on('http://localhost:4173', last, () => lastVisited('samples', SAMPLES)), SAMPLES);
+});
+
+test('an unknown site name reads nothing and changes nothing', () => {
+  assert.equal(on(SITE, '/playground/samples/', () => lastVisited('nowhere', SAMPLES)), SAMPLES);
+});
+
+/* The writing half. It is two lines, and the one thing worth pinning is that a
+ * storage that throws costs the caller nothing - it runs inside the router
+ * hook on every route change. */
+test('a storage that refuses everything does not throw', () => {
+  const before = { location: globalThis.location, localStorage: globalThis.localStorage };
+  globalThis.location = { href: `${SITE}/docs/x.html`, origin: SITE, pathname: '/docs/x.html', search: '', hash: '' };
+  globalThis.localStorage = {
+    getItem() { throw new Error('denied'); },
+    setItem() { throw new Error('denied'); },
+  };
+  try {
+    assert.doesNotThrow(() => rememberHere('docs'));
+    assert.doesNotThrow(() => lastVisited('samples', SAMPLES));
+  } finally {
+    globalThis.location = before.location;
+    globalThis.localStorage = before.localStorage;
+  }
+});


### PR DESCRIPTION
This change brings the documentation site into visual and functional alignment with the playground and sample catalogue by adopting a shared palette, accent colour, and navigation bar.

## Summary

The three abap2UI5 deployments (docs, playground, samples) now present as a single site to readers moving between them. They share one colour palette, one accent (SAP blue instead of the brand red), one navigation bar, and synchronized theme preferences via localStorage.

## Key Changes

**Palette and Theming**
- Replaced site-specific colour tokens with a unified seven-value palette (`--bg`, `--bg-sunken`, `--fg`, `--fg-dim`, `--line`, `--accent`, `--accent-fg`) shared across all three deployments
- Changed accent from brand red (`#d03c4a`) to SAP blue (`#0a6ed1` light / `#4aa3ff` dark) for links and buttons, improving contrast in dark mode (AA compliant in both themes)
- Kept the brand red exclusively for the mark/logo, as documented in `resources/logo.md`
- Added comprehensive comments explaining the palette rationale and cross-site synchronization

**Navigation Bar**
- Implemented shared bar styling matching the playground and catalogue (46px height, 5px pills, consistent spacing)
- Created `SiteBar.vue` component rendering the three-site navigation and theme toggle
- Reordered bar elements via CSS `order` property to maintain consistent layout across deployments
- Hid VitePress's default appearance switch in favour of the unified theme button

**Cross-Site State**
- Added `site-memory.js` module to remember reader position on each site (docs/samples) via shared localStorage
- Implemented `lastVisited()` with security checks (origin validation, path normalization, protocol validation) to prevent XSS and stale link attacks
- Added `rememberHere()` to record current page on route changes
- Created `test/site-memory.test.mjs` with 11 test cases covering valid paths, attack vectors, and storage failures

**Theme Synchronization**
- Added head script in `config.mjs` to read/write theme preference from shared localStorage key before first paint
- Ensures readers switching between sites maintain their light/dark preference
- Gracefully degrades if storage is unavailable

**Typography**
- Adjusted body text to 14px/1.55 (matching playground/catalogue) from 15px/24px
- Updated h1 to 26px (matching sample page titles) from 22px
- Refined h2 and h3 sizing for consistency with the shared scale

**Documentation**
- Updated `resources/logo.md` to explain the colour separation: red for the mark, blue for the interface
- Added `AGENTS.md` entries documenting the new theme files and their purpose
- Extensive inline comments in `style.css` explaining palette decisions and cross-site coordination

## Implementation Details

- All three deployments maintain independent copies of `site-memory.js` (kept in sync by hand, as with the bar markup) to avoid cross-repository dependencies
- The shared palette is written out rather than imported to avoid stylesheet requests blocking first paint
- CSS specificity carefully managed to override VitePress defaults without relying on source order
- Mobile menu (below 768px) hides the bar's site navigation but keeps the theme button

https://claude.ai/code/session_01VXy9SDH9XTmyWPsqdZxsQw