### PR TITLE
The gate that compiles the examples was running no rules — and the Run-button measurement, made

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,30 +247,51 @@ serve it, and open each example in it, checking that the status line reaches
 ```sh
 npm run runnable -- --json > /tmp/runnable.json   # 63 examples, ABAP included
 git clone https://github.com/abap2UI5/playground && cd playground
-npm ci && npm run build && npm run serve      # the first build is a few minutes
-# then, per example: put its ABAP in the editor and press Run - or open
-# /?embed=1&view=app#<the deflated fragment>. The playground's own Playwright
-# helpers (tests/helpers.mjs: open, setSource, run) drive that loop on one
-# page, which is the difference between an afternoon and twenty minutes.
+npm ci && npm run build                       # the first build is a few minutes
+RUNNABLE_JSON=/tmp/runnable.json npm test -- docs-examples
 ```
+
+The driving half lives THERE, in `tests/docs-examples.spec.js`, because that is
+where the browser harness already is — a documentation site should not need
+Playwright to run something once a quarter. It is not part of that repository's
+`npm test`: with no worklist it contributes no tests. One example is one test,
+named for its page and its class, so a failure names the page to open.
 
 The class in the example has to match the file it goes into: the playground
 refuses the pair when they disagree, exactly as a system does. Renaming the
 class to the open file's is enough — nothing in these examples depends on
 its name.
 
-The last full measurement: **61 complete app classes, 39 with a button, all 39
-started and rendered.** The site has since grown, and the hand-kept copy of
-those figures here went stale without anyone noticing — which is what
-`check:playground` now exists to prevent. The bookkeeping today, printed by the
-gate on every run: **82 complete app classes, 63 with a button, 19 excluded on
-purpose**, every exclusion a marker on its page. The growth is examples whose
-shapes the measured rules already covered, plus one page completed so its
-example could run at all; a spot-check of six buttoned examples in a served
-playground build — the newly buttoned life-cycle class driven through its whole
-event roundtrip, the quickstart and About classes, tutorial Step 12, the
-tables page, and the `SELECT FROM t100` example — started and rendered, every
-one. The next full measurement opens all 63.
+The bookkeeping, printed by the gate on every run: **82 complete app classes,
+63 with a button, 19 excluded on purpose**, every exclusion a marker on its
+page.
+
+**The last full measurement — 2026-09-04, all 63 opened in a served playground
+build: 58 started and rendered.** The five that did not, and why, because that
+is the half worth keeping:
+
+| | |
+| --- | --- |
+| `expert_more/value_help.md` | started, and showed **nothing**: a `Page` with no title holding one `Input` with no label draws no text at all. Fixed here — the page has a title and the input a placeholder |
+| `device_capabilities/geolocation.md` | same shape, worse: the `z2ui5:Geolocation` control is invisible by design, so the whole demo was an empty frame. Fixed here — the example now lists the values it reads, which is what the page is about |
+| `browser_interaction/url_handling.md` | `client->hash_set( )` |
+| `navigation/app_state.md` (both examples) | `client->app_state_set_active( )`, `client->app_state_get_href( )` |
+
+Both fixes were re-measured the same way: `value_help` now puts "Value help" on
+screen, `geolocation` "Device position / Latitude / Longitude / Altitude /
+Accuracy" — so **60 of the 63 render**, and the three that do not are all one
+thing.
+
+The last three are **not** the documentation's: all three methods exist in
+`z2ui5_if_client` on abap2UI5 `main`, which is what `check:examples` compiles
+these pages against, and the playground pins an older framework commit
+(`tools/fetch-deps.mjs`). The playground is right to refuse them and the pin is
+what moves; the pages stay as they are.
+
+The measurement before this one read *61 complete app classes, 39 with a
+button, all 39 started* and had gone stale without anyone noticing — which is
+what `check:playground` now exists to prevent for the bookkeeping half, and
+what the dated table above is for on the half a gate cannot decide.
 
 **The published playground is what readers get**, not the checkout you tested
 against. A change to the rules here can ship on its own; a change that depends

--- a/docs/configuration/authorization.md
+++ b/docs/configuration/authorization.md
@@ -115,7 +115,7 @@ CLASS z2ui5_cl_app IMPLEMENTATION.
                   )->a( n = `title` v = `Authorization`
 
                   )->tag( `Text`
-                      )->a( n = `text` v = client->_bind( mv_status ) ) ).
+                      )->a( n = `text` v = client->_bind( mv_status ) ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/browser_interaction/keyboard_shortcuts.md
+++ b/docs/cookbook/browser_interaction/keyboard_shortcuts.md
@@ -43,7 +43,7 @@ CLASS z2ui5_cl_sample_shortcut IMPLEMENTATION.
                   )->a( n = `title` v = `Keyboard Shortcuts`
 
                   )->tag( `Text`
-                      )->a( n = `text` v = `Press Ctrl+S or Ctrl+D` ) ).
+                      )->a( n = `text` v = `Press Ctrl+S or Ctrl+D` ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/browser_interaction/url_handling.md
+++ b/docs/cookbook/browser_interaction/url_handling.md
@@ -91,7 +91,7 @@ CLASS z2ui5_cl_sample_url IMPLEMENTATION.
                                                t_arg = VALUE #( ( `https://www.abap2UI5.org` ) ) )
                   )->tag( `Button`
                       )->a( n = `text`  v = `push a history entry`
-                      )->a( n = `press` v = client->_event( `PUSH` ) ) ).
+                      )->a( n = `press` v = client->_event( `PUSH` ) ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/device_capabilities/geolocation.md
+++ b/docs/cookbook/device_capabilities/geolocation.md
@@ -37,6 +37,8 @@ CLASS z2ui5_cl_sample_geolocation IMPLEMENTATION.
 
             )->ele( `Shell`
                 )->ele( `Page`
+                    )->a( n = `title` v = `Geolocation`
+
                     )->tag( n = `Geolocation` ns = `z2ui5`
                         )->a( n = `finished`         v = client->_event( `POST` )
                         )->a( n = `longitude`        v = client->_bind( longitude )
@@ -44,7 +46,25 @@ CLASS z2ui5_cl_sample_geolocation IMPLEMENTATION.
                         )->a( n = `altitude`         v = client->_bind( altitude )
                         )->a( n = `altitudeAccuracy` v = client->_bind( altitudeaccuracy )
                         )->a( n = `accuracy`         v = client->_bind( accuracy )
-                        )->a( n = `speed`            v = client->_bind( speed ) ).
+                        )->a( n = `speed`            v = client->_bind( speed )
+
+                    " the control itself draws nothing - it reads the position
+                    " and writes it into the bound attributes. Show them.
+                    )->ele( `List`
+                        )->a( n = `headerText` v = `Device position`
+                        )->ele( `items`
+                            )->tag( `DisplayListItem`
+                                )->a( n = `label` v = `Latitude`
+                                )->a( n = `value` v = client->_bind( latitude )
+                            )->tag( `DisplayListItem`
+                                )->a( n = `label` v = `Longitude`
+                                )->a( n = `value` v = client->_bind( longitude )
+                            )->tag( `DisplayListItem`
+                                )->a( n = `label` v = `Altitude`
+                                )->a( n = `value` v = client->_bind( altitude )
+                            )->tag( `DisplayListItem`
+                                )->a( n = `label` v = `Accuracy`
+                                )->a( n = `value` v = client->_bind( accuracy ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/device_capabilities/pdf.md
+++ b/docs/cookbook/device_capabilities/pdf.md
@@ -59,7 +59,7 @@ CLASS z2ui5_cl_sample_pdf IMPLEMENTATION.
                   )->tag( `PDFViewer`
                       )->a( n = `source` v = client->_bind( mv_pdf )
                       )->a( n = `title`  v = `Invoice 4711`
-                      )->a( n = `height` v = `600px` ) ).
+                      )->a( n = `height` v = `600px` ).
 
       client->view_display( view->stringify( ) ).
     ENDIF.

--- a/docs/cookbook/event_navigation/exception.md
+++ b/docs/cookbook/event_navigation/exception.md
@@ -87,7 +87,7 @@ CLASS z2ui5_cl_sample_exception IMPLEMENTATION.
 
                   )->tag( `Button`
                       )->a( n = `text`  v = `divide by zero`
-                      )->a( n = `press` v = client->_event( `DIVIDE` ) ) ).
+                      )->a( n = `press` v = client->_event( `DIVIDE` ) ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/event_navigation/navigation/inner_app.md
+++ b/docs/cookbook/event_navigation/navigation/inner_app.md
@@ -119,12 +119,14 @@ CLASS z2ui5_cl_sample_stack IMPLEMENTATION.
                   )->tag( `Button`
                       )->a( n = `text`    v = `leave, back to the caller`
                       )->a( n = `press`   v = client->_event( `UP` )
-                      )->a( n = `enabled` b = client->check_app_prev_stack( ) ) ).
+                      )->a( n = `enabled` b = client->check_app_prev_stack( ) ).
 
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `DOWN` ).
-      client->nav_app_call( NEW z2ui5_cl_sample_stack( mv_level = mv_level + 1 ) ).
+      DATA(lo_next) = NEW z2ui5_cl_sample_stack( ).
+      lo_next->mv_level = mv_level + 1.
+      client->nav_app_call( lo_next ).
 
     ELSEIF client->check_on_event( `UP` ).
       client->nav_app_leave( ).

--- a/docs/cookbook/expert_more/value_help.md
+++ b/docs/cookbook/expert_more/value_help.md
@@ -115,7 +115,7 @@ CLASS z2ui5_cl_sample_f4 IMPLEMENTATION.
                                 )->a( n = `type`        v = `Active`
                                 )->a( n = `press`       v = client->_event(
                                                                 val = `PICK`
-                                                                t_arg = VALUE #( ( `${CARRID}` ) ) ) ) ).
+                                                                t_arg = VALUE #( ( `${CARRID}` ) ) ) ).
 
         client->popup_display( popup->stringify( ) ).
 

--- a/docs/cookbook/expert_more/value_help.md
+++ b/docs/cookbook/expert_more/value_help.md
@@ -82,8 +82,11 @@ CLASS z2ui5_cl_sample_f4 IMPLEMENTATION.
                 )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
 
                 )->ele( `Page`
+                    )->a( n = `title` v = `Value help`
+
                     )->tag( `Input`
                         )->a( n = `value`            v = client->_bind( mv_carrid )
+                        )->a( n = `placeholder`      v = `press the value-help icon`
                         )->a( n = `valueHelpRequest` v = client->_event( `F4` )
                         )->a( n = `showValueHelp`    b = abap_true ).
 

--- a/docs/cookbook/model/device_model.md
+++ b/docs/cookbook/model/device_model.md
@@ -112,7 +112,7 @@ CLASS z2ui5_cl_sample_device IMPLEMENTATION.
                           )->tag( `Label`
                               )->a( n = `text` v = `viewport`
                           )->tag( `Text`
-                              )->a( n = `text` v = client->_bind( mv_size ) ) ).
+                              )->a( n = `text` v = client->_bind( mv_size ) ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/translation_messages/message.md
+++ b/docs/cookbook/translation_messages/message.md
@@ -117,7 +117,7 @@ CLASS z2ui5_cl_sample_message IMPLEMENTATION.
                       )->a( n = `press` v = client->_event( `BOX` )
                   )->tag( `Button`
                       )->a( n = `text`  v = `from an exception`
-                      )->a( n = `press` v = client->_event( `EXC` ) ) ).
+                      )->a( n = `press` v = client->_event( `EXC` ) ).
 
       client->view_display( view->stringify( ) ).
 

--- a/docs/cookbook/view/xml_templating.md
+++ b/docs/cookbook/view/xml_templating.md
@@ -163,7 +163,7 @@ CLASS z2ui5_cl_sample_templating IMPLEMENTATION.
                                       )->a( n = `var`  v = `L1`
 
                                       )->tag( `ObjectIdentifier`
-                                          )->a( n = `text` v = `{= '{' + ${L1>FNAME} + '}' }` ) ).
+                                          )->a( n = `text` v = `{= '{' + ${L1>FNAME} + '}' }` ).
 
       client->view_display( view->stringify( ) ).
 

--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -363,6 +363,25 @@ writeFileSync(join(dir, 'abaplint.json'), JSON.stringify({
     { url: 'https://github.com/abapedia/steampunk-2305-api', folder: '/deps', files: '/src/**/*.*' },
   ],
   syntax: { version: 'v750', errorNamespace: '^(Z|Y)' },
+  /* WITHOUT THIS BLOCK abaplint runs NO RULES.
+   *
+   * It still walks every file and still prints "0 issue(s) found, N file(s)
+   * analyzed", which reads exactly like a pass - and this gate believed it for
+   * as long as it has existed. Nine examples on nine pages carried an
+   * unbalanced parenthesis in their view chain, each one offered to the reader
+   * with a Run button, and the gate whose whole job is "does the class compile
+   * against the framework at all" said nothing about any of them.
+   *
+   * The three rules are the compile ones the sample repositories run (the
+   * shared app rule set in abap2UI5/abap2UI5 `.github/abaplint/app-rules.json`
+   * enables all three). Deliberately no style rules here: an example is
+   * written to be READ, and it is trimmed and indented for a page rather than
+   * for a package. What it must do is compile. */
+  rules: {
+    parser_error: true,
+    check_syntax: true,
+    unknown_types: true,
+  },
 }, null, 2));
 
 writeFileSync(join(dir, 'abap2ui5lint.jsonc'), JSON.stringify({

--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -376,7 +376,17 @@ writeFileSync(join(dir, 'abaplint.json'), JSON.stringify({
    * shared app rule set in abap2UI5/abap2UI5 `.github/abaplint/app-rules.json`
    * enables all three). Deliberately no style rules here: an example is
    * written to be READ, and it is trimmed and indented for a page rather than
-   * for a package. What it must do is compile. */
+   * for a package. What it must do is compile.
+   *
+   * That line was drawn with the whole 188-rule sample set run over these
+   * examples once, rather than by taste. Everything else it reports is either
+   * an artefact of this harness - `identical_descriptions` and `object_naming`
+   * both fire on the `zcl_docs_example_NN` rename above, 69 times - or a
+   * teaching choice: `commented_code` is how half these pages explain
+   * themselves, `check_subrc` would put four lines of error handling into a
+   * three-line SELECT example, `unused_variables` names the `DATA(lv_val) =
+   * 1 / 0.` whose whole purpose is to not be used, and `definitions_top`,
+   * `short_case` and `align_type_expressions` are about packages, not pages. */
   rules: {
     parser_error: true,
     check_syntax: true,


### PR DESCRIPTION
## The gate

`check:examples` writes an `abaplint.json` with a dependency list, a syntax version, and **no `rules` block at all**. abaplint with no rules configured runs none of them — and still walks every file and still prints

```
abaplint: 0 issue(s) found, 139 file(s) analyzed
```

which reads exactly like a pass. This gate — the one whose stated job is *"does the class compile against the framework at all"* — has believed that for as long as it has existed.

Turn the three compile rules on (`parser_error`, `check_syntax`, `unknown_types`, the ones the sample repositories run from the shared app rule set) and **ten examples on ten pages** fail immediately: each carries one closing parenthesis too many in its view chain.

```
Statement does not exist in the configured ABAP version(or a parser error), "DATA"   (parser_error) [E]
"view" not found, findTop                                                            (check_syntax) [E]
```

Nine of the ten carry a Run button. A reader pressing it gets *"2 errors in the ABAP — fix them and run again"*, which is the playground doing its job on a class that does not compile.

The eleventh finding is real too: `inner_app.md` called `NEW z2ui5_cl_sample_stack( mv_level = … )` on a class with no constructor. It creates the instance and sets the attribute now, the way that page's own first snippet already does.

**Where the rule line is drawn, and why**: the whole 188-rule sample set was run over these examples once rather than guessed at. Everything beyond the three is either an artefact of this harness — `identical_descriptions` and `object_naming` both fire on the `zcl_docs_example_NN` rename, 69 times — or a teaching choice: `commented_code` is how half these pages explain themselves, `check_subrc` would put four lines of error handling into a three-line SELECT example, `unused_variables` names the `DATA(lv_val) = 1 / 0.` whose whole purpose is to not be used. That reasoning is in the file next to the rules.

## The measurement

All 63 buttoned examples were then opened in a served playground build — the measurement AGENTS.md says CI cannot make. **58 started and rendered.** Two of the five that did not are this site's:

| | |
| --- | --- |
| `expert_more/value_help.md` | started, and showed **nothing**: a `Page` with no title holding one `Input` with no label draws no text at all |
| `device_capabilities/geolocation.md` | worse — `z2ui5:Geolocation` is invisible by design, so a demo of reading a device position was a blank screen, on a page whose prose promises the values are written into the bound attributes |

Both fixed and **re-measured**: `"Value help"` and `"Device position / Latitude / Longitude / Altitude / Accuracy"` are on screen. **60 of 63 render.**

The other three — `url_handling.md` and both `app_state.md` examples — name `client->hash_set( )`, `client->app_state_set_active( )` and `client->app_state_get_href( )`. All three are in `z2ui5_if_client` on abap2UI5 `main`, which is what `check:examples` compiles these pages against; none is in the commit the playground pins. The playground is right to refuse them, the pin is what moves, and the pages stay as they are.

`AGENTS.md` records the result with its date and all five rows, and the "to redo the measurement" procedure now points at `abap2UI5/playground` `tests/docs-examples.spec.js` (abap2UI5/playground#58) — the driving half living where the browser harness already is, instead of being rebuilt by whoever asks next.

## Verification

`npm run check` — all nine gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ