### PR TITLE
Record what the render gate says, since somebody will ask

### DIFF
--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -399,9 +399,26 @@ writeFileSync(join(dir, 'abap2ui5lint.jsonc'), JSON.stringify({
   // the floor the documentation targets, and abap2UI5's own
   ui5: '1.71',
   distribution: 'openui5',
-  // the render gate needs a browser and ~118 MB of UI5 sources; the property
-  // gate is what decides whether an example names API that exists, which is
-  // the drift this check is for
+  /* The render gate needs a browser and ~118 MB of UI5 sources; the property
+   * gate is what decides whether an example names API that exists, which is
+   * the drift this check is for.
+   *
+   * It was run over these examples once, by hand, on 2026-09-04 - set
+   * `render: true` here and point the CLI at the `--keep` directory - and the
+   * answer is why it stays off rather than merely being expensive. Five of the
+   * 69 fail, and all five for the same reason: the harness serves plain
+   * OpenUI5, which ships neither abap2UI5's own custom controls
+   * (`z2ui5/cc/CameraPicture`, `Geolocation`, `FileUploader` - the camera,
+   * geolocation and upload pages) nor SAPUI5's XML-templating extension
+   * (`xml_templating.md`). Turning the gate on would fail five correct pages
+   * for having nothing to do with them.
+   *
+   * The run was worth making anyway: a sixth failure was real, and it was the
+   * linter's. `cookbook/model/expression_binding.md` writes a UI5 type binding
+   * across two lines with `|\n|`, the resolver reduced that to the letter `n`,
+   * and UI5 answered "SyntaxError: Expected ':' instead of 'p'" - a broken
+   * view reported against an example that runs. Fixed upstream in
+   * abap2UI5/linter#97; there is nothing to change here. */
   render: false,
   failOn: 'warning',
 }, null, 2));


### PR DESCRIPTION
`render: false` in the generated `abap2ui5lint.jsonc` carried *"needs a browser and ~118 MB of UI5 sources"* — true, and not the whole answer. The next person to read that line will wonder what turning it on would actually say.

So it was run, once, by hand: `render: true` and the CLI pointed at the `--keep` directory. **Five of the 69 fail, and all five for the same reason.** The harness serves plain OpenUI5, which ships neither abap2UI5's own custom controls nor SAPUI5's XML-templating extension:

```
zcl_docs_example_16  z2ui5/cc/CameraPicture.js   ← device_capabilities/camera.md
zcl_docs_example_17  z2ui5/cc/Geolocation.js     ← device_capabilities/geolocation.md
zcl_docs_example_19  z2ui5/cc/FileUploader.js    ← device_capabilities/upload_download.md
zcl_docs_example_20  z2ui5/cc/FileUploader.js    ←    "
zcl_docs_example_58  …/sap/ui/core/template/1/repeat.js  ← cookbook/view/xml_templating.md
```

Turning the gate on would fail five correct pages for having nothing to do with them. That is a better reason to leave it off than the cost, and it is now written next to the switch.

**The run was worth making anyway.** A sixth failure was real, and it was the linter's:

```
<Input value="{ type : &quot;sap.ui.model.type.Integer&quot;,n path:&quot;/INPUT32&quot; }"/>
SyntaxError: Expected ':' instead of 'p'
```

`cookbook/model/expression_binding.md` writes that type binding across two lines with `|\n|`. The linter's template resolver reduced the escape to the letter `n`, so it reported a broken view against an example that starts and renders correctly in a playground. Fixed upstream in abap2UI5/linter#97 — **there is nothing to change on this side**, which is the other half worth writing down.

## Verification

`npm run check` — all nine gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ)_