### PR TITLE
Bar: the catalogue's measure, a refreshed Samples item, the same menu, and the Run link in this tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,10 @@ two live in [abap2UI5/playground](https://github.com/abap2UI5/playground)
 `theme/style.css` are `src/catalogue/catalogue.css`'s, written out. Three
 repositories deploy separately, and a stylesheet fetched across them would be a
 request in front of the first paint. Change them together — the same applies to
-the bar's markup, which exists four times by hand for the same reason.
+the bar's markup, which exists four times by hand for the same reason, and to
+the bar's **measure**: 20px from either edge at every width, 12px on a phone,
+over the whole width and never centred, which is the catalogue's bar and which
+`style.css` (*the measure*) holds the theme's two nav layouts to.
 
 **The accent is SAP blue, and the mark is still red.** `#0a6ed1` / `#4aa3ff` is
 what a link, a button and the hero name are set in; `#d03c4a` is the circle in

--- a/docs/.vitepress/theme/SiteBar.vue
+++ b/docs/.vitepress/theme/SiteBar.vue
@@ -40,8 +40,23 @@ const SAMPLES = "https://abap2ui5.github.io/playground/samples/";
  * onMounted only ever replaces it with a deeper page of the same site. */
 const samplesHref = ref(SAMPLES);
 const extra = ref(null);
-onMounted(() => {
+/* Lifted on mount, and again whenever it can have moved while this page stayed
+ * open: the catalogue narrowed in another tab, a Back that brought this page
+ * out of the back-forward cache. The click itself is the lift that cannot be
+ * missed - the href is set on the element there, before the browser follows
+ * it, because a ref set in the handler reaches the DOM a tick too late. */
+const lift = () => {
   samplesHref.value = lastVisited("samples", SAMPLES);
+};
+const liftNow = (e) => {
+  e.currentTarget.href = lastVisited("samples", SAMPLES);
+};
+onMounted(() => {
+  lift();
+  addEventListener("pageshow", lift);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") lift();
+  });
   document.addEventListener("click", (e) => {
     const el = extra.value;
     if (el?.open && !el.contains(e.target)) el.open = false;
@@ -79,13 +94,14 @@ watch(isDark, (dark) => {
     <!-- The one you are on, which is why it is a span and not a link - the
          look aria-current gets on the other three bars. -->
     <span class="here" aria-current="page">Documentation</span>
-    <a :href="samplesHref" data-site="samples" title="Every abap2UI5 sample, searchable">Samples</a>
+    <a :href="samplesHref" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
     <a :href="PLAYGROUND" title="Write ABAP and run it in the browser">Playground</a>
   </nav>
   <!-- The rest of abap2UI5 behind one more button: light or dark, then the
-       project's tools and its repositories - the list the Links menu carries,
-       in the order the other three bars carry it. The switch says what a press
-       does and swaps its whole label with the theme (style.css). -->
+       practical links (issues, release notes, install, support), the project's
+       tools and its repositories by kind - the same rows, in the same order,
+       as the other three bars carry. The switch says what a press does and
+       swaps its whole label with the theme (style.css). -->
   <details v-if="theme" ref="extra" class="a2ui5-extra">
     <summary class="a2ui5-extra-button" title="More: light or dark, and the rest of abap2UI5" aria-label="More: light or dark, and the rest of abap2UI5">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="5" cy="12" r="2.2"/><circle cx="12" cy="12" r="2.2"/><circle cx="19" cy="12" r="2.2"/></svg>
@@ -95,20 +111,67 @@ watch(isDark, (dark) => {
         <span class="when-light"><span class="glyph" aria-hidden="true">☾</span>Switch to dark</span>
         <span class="when-dark"><span class="glyph" aria-hidden="true">☀</span>Switch to light</span>
       </button>
+      <a href="https://github.com/abap2UI5/abap2UI5/issues" target="_blank" rel="noopener">Issues</a>
+      <a href="/docs/resources/changelog">Release notes</a>
+      <a href="/docs/get_started/quickstart">Install with abapGit</a>
+      <a href="/docs/resources/support">Support</a>
+      <a href="/docs/resources/contribution">Contribute</a>
+      <a href="/docs/resources/sponsor">Sponsor</a>
       <span class="a2ui5-menu-head">Tools</span>
       <a href="https://github.com/abap2UI5/linter" target="_blank" rel="noopener">Linter</a>
+      <a href="https://abap2ui5.github.io/linter/">Linter rules</a>
       <a href="https://github.com/abap2UI5/vscode-extension" target="_blank" rel="noopener">VS Code extension</a>
       <a href="/docs/advanced/mcp_server">MCP server</a>
       <a href="https://github.com/abap2UI5/app-template" target="_blank" rel="noopener">App template</a>
-      <a href="https://github.com/abap2UI5-addons" target="_blank" rel="noopener">Add-ons</a>
+      <a href="/docs/resources/addons">Add-ons</a>
       <span class="a2ui5-menu-head">Repositories</span>
-      <a href="https://github.com/abap2UI5/abap2UI5" target="_blank" rel="noopener">abap2UI5</a>
-      <a href="https://github.com/abap2UI5/samples" target="_blank" rel="noopener">samples</a>
-      <a href="https://github.com/abap2UI5/samples-controls" target="_blank" rel="noopener">samples-controls</a>
-      <a href="https://github.com/abap2UI5/samples-stack" target="_blank" rel="noopener">samples-stack</a>
-      <a href="https://github.com/abap2UI5/playground" target="_blank" rel="noopener">playground</a>
-      <a href="https://github.com/abap2UI5/docs" target="_blank" rel="noopener">docs</a>
-      <a href="https://github.com/abap2UI5/abap2UI5/issues" target="_blank" rel="noopener">Issues</a>
+      <div class="a2ui5-menu-repos">
+        <div class="a2ui5-menu-group">
+          <span class="a2ui5-menu-sub">Framework</span>
+          <a href="https://github.com/abap2UI5/abap2UI5" target="_blank" rel="noopener">abap2UI5</a>
+          <a href="https://github.com/abap2UI5/frontend" target="_blank" rel="noopener">frontend</a>
+          <a href="https://github.com/abap2UI5/abap2UI5-local" target="_blank" rel="noopener">abap2UI5-local</a>
+          <a href="https://github.com/abap2UI5/mirror-ajson" target="_blank" rel="noopener">mirror-ajson</a>
+          <a href="https://github.com/abap2UI5/mirror-srtti" target="_blank" rel="noopener">mirror-srtti</a>
+          <a href="https://github.com/abap2UI5/web-abap2UI5" target="_blank" rel="noopener">web-abap2UI5</a>
+        </div>
+        <div class="a2ui5-menu-group">
+          <span class="a2ui5-menu-sub">Samples</span>
+          <a href="https://github.com/abap2UI5/samples" target="_blank" rel="noopener">samples</a>
+          <a href="https://github.com/abap2UI5/samples-controls" target="_blank" rel="noopener">samples-controls</a>
+          <a href="https://github.com/abap2UI5/samples-stack" target="_blank" rel="noopener">samples-stack</a>
+        </div>
+        <div class="a2ui5-menu-group">
+          <span class="a2ui5-menu-sub">Sites</span>
+          <a href="https://github.com/abap2UI5/docs" target="_blank" rel="noopener">docs</a>
+          <a href="https://github.com/abap2UI5/playground" target="_blank" rel="noopener">playground</a>
+        </div>
+        <div class="a2ui5-menu-group">
+          <span class="a2ui5-menu-sub">Tools</span>
+          <a href="https://github.com/abap2UI5/linter" target="_blank" rel="noopener">linter</a>
+          <a href="https://github.com/abap2UI5/vscode-extension" target="_blank" rel="noopener">vscode-extension</a>
+          <a href="https://github.com/abap2UI5/mcp-server" target="_blank" rel="noopener">mcp-server</a>
+          <a href="https://github.com/abap2UI5/app-template" target="_blank" rel="noopener">app-template</a>
+        </div>
+        <div class="a2ui5-menu-group">
+          <span class="a2ui5-menu-sub">Add-ons</span>
+          <a href="https://github.com/abap2UI5-addons/popups" target="_blank" rel="noopener">popups</a>
+          <a href="https://github.com/abap2UI5-addons/http-connector" target="_blank" rel="noopener">http-connector</a>
+          <a href="https://github.com/abap2UI5-addons/rfc-connector" target="_blank" rel="noopener">rfc-connector</a>
+          <a href="https://github.com/abap2UI5-addons/lock-manager" target="_blank" rel="noopener">lock-manager</a>
+          <a href="https://github.com/abap2UI5-addons/launchpad-kpi" target="_blank" rel="noopener">launchpad-kpi</a>
+          <a href="https://github.com/abap2UI5-addons/table-maintenance" target="_blank" rel="noopener">table-maintenance</a>
+          <a href="https://github.com/abap2UI5-addons/se16n" target="_blank" rel="noopener">se16n</a>
+          <a href="https://github.com/abap2UI5-addons/custom-controls" target="_blank" rel="noopener">custom-controls</a>
+          <a href="https://github.com/abap2UI5-addons" target="_blank" rel="noopener">All add-ons</a>
+        </div>
+        <div class="a2ui5-menu-group">
+          <span class="a2ui5-menu-sub">Apps</span>
+          <a href="https://github.com/abap2UI5-apps/sql-console" target="_blank" rel="noopener">sql-console</a>
+          <a href="https://github.com/abap2UI5-apps/table-content-loader" target="_blank" rel="noopener">table-content-loader</a>
+          <a href="https://github.com/abap2UI5-apps" target="_blank" rel="noopener">All apps</a>
+        </div>
+      </div>
     </div>
   </details>
 </template>

--- a/docs/.vitepress/theme/playground.js
+++ b/docs/.vitepress/theme/playground.js
@@ -22,9 +22,10 @@
  * **The app is shown, not the editor.** The code is already above it, in this
  * site's own font and highlighting; a second copy in an editor beside it would
  * be the same thing twice. What the page cannot show is the running app, so
- * that is what the frame shows. "Open in the playground" is one link away for
- * a reader who wants to change it — and it opens the full playground, editor
- * and the Problems / abaplint panel included, not another embedded frame.
+ * that is what the frame shows. "Switch to Playground with this code" is one
+ * link away for a reader who wants to change it — and it goes to the full
+ * playground, editor and the Problems / abaplint panel included, in this tab,
+ * not to another embedded frame.
  */
 
 /* The published playground. Absolute rather than site-relative on purpose: it
@@ -108,11 +109,14 @@ function bar(container, demo, embed, source) {
     bar.replaceWith(runButton());
   });
 
+  /* In THIS tab, and the label says so: a switch to the playground with the
+   * code that is on this page, not a window that opens beside it. The way
+   * back is the Documentation item in the playground's bar, which comes back
+   * to this page (site-memory.js); a reader who wants a second tab has the
+   * middle button. */
   const open = document.createElement('a');
   open.className = 'a2ui5-play-open';
-  open.target = '_blank';
-  open.rel = 'noopener';
-  open.textContent = 'Open in the playground';
+  open.textContent = 'Switch to Playground with this code';
   /* Built by the loader rather than here: the fragment format is the
    * playground's, and a fragment it cannot read is quietly replaced by its own
    * sample — a wrong link that looks like a working one. An older loader that

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -847,8 +847,10 @@
   text-decoration: none;
 }
 
+/* A chevron rather than the ↗ it used to carry: the link stays in this tab,
+ * and the arrow said otherwise. */
 .vp-doc .a2ui5-play-open::after {
-  content: " ↗";
+  content: " ›";
 }
 
 .vp-doc .a2ui5-play-close:hover,
@@ -1363,6 +1365,50 @@
   margin-right: 0;
 }
 
+/* ------------------------------------------------------- the measure ---
+ *
+ * The catalogue's bar stands 20px from either edge at every width, over the
+ * whole width, and 12px on a phone (catalogue.css); the theme's stands 24 and
+ * then 32, and from 1440px it is centred with the page under it. A reader
+ * crossing from the catalogue saw the brand step 12px to the right and the
+ * menu's button step in from the edge - the one difference left between the
+ * four bars, and one with no reason behind it. So: the catalogue's numbers,
+ * for the two layouts the theme has. On a page without a sidebar the bar is
+ * one `.wrapper` with padding and a centred `.container`; on a page with one,
+ * from 960px, the wrapper's padding goes and the brand is placed absolutely
+ * at the left, with the content strip padded to sit beside it. The sidebar's
+ * own text stays where the theme puts it (32px): it is a column of the page,
+ * not part of the bar. */
+.Layout .VPNav .VPNavBar .wrapper {
+  padding: 0 20px;
+}
+
+.Layout .VPNav .VPNavBar .container {
+  max-width: none;
+}
+
+@media (min-width: 960px) {
+  .Layout .VPNav .VPNavBar.has-sidebar .wrapper {
+    padding: 0;
+  }
+
+  .Layout .VPNav .VPNavBar.has-sidebar .title {
+    padding: 0 20px;
+    width: var(--vp-sidebar-width);
+  }
+
+  .Layout .VPNav .VPNavBar.has-sidebar .content {
+    padding-right: 20px;
+    padding-left: var(--vp-sidebar-width);
+  }
+}
+
+@media (max-width: 620px) {
+  .Layout .VPNav .VPNavBar .wrapper {
+    padding: 0 12px;
+  }
+}
+
 /* ---------------------------------------------------- the row's order ---
  *
  * `.content-body` is a flex row, so the slot's content can be moved without
@@ -1488,7 +1534,13 @@
   z-index: 6;
   display: flex;
   flex-direction: column;
-  min-width: 220px;
+  /* Wide enough for the repositories in two columns below, and never wider
+   * than the viewport less the bar's own padding; taller than the viewport
+   * it scrolls, rather than running off the bottom of a small window. */
+  width: 372px;
+  max-width: calc(100vw - 24px);
+  max-height: calc(100vh - 62px);
+  overflow-y: auto;
   padding: 6px;
   background: var(--bg);
   border: 1px solid var(--line);
@@ -1536,6 +1588,34 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--fg-dim);
+}
+
+/* The repositories, by kind, in two columns: each kind is a small group under
+ * a dim heading, kept whole across the column break, in rows a little tighter
+ * than the menu's own so twenty-odd links read as a list rather than a wall. */
+.Layout .VPNav .a2ui5-menu-repos {
+  columns: 2;
+  column-gap: 4px;
+}
+
+.Layout .VPNav .a2ui5-menu-group {
+  break-inside: avoid;
+  padding-bottom: 4px;
+}
+
+.Layout .VPNav .a2ui5-menu-sub {
+  display: block;
+  padding: 6px 10px 2px;
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+
+.Layout .VPNav .a2ui5-menu-repos a {
+  padding: 4px 10px;
+}
+
+@media (max-width: 420px) {
+  .Layout .VPNav .a2ui5-menu-repos { columns: 1; }
 }
 
 .Layout .VPNav .when-dark { display: none; }


### PR DESCRIPTION
## What

Four things a reader crossing from the sample catalogue saw differ, all in `docs/.vitepress/theme/`:

- **The bar's measure** (`style.css`). The theme stood 32px from either edge and centred itself from 1440px; the catalogue stands 20px, over the whole width, and 12px on a phone. The theme's two nav layouts (the padded wrapper on a page without a sidebar, the absolutely placed brand beside a padded content strip on a page with one) are held to those numbers. Measured with Playwright against the built site: brand at 20px and the menu's button 14px from the right edge on the home page, a cookbook page and the catalogue alike, at 1280px and 1600px.
- **The Samples item stays current** (`SiteBar.vue`). It was lifted once, on mount, so a page left open carried the position from before. It is lifted again when the page is shown or the tab looked at again, and on the click itself (set on the element, since a ref set in the handler reaches the DOM a tick too late).
- **The menu behind the bar's last button** (`SiteBar.vue`, `style.css`): after the switch, the practical links (issues, release notes, install, support, contribute, sponsor), then the tools with the linter's rule reference beside the linter, then the repositories by kind (framework, samples, sites, tools, add-ons, apps) in two columns; wider, and scrolling when taller than the window. The same rows as the other three bars in [abap2UI5/playground](https://github.com/abap2UI5/playground) (same branch), kept in step by hand as before.
- **The Run button's link** (`playground.js`). *Open in the playground* opened a second tab; it is *Switch to Playground with this code* now, in this tab, with the way back in the playground's own bar. The ↗ after it became a chevron.

`AGENTS.md` records the measure beside the palette and the markup as the third thing copied by hand.

## Checks

`npm test` and `npm run docs:build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQX6iME3o3LUr8PPKe3C4g

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQX6iME3o3LUr8PPKe3C4g)_