### PR TITLE
Add unified search across docs and sample catalogues

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,6 +92,16 @@ jobs:
         if: ${{ !cancelled() }}
         run: npm run docs:build
 
+      # every link out of this deployment and into a neighbouring one on the
+      # same origin - the playground, the catalogue, the linter's rule pages.
+      # They share an origin, so VitePress's router takes such a link over,
+      # finds no page of THIS site behind it and renders the 404 at the
+      # neighbour's URL. It read as the other site being broken. Reads the
+      # built HTML, so it runs after the build
+      - name: cross-site links
+        if: ${{ !cancelled() }}
+        run: npm run check:cross-site
+
       # the ABAP in the fenced blocks, against the real framework: does it
       # compile, and does the view it builds name controls and properties that
       # exist on the UI5 floor this documentation targets

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,15 @@ jobs:
       # read - so it stays a build step rather than being listed twice.
       - name: Build with VitePress
         run: npm run docs:build
+
+      # The one gate that cannot run before the build, because what it judges
+      # is the built HTML: every link into a neighbouring deployment on this
+      # origin carries the attribute that keeps VitePress's router off it.
+      # Between the build and the upload, so a site whose bar leads to its own
+      # 404 is not what gets published.
+      - name: cross-site links
+        run: npm run check:cross-site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ docs/.vitepress/dist
 docs/public/llms.txt
 docs/public/llms-full.txt
 docs/public/**/*.md
+
+# and by scripts/generate-search.mjs - the index behind the box in the bar, a
+# projection of those same pages plus the three sample catalogues. Committed it
+# would be stale on every commit that touches a page, and a stale index answers
+# a search with a page that has moved.
+docs/public/search-index.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,15 +28,16 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `docs/.vitepress/theme/style.css` | Everything this site looks like. Its palette is the playground's, copied — see *One site in three places* below |
 | `docs/.vitepress/theme/SiteBar.vue` | The right-hand end of the bar: the three sites, and the menu behind the bar's last button — the light/dark switch, the project's tools and its repositories. Rendered into `nav-bar-content-after` by `theme/index.js`; the marks between them are VitePress's own `socialLinks`, ordered by `style.css` |
 | `docs/.vitepress/theme/site-memory.js` | Where the reader was, on each site, so the bar comes back to it; pinned by `test/site-memory.test.mjs` |
+| `scripts/check-cross-site.mjs` | Every link out of this deployment and into a neighbouring one on the same origin carries a `target`, or VitePress's router swallows it and shows this site's 404 at the other site's URL. Reads the BUILT html, so it runs after `docs:build`; the rule and the reasoning are in `scripts/lib/cross-site.mjs` |
 
 ## Build & verify — run before every commit
 
 ```bash
-npm run check          # test + check:version + docs:build + check:examples + check:conventions + check:playground + check:api-names + check:api-reference + check:samples
+npm run check          # test + check:version + docs:build + check:cross-site + check:examples + check:conventions + check:playground + check:api-names + check:api-reference + check:samples
 ```
 
-A documentation repository has no compiler for its prose, but nine things in
-it are decidable, and all nine are decided before a merge:
+A documentation repository has no compiler for its prose, but ten things in
+it are decidable, and all ten are decided before a merge:
 
 | | |
 |---|---|
@@ -48,16 +49,19 @@ it are decidable, and all nine are decided before a merge:
 | `check:api-reference` | the committed client API reference — the generated block in `resources/api.md` and `docs/public/api/client-api.json` — regenerated from `z2ui5_if_client` on `main` and compared byte for byte. Goes stale whenever the interface changes over there and the committed reference still describes the shape before it. `npm run generate:api` rewrites both |
 | `check:conventions` | the fenced ABAP against the house style the reader meets next: the view-chain layout, and the three section blocks of an app class. `check:examples` asks whether an example compiles and names real API — both questions about the framework; neither can see that a snippet is written in a different style from every sample. Measured against [samples-controls](https://github.com/abap2UI5/samples-controls) (637 classes, gated, at zero): five chains here showed the reader a different tree than the one that renders, and 57 of 86 app classes carried neither `PROTECTED SECTION.` nor `PRIVATE SECTION.`. What this gate deliberately does NOT take over is the blank-line and `t_arg` continuation rules — those are pattern-lint *warnings* over there and that corpus carries 382 of them |
 | `check:playground` | every complete app class on the site either carries a **Run** button or a marker on its page saying why it cannot run. The rules that offer the button fail towards *not* offering one, so without this an example nobody ever measured is indistinguishable from an example that can never run — which is exactly how the coverage ledger below went stale. What stays undecidable by CI — does a *buttoned* example actually start — is the measurement the Run-button section describes |
+| `check:cross-site` | every link that leaves this deployment for a neighbouring one on the same origin — the playground, the catalogue, the linter's rule pages — carries a `target`. Without it VitePress's router treats the link as a route of THIS site, finds no page behind `/playground/` and renders the 404 *at that URL*, which reads as the other site being broken. Every way out of the manual was in that state at once: both bar items, the Linter rules row in the menu and the Run bar's link. Judges the built HTML, so it runs straight after `docs:build`. What it cannot see is the Run bar's link — built in a browser, in no built page — which is why `test/cross-site.test.mjs` pins that one as source |
 | `check:samples` | the **Working Samples** blocks, against [abap2UI5/samples](https://github.com/abap2UI5/samples) |
 
-**All three walking gates carry a floor.** A gate that checked nothing reports
+**All four walking gates carry a floor.** A gate that checked nothing reports
 the same shape as a gate that found nothing wrong — which is precisely how
 `check:examples` passed for years on an abaplint config with no rules in it. So
 `check:examples`, `check:conventions` and `check:playground` each exit 1 when
 their walk finds no example at all, and say which of the fence language, the
-page layout or the builder name is the likely cause.
+page layout or the builder name is the likely cause. `check:cross-site` carries
+the same floor twice over: no HTML in `dist` at all, and no cross-site link on
+a site whose bar carries three of them on every page.
 
-`.github/workflows/check.yml` runs the same nine, in the same order. Keep the
+`.github/workflows/check.yml` runs the same ten, in the same order. Keep the
 two in step: a step that exists only in `package.json` is a step no pull
 request has to pass, which is how `npm test` — the pin added *because* the
 catalogue parser broke twice in silence — went a release without CI.
@@ -148,6 +152,30 @@ the wordmark and belongs to the mark alone. `resources/logo.md` is the page
 that says so and the one place either value is quoted to a reader — if you move
 an accent, move that table with it.
 
+**One origin is also what breaks a plain link between them, and every link out
+of this site carries `target="_self"` because of it.** This site is a single
+page application: VitePress's router listens on the window and takes over any
+link that is same-origin and looks like a page
+(`origin === currentUrl.origin && treatAsHtml(pathname)`, in
+`vitepress/dist/client/app/router.js`). `/playground/` passes both tests — so
+the router pushed the URL, went looking for a page of THIS site to render
+there, found none, and drew this site's own **404** in its place. The address
+bar said `/playground/`, the document said PAGE NOT FOUND, and a reload then
+loaded the real playground, which is what a failed SPA route change looks like
+from the outside. Every way out of the manual was in that state at once: both
+bar items, the *Linter rules* row in the menu, and the Run bar's *Switch to
+Playground with this code*.
+
+The router's own escape hatch is the line above those two tests — a link with a
+`target` attribute is left alone, whatever the value. `_self` is the value,
+because these three are one site and open in one tab. It is needed for
+**neighbours on this origin only**: a link to github.com is another origin, the
+router never looks at it, and VitePress gives external links in a page a
+`target="_blank"` of their own — which is why only the hand-written bar and
+menu ever got this wrong. `check:cross-site` now holds the whole built site to
+it, and the direction back needs nothing: the other three documents are static
+pages with no router in front of them.
+
 **One origin means one localStorage**, which is what two things here rely on:
 
 | | |
@@ -165,6 +193,26 @@ abap2ui5.github.io, so every path through `lastVisited( )` takes the
 different-origin branch and falls back. That is why the same-origin cases are a
 unit test with a stubbed `location` rather than an end-to-end one. The round
 trip itself is held over there, in `tests/site-memory.spec.js`.
+
+**Why this is not one deployment, and why merging them would not have helped.**
+The question comes up whenever the bar misbehaves: put the documentation, the
+playground and the catalogue in one GitHub Pages site and the seams go away.
+They are already on one origin — that is what a project page per repository
+under `abap2ui5.github.io` gives you — so a merge would buy no origin that is
+not already shared, and the 404 above was **not** a cross-origin problem: it
+was a same-origin one, caused by exactly the sharing a merge would deepen. One
+deployment would still serve the playground at a path VitePress does not own,
+the router would still swallow the link, and the fix would still be the
+attribute.
+
+What it would cost is concrete: one repository publishing everything means the
+documentation waits on the playground's build (a pinned framework, a transpile,
+UI5, seven hundred catalogue pages) to publish a typo fix, one `pages` queue
+for both, and the gates of two very different projects in one run. What it
+would buy — one bar instead of four, one palette — is real, and is the price
+deliberately paid above for a first paint that fetches nothing across a
+deployment. If that trade is ever re-opened, re-open it for the four copies of
+the bar, not for the links between the sites; those are one attribute.
 
 ## Things that will trip you up
 
@@ -184,6 +232,16 @@ trip itself is held over there, in `tests/site-memory.spec.js`.
   `check:version` keeps the release number in the nav bar, the deprecations
   page and the changelog honest. `A2UI5_REF` still overrides the ref — now to
   pin a run BACK to a release rather than forward to main.
+
+- **A link to a neighbouring site needs `target="_self"`, and looks fine
+  without it.** The playground, the catalogue and the linter's rule pages are
+  on this origin, so VitePress's router takes an ordinary link to them over,
+  finds no page of this site there and renders the 404 at their URL. Nothing
+  is red: the markup is valid, the URL is right, and a reload lands on the
+  real page — so it reads as the other site being down. Adding a row to the
+  bar or to the menu behind its last button means adding the attribute;
+  `npm run check:cross-site` (after a build) says so if you forget. A link to
+  another host needs nothing.
 
 - **The nav bar and the sidebar contain the same two entries.**
   `Contribution` and `Sponsor` appear in both `themeConfig.nav` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `scripts/generate-llms.mjs` | Builds `llms.txt` / `llms-full.txt` / per-page markdown from the sidebar. Runs inside `docs:build`, so the deploy publishes them |
 | `scripts/generate-api-reference.mjs` | Generates the client API reference — the block in `docs/resources/api.md` and `docs/public/api/client-api.json` — from `z2ui5_if_client` on the framework branch this site tracks (`main`); `--check` is the freshness gate |
 | `scripts/lib/client-interface.mjs` | Where `z2ui5_if_client` is fetched from (the ref comes from `lib/release.mjs`, shared with `check-api-names.mjs`) and the full parser `generate-api-reference.mjs` renders from |
-| `scripts/check-version.mjs` | The release number in the nav bar, the deprecations page and the changelog, against the newest release tag of the framework |
+| `scripts/check-version.mjs` | The release number in the bar's menu, the deprecations page and the changelog, against the newest release tag of the framework |
+| `scripts/generate-search.mjs` | Builds `docs/public/search-index.json` — the pages of this site plus every entry in the three sample catalogues, which is what the box in the middle of the bar searches. Runs inside `docs:build`, so the deploy publishes it; `scripts/lib/search-index.mjs` is what goes in |
+| `scripts/lib/pages.mjs` | What a page of this site IS: the sidebar walk, its title, its first sentence, its headings, its words. Shared by `generate-llms.mjs` and `generate-search.mjs` so a page added to the sidebar reaches both |
 | `docs/.vitepress/playground.mjs` | Decides which fenced ABAP example gets a **Run** button, and wraps the fence; `theme/playground.js` is the browser half |
 | `scripts/list-runnable.mjs` | The measurement's worklist: every fenced example that carries a Run button, out of the same `playground.mjs` that decides the button. `--json` adds each example's ABAP verbatim - what the button sends - so the measurement below can be driven rather than clicked |
 | `scripts/check-playground.mjs` | The Run-button bookkeeping: every complete app class either gets a button from `playground.mjs` or carries a `<!-- playground: no Run button — … -->` marker above its fence saying why it cannot run; a stale marker fails as loudly as a missing one. `--list` prints the deliberate exclusions with both reasons |
@@ -28,6 +30,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `docs/.vitepress/theme/style.css` | Everything this site looks like. Its palette is the playground's, copied — see *One site in three places* below |
 | `docs/.vitepress/theme/SiteBar.vue` | The right-hand end of the bar: the three sites, and the menu behind the bar's last button — the light/dark switch, the project's tools and its repositories. Rendered into `nav-bar-content-after` by `theme/index.js`; the marks between them are VitePress's own `socialLinks`, ordered by `style.css` |
 | `docs/.vitepress/theme/site-memory.js` | Where the reader was, on each site, so the bar comes back to it; pinned by `test/site-memory.test.mjs` |
+| `docs/.vitepress/theme/SearchBox.vue` | The box in the middle of the bar and what it opens. `theme/search-engine.js` is the matching, framework-free because the other three bars carry a copy of it; both are pinned by `test/search.test.mjs` |
 | `scripts/check-cross-site.mjs` | Every link out of this deployment and into a neighbouring one on the same origin carries a `target`, or VitePress's router swallows it and shows this site's 404 at the other site's URL. Reads the BUILT html, so it runs after `docs:build`; the rule and the reasoning are in `scripts/lib/cross-site.mjs` |
 
 ## Build & verify — run before every commit
@@ -42,7 +45,7 @@ it are decidable, and all ten are decided before a merge:
 | | |
 |---|---|
 | `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate — and the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow |
-| `check:version` | the release number in the nav bar, the deprecations page and the changelog, against the newest release tag of the framework — this one goes stale without anybody touching this repository |
+| `check:version` | the release number in the bar's menu (`VERSION` in `theme/SiteBar.vue` — it was a nav dropdown's label in `config.mjs` until the bar was rebuilt), the deprecations page and the changelog, against the newest release tag of the framework — this one goes stale without anybody touching this repository |
 | `docs:build` | a page that does not build is a page nobody can read |
 | `check:examples` | the ABAP in the fenced blocks, against the real framework: does it compile, and does the view it builds name controls and properties that exist on the UI5 floor this documentation targets. **It ran no abaplint rules at all until 2026-09-04** — the generated config had no `rules` block, so abaplint walked 139 files, ran nothing, and printed `0 issue(s) found` for years. Ten examples with an unbalanced parenthesis were sitting behind that. The three compile rules it runs now (`parser_error`, `check_syntax`, `unknown_types`) are the sample repositories' own; the reasoning for stopping there, measured against the full 188-rule set, is in the file |
 | `check:api-names` | every `client->` name on the site — method, parameter, `cs_*` constant — against `z2ui5_if_client` on `main`, plus every `blob/main/` link into the framework's tree, plus **no name from the frozen package** (`src/99`: `z2ui5_cl_util*`, `z2ui5_cl_pop_*`, `z2ui5_cl_xml_view*`, `z2ui5_if_exit`, `z2ui5_if_types`, …) anywhere but on the deprecations page and in the changelog. `check:examples` compiles the fenced blocks that are whole CLASSES; this is the rest of the page: the sentence, the two-line snippet, the constant block a page reproduces, the source link. Four pages taught API that 1.143.0 had deleted and nothing was red |
@@ -152,6 +155,39 @@ the wordmark and belongs to the mark alone. `resources/logo.md` is the page
 that says so and the one place either value is quoted to a reader — if you move
 an accent, move that table with it.
 
+**What the bar carries, left to right.** The mark and the name, then the four
+sections of the project — **Home**, **Documentation**, **Samples**,
+**Playground** — then the search, then the two marks and the menu behind the
+last button. One row at every width, which is the whole bar: the sections are
+hard against the brand because that is where a reader's eye already is, and the
+search sits on auto margins so it is centred in whatever the row has left
+rather than at a number that is right on one screen.
+
+Two of the four sections are pages of THIS deployment (Home is
+`docs/index.md`, which the brand alone used to open and nothing named;
+Documentation opens the manual) and two are the neighbouring sites. The one
+you are on is marked, which for this site means Home *or* Documentation
+depending on the page — `relativePath` decides it, server-side, so the bar is
+right in the HTML rather than after hydration.
+
+**The search is one box for the whole project.** It was VitePress's own local
+search, which indexes the pages of this site and nothing else — and half of
+what a reader wants is a sample, in another repository, on another deployment.
+`theme/SearchBox.vue` searches one index instead
+(`/docs/search-index.json`, built by `generate-search.mjs`): every page of the
+manual with its headings and its words, and all ~770 entries of the three
+sample catalogues with the titles, summaries and keywords those repositories
+maintain. Results are grouped by area, documentation first, and a sample hit
+opens that sample's own page in the catalogue.
+
+The index is generated, gitignored and fetched lazily — nothing is loaded until
+somebody types. The matching is `theme/search-engine.js`, deliberately
+framework-free: the other three bars are static HTML and carry a copy of it,
+the same arrangement as the palette and the position memory. **The index is not
+copied.** It is one document on the shared origin, fetched by whichever site
+the reader is on, because two copies of the data would be two answers to the
+same query.
+
 **One origin is also what breaks a plain link between them, and every link out
 of this site carries `target="_self"` because of it.** This site is a single
 page application: VitePress's router listens on the window and takes over any
@@ -229,7 +265,7 @@ the bar, not for the links between the sites; those are one attribute.
   `.github/shared/check-framework-pin.mjs`, "releases never gate a merge").
   What a reader on the newest release does not have yet is now a question of
   PROSE: `resources/deprecations.md` carries a *next release* column, and
-  `check:version` keeps the release number in the nav bar, the deprecations
+  `check:version` keeps the release number in the bar's menu, the deprecations
   page and the changelog honest. `A2UI5_REF` still overrides the ref — now to
   pin a run BACK to a release rather than forward to main.
 
@@ -243,13 +279,15 @@ the bar, not for the links between the sites; those are one attribute.
   `npm run check:cross-site` (after a build) says so if you forget. A link to
   another host needs nothing.
 
-- **The nav bar and the sidebar contain the same two entries.**
-  `Contribution` and `Sponsor` appear in both `themeConfig.nav` and
-  `themeConfig.sidebar` in `config.mjs`. The four lines now carry a `// nav` or
-  `// sidebar` marker so each one is unique — match on the marker, not on the
-  link. Any further line that has to exist twice gets the same treatment;
-  a replace-first edit on a text that appears twice hits the wrong one and
-  looks like it worked.
+- **`themeConfig.nav` is empty, and it stays empty.** The bar carries the four
+  sections of the project (`theme/SiteBar.vue`), the search, and everything
+  else behind the menu at its right-hand end. An entry added back to `nav`
+  lands between the sections and the search box and the row stops reading left
+  to right. What used to be there — Guide, Links, the version number — is
+  written out in `config.mjs` where the array was, including where each one
+  went. The `// nav` / `// sidebar` markers left in the sidebar are the scar of
+  the duplication that dropdown cost: two of its entries stood twice in one
+  file, and a replace-first edit hit the wrong one and looked like it worked.
 - **A fenced ABAP example is code, and it is checked.** `check:examples`
   compiles it and lints the view. It also refuses `z2ui5_cl_xml_view=>` — the
   frozen builder — unless the page carries the migration banner, and refuses a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ pages with no router in front of them.
 | | |
 |---|---|
 | the theme | The key is the playground's (`abap2ui5-playground:theme`). A head script in `config.mjs` reads it before the first paint and hands it to VitePress's own appearance handling; `SiteBar.vue` writes it back when the button is pressed. A reader crossing from a dark playground gets a dark page, with no flash |
-| where you were | `theme/site-memory.js`. Every page writes its own path down; the Samples item is lifted to whatever the catalogue last wrote. A stored value is **checked, not followed** — resolved against this origin and kept only if it is still inside the href the markup carries, which is what makes a poisoned or stale key cost a restored position and nothing else. The eleven cases are `test/site-memory.test.mjs` |
+| where you were | `theme/site-memory.js`. Every page writes its own path down; the Samples item is lifted to whatever the catalogue last wrote. A stored value is **checked, not followed** — resolved against this origin and kept only if it is still inside the section the markup declares: the href it carries, or a wider `scope` the caller names for a link written deeper than what it restores (the other three bars point Documentation at the first page of the manual and still come back to wherever the reader was in it). A poisoned or stale key costs a restored position and nothing else. The cases are `test/site-memory.test.mjs` |
 
 The playground is consulted by both and remembered by neither: its URL carries
 the code in the editor, so an item that reopened yesterday's sample would be a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
 All project guidance lives in **[AGENTS.md](AGENTS.md)** — the single source of
-truth for this repository (how the site is built, the nine gates, the playground rule engine, and what may be written where).
+truth for this repository (how the site is built, the ten gates, the playground rule engine, and what may be written where).
 
 Read `AGENTS.md` before making any change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,4 @@ Nothing here is a source of truth about the framework: the API reference, the
 sample catalogue and the corpus figures are generated or checked against
 `abap2UI5`, `abap2UI5/samples` and its siblings. If a fact is wrong, it is
 usually wrong there first. [AGENTS.md](AGENTS.md) is the full contract — how
-the site is built, the nine gates, and what may be written where.
+the site is built, the ten gates, and what may be written where.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ why the deploy re-runs them rather than trusting the merge.
 which of them need a sibling checkout to say anything at all — read it before
 changing anything beyond prose.
 
+### The bar, and what the search covers
+
+The bar is the mark, then the four sections — **Home**, **Documentation**,
+**Samples**, **Playground** — then one search box, then the project's links.
+The two middle sections are this site; Samples and Playground are the two
+neighbouring deployments on the same origin, and all four bars across them are
+kept identical by hand.
+
+The search covers **both areas at once**: every page here, and every one of the
+~770 samples in [samples](https://github.com/abap2UI5/samples),
+[samples-controls](https://github.com/abap2UI5/samples-controls) and
+[samples-stack](https://github.com/abap2UI5/samples-stack). It reads one
+generated index (`npm run search`), published at
+[`/docs/search-index.json`](https://abap2ui5.github.io/docs/search-index.json)
+and fetched by the playground and the catalogue too, so one query answers from
+one place wherever it is typed.
+
 ### What the site publishes for machines
 
 Besides the site, `docs:build` writes [`llms.txt`](https://abap2ui5.github.io/docs/llms.txt),

--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ Every contribution makes the documentation better for the community!
 ```sh
 npm ci
 npm run docs:dev     # the site, with hot reload
-npm run check        # what CI runs, all nine steps
+npm run check        # what CI runs, all ten steps
 ```
 
 ### What CI checks
 
-A documentation repository has no compiler for its prose, but nine things in
-it are decidable, and `npm run check` decides all nine before a merge — the
-prose builds (`docs:build`), the fenced ABAP examples compile and the views
+A documentation repository has no compiler for its prose, but ten things in
+it are decidable, and `npm run check` decides all ten before a merge — the
+prose builds (`docs:build`), every link into a neighbouring site on this origin
+— the playground, the catalogue — still leads there rather than to this site's
+own 404 (`check:cross-site`), the fenced ABAP examples compile and the views
 they build name real UI5 API (`check:examples`), those examples are written
 in the same house style as the sample corpora — chain layout and class shell —
 (`check:conventions`), every `client->` name and
@@ -41,7 +43,7 @@ passed. Several of these go stale without anybody touching this repository (a
 release is published elsewhere, a sample class is renamed elsewhere), which is
 why the deploy re-runs them rather than trusting the merge.
 
-**[AGENTS.md](AGENTS.md) describes each of the nine**, what a failure means and
+**[AGENTS.md](AGENTS.md) describes each of the ten**, what a failure means and
 which of them need a sibling checkout to say anything at all — read it before
 changing anything beyond prose.
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -152,67 +152,39 @@ export default defineConfig({
         "https://github.com/abap2UI5/docs/tree/main/docs/:path",
       text: "Edit this page on GitHub",
     },
-    search: {
-      provider: "local",
-    },
+    /* No `search` provider. VitePress's local search indexes the pages of THIS
+     * site and nothing else, and half of what a reader comes here to find is a
+     * sample in another repository - which meant knowing the catalogue existed
+     * and searching a second time, over there. The box in the middle of the bar
+     * is theme/SearchBox.vue, over one index that carries both areas
+     * (scripts/lib/search-index.mjs). The theme's own search slot stays empty;
+     * the component is rendered into `nav-bar-content-before`. */
     // https://vitepress.dev/reference/default-theme-config
-    nav: [
-      {
-        text: "Guide",
-        items: [
-          // The section is called Getting Started in the sidebar this opens;
-          // "Introduction" was the first PAGE in it, one level down.
-          { text: "Getting Started", link: "/get_started/about" }, // nav
-          { text: "Tutorial", link: "/tutorials/walkthrough/" }, // nav
-          { text: "Cookbook", link: "/cookbook/view/definition" },
-          { text: "Configuration", link: "/configuration/setup" },
-          // Technical Insight is not a line of its own here any more: it is a
-          // subsection of Advanced Topic in the sidebar, and a flat dropdown
-          // that still lists it next to its parent tells the reader a
-          // different structure than the sidebar they land in.
-          { text: "Advanced Topics", link: "/advanced/downporting" }, // nav
-          { text: "Resources", link: "/resources/references" }, // nav
-        ],
-      },
-      {
-        // Just the repositories, flat. The dropdown used to carry the three
-        // sample catalogues on top of them, which meant nine entries in two
-        // groups and a reader scanning for "where is the code" reading past
-        // half of it first. The catalogues are a reading destination and are
-        // linked where a reader looks for one — the cookbook chapters, and
-        // the playground the home page opens; this menu answers the other
-        // question, which repository to clone.
-        text: "Links",
-        items: [
-          { text: "abap2UI5", link: "https://github.com/abap2UI5/abap2UI5" },
-          { text: "addons", link: "https://github.com/abap2UI5-addons" },
-          { text: "samples", link: "https://github.com/abap2UI5/samples" },
-          {
-            text: "samples-controls",
-            link: "https://github.com/abap2UI5/samples-controls",
-          },
-          {
-            text: "samples-stack",
-            link: "https://github.com/abap2UI5/samples-stack",
-          },
-          { text: "docs", link: "https://github.com/abap2UI5/docs" },
-          { text: "issues", link: "https://github.com/abap2UI5/abap2UI5/issues" },
-        ],
-      },
-      {
-        // the released framework version — z2ui5_if_app=>version in
-        // abap2UI5/src/02/z2ui5_if_app.intf.abap is where it comes from
-        text: "1.144.0",
-        items: [
-          { text: "Release Notes", link: "/resources/changelog" },
-          { text: "Support", link: "/resources/support" },
-          // NAV copy — the sidebar has the same two entries verbatim, further
-          // down under "Resource". Search for this marker, not for the text.
-          { text: "Contribution", link: "/resources/contribution" }, // nav
-          { text: "Sponsor", link: "/resources/sponsor" }, // nav
-        ],
-      },
-    ],
+    //
+    // EMPTY, AND THAT IS THE BAR'S SHAPE NOW. There were three dropdowns here
+    // - Guide, Links and the version number - and the bar they sat in has been
+    // rebuilt around the four sections of the project (Home, Documentation,
+    // Samples, Playground, in theme/SiteBar.vue), with the search in the
+    // middle and everything else behind the menu at the right-hand end. All
+    // three were duplicates of something the reader already had:
+    //
+    //   Guide      six entries, every one of them a section of the sidebar
+    //              that opens the moment Documentation is clicked. A dropdown
+    //              listing the navigation standing open below it is a second
+    //              copy to keep in step, and it drifted twice already - the
+    //              `// nav` / `// sidebar` markers in this file are the scar.
+    //   Links      seven repositories, all seven in the menu behind the bar's
+    //              last button, grouped by kind rather than flat.
+    //   1.144.0    four entries - release notes, support, contribute, sponsor
+    //              - all four already in that same menu. What was NOT
+    //              elsewhere is the NUMBER, which moved into the menu as its
+    //              first heading (`VERSION` in SiteBar.vue; check:version
+    //              follows it there).
+    //
+    // So nothing was taken off the site, only out of the row. Keep it empty:
+    // an entry added here lands between the sections and the search box, and
+    // the row stops reading left to right.
+    nav: [],
     sidebar: [
       {
         text: "Getting Started",

--- a/docs/.vitepress/theme/SearchBox.vue
+++ b/docs/.vitepress/theme/SearchBox.vue
@@ -1,0 +1,191 @@
+<script setup>
+/*
+ * The search in the middle of the bar — one box for the whole project.
+ *
+ * It replaces VitePress's own local search, which indexed the pages of this
+ * site and nothing else. Half of what a reader is looking for is a SAMPLE, in
+ * another repository and on another deployment, and finding it meant knowing
+ * the catalogue existed and searching there instead. The index this reads
+ * (scripts/lib/search-index.mjs, published as /docs/search-index.json) carries
+ * both areas, and the results say which is which.
+ *
+ * The matching is search-engine.js, which is framework-free because the same
+ * box is on the playground, the catalogue and the per-sample pages, and those
+ * are static HTML. This file is the Vue half: the button in the bar, the
+ * overlay, the keyboard.
+ *
+ * Nothing is fetched until the box is opened. The index is 400 kB (80 over the
+ * wire), which is not a price to charge a reader who came to read one page.
+ */
+import { computed, nextTick, ref, shallowRef, watch, onMounted, onUnmounted } from 'vue';
+import { search, grouped, loadIndex, highlight } from './search-engine.js';
+
+const open = ref(false);
+const query = ref('');
+const input = ref(null);
+const active = ref(0);
+const entries = shallowRef([]);
+const failed = ref(false);
+
+/* The index lives at an absolute URL on the shared origin, and this site is
+ * also served from a dev server on localhost. Its PATH is what is used here,
+ * so the box works on both without knowing which it is on - the same reason
+ * the position memory resolves against `location` rather than trusting a
+ * stored origin. */
+const INDEX = '/docs/search-index.json';
+
+async function fetchIndex() {
+  if (entries.value.length) return;
+  try {
+    const index = await loadIndex(INDEX);
+    entries.value = index.entries;
+    failed.value = false;
+  } catch {
+    /* No index is a search box that says so, not one that reports "nothing
+     * found" - the reader would take that for an answer about the project. */
+    failed.value = true;
+  }
+}
+
+function show() {
+  open.value = true;
+  fetchIndex();
+  nextTick(() => input.value?.focus());
+}
+
+function hide() {
+  open.value = false;
+  query.value = '';
+  active.value = 0;
+}
+
+const hits = computed(() => (entries.value.length ? search(entries.value, query.value) : []));
+const groups = computed(() => grouped(hits.value));
+/* The rows in the order the arrow keys walk them, which is the order they are
+ * drawn in - grouped, not scored. */
+const rows = computed(() => groups.value.flatMap((g) => g.hits));
+
+watch(query, () => { active.value = 0; });
+
+/** A documentation hit stays inside this deployment, so it is followed as a
+ *  path: the published index names absolute URLs, and on a dev server those
+ *  would send the reader to the live site. A sample hit really does leave for
+ *  the catalogue, and carries the `target` that keeps VitePress's router off
+ *  it (scripts/lib/cross-site.mjs). */
+function hrefOf(hit) {
+  const url = hit.entry.url + (hit.heading ? `#${hit.heading.anchor}` : '');
+  if (hit.entry.area !== 'docs') return { href: url, target: '_self' };
+  try {
+    const u = new URL(url);
+    return { href: u.pathname + u.search + u.hash, target: null };
+  } catch {
+    return { href: url, target: null };
+  }
+}
+
+function go(hit) {
+  if (!hit) return;
+  const { href } = hrefOf(hit);
+  hide();
+  location.assign(href);
+}
+
+function onKey(e) {
+  if (!open.value) {
+    /* Two ways in, both what a reader of technical documentation already has
+     * in their fingers, and neither of them while they are typing in a field
+     * of the page. */
+    const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(e.target?.tagName || '') || e.target?.isContentEditable;
+    if (typing) return;
+    if (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key === 'k')) { e.preventDefault(); show(); }
+    return;
+  }
+  if (e.key === 'Escape') { e.preventDefault(); hide(); return; }
+  if (e.key === 'ArrowDown') { e.preventDefault(); active.value = Math.min(active.value + 1, rows.value.length - 1); }
+  else if (e.key === 'ArrowUp') { e.preventDefault(); active.value = Math.max(active.value - 1, 0); }
+  else if (e.key === 'Enter') { e.preventDefault(); go(rows.value[active.value]); }
+}
+
+onMounted(() => document.addEventListener('keydown', onKey));
+onUnmounted(() => document.removeEventListener('keydown', onKey));
+
+const indexOf = (hit) => rows.value.indexOf(hit);
+const parts = (text) => highlight(text, query.value);
+</script>
+
+<template>
+  <!-- The button is drawn as the field it opens, which is what every search in
+       a documentation bar looks like now; the shortcut is printed in it so it
+       is discoverable without a tooltip. -->
+  <button class="a2ui5-search-button" type="button" @click="show" aria-label="Search the documentation and the samples">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="11" cy="11" r="6.4" fill="none" stroke="currentColor" stroke-width="1.9"/>
+      <path d="M15.8 15.8 20 20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
+    </svg>
+    <span class="a2ui5-search-label">Search</span>
+    <kbd class="a2ui5-search-key">/</kbd>
+  </button>
+
+  <Teleport to="body">
+    <div v-if="open" class="a2ui5-search-scrim" @click.self="hide">
+      <div class="a2ui5-search-panel" role="dialog" aria-modal="true" aria-label="Search">
+        <div class="a2ui5-search-field">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="11" cy="11" r="6.4" fill="none" stroke="currentColor" stroke-width="1.9"/>
+            <path d="M15.8 15.8 20 20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
+          </svg>
+          <input
+            ref="input"
+            v-model="query"
+            type="search"
+            autocomplete="off"
+            spellcheck="false"
+            placeholder="Search the documentation and every sample"
+          />
+          <button class="a2ui5-search-close" type="button" @click="hide" aria-label="Close">Esc</button>
+        </div>
+
+        <div class="a2ui5-search-results">
+          <p v-if="failed" class="a2ui5-search-note">
+            The search index could not be loaded. The
+            <a href="/docs/">documentation</a> and the
+            <a href="https://abap2ui5.github.io/playground/samples/" target="_self">sample catalogue</a>
+            are both browsable without it.
+          </p>
+          <p v-else-if="!query" class="a2ui5-search-note">
+            Every page of the documentation and every sample in the three catalogues.
+            <kbd>↑</kbd><kbd>↓</kbd> to move, <kbd>↵</kbd> to open.
+          </p>
+          <p v-else-if="!rows.length" class="a2ui5-search-note">
+            Nothing matches <strong>{{ query }}</strong>.
+          </p>
+
+          <div v-for="group in groups" :key="group.label" class="a2ui5-search-group">
+            <div class="a2ui5-search-group-head">{{ group.label }}</div>
+            <a
+              v-for="hit in group.hits"
+              :key="hit.entry.url"
+              class="a2ui5-search-hit"
+              :class="{ active: indexOf(hit) === active }"
+              :href="hrefOf(hit).href"
+              :target="hrefOf(hit).target"
+              @mouseenter="active = indexOf(hit)"
+              @click="hide"
+            >
+              <span class="a2ui5-search-hit-title">
+                <span v-for="([text, on], i) in parts(hit.entry.title)" :key="i" :class="{ hl: on }">{{ text }}</span>
+              </span>
+              <span v-if="hit.heading" class="a2ui5-search-hit-where">›&nbsp;{{ hit.heading.text }}</span>
+              <span v-if="hit.entry.code" class="a2ui5-search-hit-code">
+                <span v-for="([text, on], i) in parts(hit.entry.code)" :key="i" :class="{ hl: on }">{{ text }}</span>
+              </span>
+              <span v-if="hit.entry.text" class="a2ui5-search-hit-text">
+                <span v-for="([text, on], i) in parts(hit.entry.text)" :key="i" :class="{ hl: on }">{{ text }}</span>
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/docs/.vitepress/theme/SiteBar.vue
+++ b/docs/.vitepress/theme/SiteBar.vue
@@ -35,6 +35,21 @@ defineProps({ theme: { type: Boolean, default: true } });
 const PLAYGROUND = "https://abap2ui5.github.io/playground/";
 const SAMPLES = "https://abap2ui5.github.io/playground/samples/";
 
+/* EVERY LINK OUT OF THIS SITE AND INTO A NEIGHBOURING ONE CARRIES A `target`,
+ * and it is not decoration: without it the link does not arrive.
+ *
+ * The three sites share an origin - the thing that makes the shared theme and
+ * the shared position memory possible - and that is also what breaks a plain
+ * link between them. This site is a single page application: VitePress's
+ * router takes over any link that is same-origin and looks like a page, and
+ * /playground/ is both. It then has no page of THIS site to render there, so
+ * it drew this site's 404 at the playground's URL. `_self` is the value
+ * because it is the behaviour these items already promised - one site, one
+ * tab. A link to another host needs nothing; only abap2ui5.github.io outside
+ * /docs/ is affected. scripts/lib/cross-site.mjs is the whole story, and
+ * scripts/check-cross-site.mjs holds the built site to it. */
+const SAME_TAB = "_self";
+
 /* The catalogue's front page until the browser says otherwise. This is what
  * the server renders, what a crawler is given and what a first visit follows;
  * onMounted only ever replaces it with a deeper page of the same site. */
@@ -94,8 +109,8 @@ watch(isDark, (dark) => {
     <!-- The one you are on, which is why it is a span and not a link - the
          look aria-current gets on the other three bars. -->
     <span class="here" aria-current="page">Documentation</span>
-    <a :href="samplesHref" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
-    <a :href="PLAYGROUND" title="Write ABAP and run it in the browser">Playground</a>
+    <a :href="samplesHref" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
+    <a :href="PLAYGROUND" :target="SAME_TAB" title="Write ABAP and run it in the browser">Playground</a>
   </nav>
   <!-- The rest of abap2UI5 behind one more button: light or dark, then the
        practical links (issues, release notes, install, support), the project's
@@ -119,7 +134,9 @@ watch(isDark, (dark) => {
       <a href="/docs/resources/sponsor">Sponsor</a>
       <span class="a2ui5-menu-head">Tools</span>
       <a href="https://github.com/abap2UI5/linter" target="_blank" rel="noopener">Linter</a>
-      <a href="https://abap2ui5.github.io/linter/">Linter rules</a>
+      <!-- Same origin, another deployment: the attribute above, not the
+           `target="_blank"` the github.com rows carry. -->
+      <a href="https://abap2ui5.github.io/linter/" :target="SAME_TAB">Linter rules</a>
       <a href="https://github.com/abap2UI5/vscode-extension" target="_blank" rel="noopener">VS Code extension</a>
       <a href="/docs/advanced/mcp_server">MCP server</a>
       <a href="https://github.com/abap2UI5/app-template" target="_blank" rel="noopener">App template</a>

--- a/docs/.vitepress/theme/SiteBar.vue
+++ b/docs/.vitepress/theme/SiteBar.vue
@@ -20,11 +20,22 @@
  * <details> does not - a click anywhere outside it, and Escape. The same lines
  * as setUpExtra() in the playground's catalogue.mjs and extra.mjs.
  */
-import { inject, onMounted, ref, watch } from "vue";
+import { computed, inject, onMounted, ref, watch } from "vue";
 import { useData } from "vitepress";
 import { lastVisited } from "./site-memory.js";
 
-const { isDark } = useData();
+const { isDark, page } = useData();
+
+/* The released framework version - z2ui5_if_app=>version in
+ * abap2UI5/src/02/z2ui5_if_app.intf.abap is where the number comes from, and
+ * check:version (scripts/lib/release.mjs) holds this line against the newest
+ * release tag, the deprecations page and the changelog. It stood in a nav
+ * dropdown of its own until the bar was rebuilt around the four sections; the
+ * four entries under it - release notes, support, contribute, sponsor - were
+ * already in the menu below, so what was left of that dropdown was the
+ * NUMBER, and this is where the number went. Moving it means moving the
+ * pattern in release.mjs with it. */
+const VERSION = "1.144.0";
 
 /* The same three items serve the bar and the menu a phone opens instead of it
  * (`nav-screen-content-after`). Only the menu behind the third mark differs:
@@ -34,6 +45,18 @@ defineProps({ theme: { type: Boolean, default: true } });
 
 const PLAYGROUND = "https://abap2ui5.github.io/playground/";
 const SAMPLES = "https://abap2ui5.github.io/playground/samples/";
+/* The two sections of THIS deployment. Home is the page the brand has always
+ * opened and nothing else ever named; Documentation opens on the first page of
+ * the manual, which is where the Guide dropdown used to send a reader who
+ * clicked its first entry. Both are pages of this site, so neither needs the
+ * `target` the two above carry. */
+const HOME = "/docs/";
+const DOCS = "/docs/get_started/about";
+
+/* Which of the two is the one you are on. `relativePath` rather than the URL:
+ * it is what the server rendered as well, so the bar is right in the HTML and
+ * not only after hydration. */
+const onHome = computed(() => page.value.relativePath === "index.md");
 
 /* EVERY LINK OUT OF THIS SITE AND INTO A NEIGHBOURING ONE CARRIES A `target`,
  * and it is not decoration: without it the link does not arrive.
@@ -106,9 +129,13 @@ watch(isDark, (dark) => {
 
 <template>
   <nav class="bar-nav" aria-label="abap2UI5 sites">
-    <!-- The one you are on, which is why it is a span and not a link - the
-         look aria-current gets on the other three bars. -->
-    <span class="here" aria-current="page">Documentation</span>
+    <!-- The four sections of the project, left to right in the order a reader
+         meets them, and the one you are on marked. Home and Documentation are
+         two sections of THIS deployment now - the section that used to be one
+         non-clickable word ("Documentation") is two places a reader can move
+         between, which is what the brand alone could not offer. -->
+    <a :href="HOME" :class="{ here: onHome }" :aria-current="onHome ? 'page' : undefined" title="abap2UI5 in one page">Home</a>
+    <a :href="DOCS" :class="{ here: !onHome }" :aria-current="!onHome ? 'page' : undefined" title="The manual: guide, cookbook, reference">Documentation</a>
     <a :href="samplesHref" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
     <a :href="PLAYGROUND" :target="SAME_TAB" title="Write ABAP and run it in the browser">Playground</a>
   </nav>
@@ -126,6 +153,7 @@ watch(isDark, (dark) => {
         <span class="when-light"><span class="glyph" aria-hidden="true">☾</span>Switch to dark</span>
         <span class="when-dark"><span class="glyph" aria-hidden="true">☀</span>Switch to light</span>
       </button>
+      <span class="a2ui5-menu-head">Version {{ VERSION }}</span>
       <a href="https://github.com/abap2UI5/abap2UI5/issues" target="_blank" rel="noopener">Issues</a>
       <a href="/docs/resources/changelog">Release notes</a>
       <a href="/docs/get_started/quickstart">Install with abapGit</a>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -4,6 +4,7 @@ import DefaultTheme from 'vitepress/theme'
 import './style.css'
 import { setUpPlayground } from './playground.js'
 import SiteBar from './SiteBar.vue'
+import SearchBox from './SearchBox.vue'
 import { rememberHere } from './site-memory.js'
 
 /** @type {import('vitepress').Theme} */
@@ -18,6 +19,13 @@ export default {
   // menu after them.
   Layout() {
     return h(DefaultTheme.Layout, null, {
+      // The search, in the middle of the row. `nav-bar-content-before` is the
+      // FIRST thing in `.content-body`; style.css gives it auto margins, which
+      // is what centres it between the four sections on the left and the marks
+      // on the right. It is not in SiteBar because SiteBar is rendered twice -
+      // the bar and the screen a phone opens instead of it - and two search
+      // boxes in one document is two ids, two shortcuts and one of them wrong.
+      'nav-bar-content-before': () => h(SearchBox),
       'nav-bar-content-after': () => h(SiteBar),
       'nav-screen-content-after': () => h(SiteBar, { theme: false }),
     })

--- a/docs/.vitepress/theme/playground.js
+++ b/docs/.vitepress/theme/playground.js
@@ -117,6 +117,14 @@ function bar(container, demo, embed, source) {
   const open = document.createElement('a');
   open.className = 'a2ui5-play-open';
   open.textContent = 'Switch to Playground with this code';
+  /* In this tab, and out of VitePress's hands: the playground is same-origin
+   * and its path looks like a page, so without a `target` the router takes
+   * this link over, has no page of this site to render at it and shows the
+   * 404 instead. The reasoning is in scripts/lib/cross-site.mjs. The gate
+   * that holds the bar to this cannot see this link - it is built here, in a
+   * browser, from a URL the loader returns - so test/cross-site.test.mjs
+   * reads this line instead. */
+  open.target = '_self';
   /* Built by the loader rather than here: the fragment format is the
    * playground's, and a fragment it cannot read is quietly replaced by its own
    * sample — a wrong link that looks like a working one. An older loader that

--- a/docs/.vitepress/theme/search-engine.js
+++ b/docs/.vitepress/theme/search-engine.js
@@ -1,0 +1,170 @@
+/*
+ * The matcher behind the search box in the bar — framework-free on purpose.
+ *
+ * Four documents carry that box: this site, the playground, the sample
+ * catalogue and the per-sample pages. One of them is a Vue application and
+ * three are static HTML with a module or two, so anything shared between them
+ * has to be plain JavaScript with no imports. This file is that, and
+ * `src/shell/search-engine.mjs` in abap2UI5/playground is its copy — kept in
+ * step by hand, the same arrangement as the palette and site-memory. What is
+ * NOT copied is the index it reads: that is one generated document at
+ * /docs/search-index.json, fetched by whichever site the reader is on, because
+ * two copies of the DATA would be two answers to the same query.
+ *
+ * The ranking, in one sentence: a word you typed is worth most in a title,
+ * then in a class name, then in a heading, then in the summary or the
+ * keywords — and every word has to appear somewhere, so a second word narrows
+ * a search rather than widening it.
+ *
+ * There is no stemming and no fuzzy matching. The corpus is ~950 short
+ * entries of technical vocabulary — control names, ABAP class names, chapter
+ * titles — where a near-miss is usually a DIFFERENT control, and "close
+ * enough" answers are worse than none. A prefix match is as far as it goes,
+ * because that is what typing looks like before you have finished.
+ */
+
+/** Where the index lives — one document, on the origin all four sites share. */
+export const INDEX_URL = 'https://abap2ui5.github.io/docs/search-index.json';
+
+const normalise = (s) => (s || '').toLowerCase();
+/* A query is split the way the index was built (scripts/lib/pages.mjs): the
+ * dot and the underscore stay inside a word, everything else is a boundary. So
+ * `client->view_display( )` pasted out of a page is two terms, both of which
+ * are in the index, rather than one that is in nothing. */
+const words = (s) => normalise(s).split(/[^\p{L}\p{N}._]+/u)
+  .map((w) => w.replace(/^[._]+|[._]+$/g, ''))
+  .filter(Boolean);
+
+/* How much a word found in each field is worth. A title hit beats everything:
+ * the entries are short and their titles are what a reader is trying to
+ * remember. `code` is the ABAP class name, which is either exactly what
+ * somebody pasted in or irrelevant - hence high, and only on a prefix. */
+const FIELD = { title: 10, code: 8, heading: 5, text: 2, terms: 2, group: 1 };
+
+function scoreField(value, term, weight) {
+  if (!value) return 0;
+  const hay = normalise(value);
+  const at = hay.indexOf(term);
+  if (at < 0) return 0;
+  /* Where the word sits decides how much of the weight it earns: the whole
+   * field, the start of it, the start of any word in it, or somewhere inside
+   * a longer word - `list` in `ActionListItem` is a real hit and a weaker one
+   * than `list` in `List Report`. */
+  if (hay === term) return weight * 3;
+  if (at === 0) return weight * 2;
+  return /[^\p{L}\p{N}]/u.test(hay[at - 1] || '') ? weight : weight / 2;
+}
+
+/**
+ * The entries that match `query`, best first.
+ *
+ * Every term must be found somewhere in an entry, or the entry is out: typing
+ * a second word is how a reader narrows a result list, and a search that
+ * treats the words as alternatives grows the list instead, which reads as the
+ * box ignoring what you typed.
+ */
+export function search(entries, query, { limit = 30 } = {}) {
+  const terms = words(query);
+  if (!terms.length) return [];
+
+  const hits = [];
+  for (const e of entries) {
+    let total = 0;
+    let missed = false;
+    /* Which heading matched, so the result can offer the SECTION rather than
+     * the page - the difference between "Cookbook: Tables" and the paragraph
+     * about sorting. */
+    let heading = null;
+
+    for (const term of terms) {
+      let best = scoreField(e.title, term, FIELD.title)
+        + scoreField(e.code, term, FIELD.code)
+        + scoreField(e.text, term, FIELD.text)
+        + scoreField(e.terms, term, FIELD.terms)
+        + scoreField(e.group, term, FIELD.group);
+
+      for (const [text, anchor] of e.headings || []) {
+        const s = scoreField(text, term, FIELD.heading);
+        if (!s) continue;
+        best += s;
+        if (!heading || s > heading.score) heading = { text, anchor, score: s };
+      }
+
+      if (!best) { missed = true; break; }
+      total += best;
+    }
+    if (missed || !total) continue;
+
+    /* A shorter entry that scored the same is the better answer: the words
+     * are a larger part of what it is about. */
+    hits.push({ entry: e, score: total - Math.min(4, (e.title || '').length / 40), heading });
+  }
+
+  hits.sort((a, b) => b.score - a.score || (a.entry.title || '').localeCompare(b.entry.title || ''));
+  return hits.slice(0, limit);
+}
+
+/**
+ * The hits, grouped the way the index declares its areas — Documentation
+ * first, then each sample corpus — with at most `perGroup` in each, so one
+ * corpus of 636 ports cannot bury the four pages that explain them.
+ */
+export function grouped(hits, { perGroup = 6 } = {}) {
+  const order = [];
+  const byGroup = new Map();
+  for (const hit of hits) {
+    const key = hit.entry.area === 'docs' ? 'Documentation' : hit.entry.group;
+    if (!byGroup.has(key)) { byGroup.set(key, []); order.push(key); }
+    const rows = byGroup.get(key);
+    if (rows.length < perGroup) rows.push(hit);
+  }
+  /* Documentation first whenever it is in the answer at all. The reader who
+   * typed a word that is both a chapter and a control wants the explanation
+   * before the seven hundred examples of it. */
+  order.sort((a, b) => (a === 'Documentation' ? -1 : b === 'Documentation' ? 1 : 0));
+  return order.map((label) => ({ label, hits: byGroup.get(label) }));
+}
+
+/** The index, fetched once. Callers await this on the first keystroke, never
+ *  at load: a reader who does not search pays nothing for the box. */
+let pending = null;
+export function loadIndex(url = INDEX_URL, { fetchFn = globalThis.fetch } = {}) {
+  pending ??= fetchFn(url)
+    .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`search index: HTTP ${r.status}`))))
+    .catch((e) => { pending = null; throw e; });
+  return pending;
+}
+
+/** `text` split into the parts that matched `query` and the parts that did
+ *  not, as `[string, boolean][]` — for a result row that shows WHY it is in
+ *  the list. Markup is the caller's business; three documents draw it three
+ *  ways and none of them wants a string of HTML from here. */
+export function highlight(text, query) {
+  const terms = [...new Set(words(query))].sort((a, b) => b.length - a.length);
+  const hay = text || '';
+  if (!terms.length || !hay) return [[hay, false]];
+  const marks = [];
+  const low = hay.toLowerCase();
+  for (const term of terms) {
+    let from = 0;
+    for (;;) {
+      const at = low.indexOf(term, from);
+      if (at < 0) break;
+      marks.push([at, at + term.length]);
+      from = at + term.length;
+    }
+  }
+  if (!marks.length) return [[hay, false]];
+  marks.sort((a, b) => a[0] - b[0]);
+  const out = [];
+  let at = 0;
+  for (const [start, end] of marks) {
+    if (end <= at) continue;
+    const from = Math.max(start, at);
+    if (from > at) out.push([hay.slice(at, from), false]);
+    out.push([hay.slice(from, end), true]);
+    at = end;
+  }
+  if (at < hay.length) out.push([hay.slice(at), false]);
+  return out;
+}

--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -54,12 +54,21 @@ export function rememberHere(site = "docs") {
  * A stored value is untrusted: anything running on this origin can put
  * anything in it, and a stale one outlives the page it named. So it is not
  * returned, it is CHECKED - resolved against this origin first, and kept only
- * if what comes back is still inside `fallback`'s own path. That is what turns
+ * if what comes back is still inside `scope`, which is `fallback`'s own path
+ * unless the caller names a wider one.
+ *
+ * `scope` is for a link written DEEPER than the section it restores inside:
+ * the other three bars point Documentation at the first page of the manual and
+ * still come back to wherever the reader was in it (`data-scope` on the link
+ * over there, src/shell/site-memory.mjs). It is a value the CALLER passes,
+ * never one that comes out of storage, so it widens nothing - what may be
+ * restored is still declared by this document and still checked against this
+ * origin. That is what turns
  * "//elsewhere/x" (a different origin), "/docs/../x" (a path that normalises
  * out of the section) and "javascript:…" (an origin of "null") into three
  * values that are simply ignored.
  */
-export function lastVisited(site, fallback) {
+export function lastVisited(site, fallback, scope = fallback) {
   if (typeof localStorage === "undefined") return fallback;
   try {
     const last = localStorage.getItem(KEY[site]);
@@ -68,7 +77,7 @@ export function lastVisited(site, fallback) {
      * unchanged on a dev server where the three sites sit at other paths - and
      * so a link to another HOST, which shares no storage and therefore has
      * nothing to restore, falls through the origin test. */
-    const base = new URL(fallback, location.href);
+    const base = new URL(scope, location.href);
     if (base.origin !== location.origin) return fallback;
     const target = new URL(last, location.origin);
     if (target.origin !== location.origin) return fallback;

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1387,19 +1387,50 @@
   max-width: none;
 }
 
+/* ONE ROW, AND THE BRAND IS PART OF IT.
+ *
+ * The theme has two nav layouts, and the second one is the reason this block
+ * exists. On a page with a sidebar it places the brand ABSOLUTELY over the
+ * sidebar's column and pads the content strip by the sidebar's width, so that
+ * the two line up with the columns below them. That is a good decision for a
+ * bar whose only job is to sit on top of this site - and it puts a 272px gap
+ * between the brand and the first thing after it, which is exactly where the
+ * four sections now go. Left of the gap: the mark. Right of it: everything.
+ *
+ * So the brand is placed in the row like any other item, at every width, and
+ * the content strip beside it starts where the brand ends. The bar reads as
+ * one row across the whole width - which is what the catalogue's bar already
+ * was, and what the sections needed to sit next to the name. */
 @media (min-width: 960px) {
   .Layout .VPNav .VPNavBar.has-sidebar .wrapper {
-    padding: 0;
+    padding: 0 0 0 20px;
   }
 
   .Layout .VPNav .VPNavBar.has-sidebar .title {
-    padding: 0 20px;
-    width: var(--vp-sidebar-width);
+    position: static;
+    padding: 0;
+    width: auto;
   }
 
   .Layout .VPNav .VPNavBar.has-sidebar .content {
     padding-right: 20px;
-    padding-left: var(--vp-sidebar-width);
+    padding-left: 0;
+  }
+}
+
+/* The same two rules again for the width at which the theme centres the bar
+ * over the page: from 1440px it recomputes the brand's width and the strip's
+ * padding from the layout's max width, and both terms are the sidebar again.
+ * Left as they were, the gap comes back on a wide screen only. */
+@media (min-width: 1440px) {
+  .Layout .VPNav .VPNavBar.has-sidebar .title {
+    padding-left: 0;
+    width: auto;
+  }
+
+  .Layout .VPNav .VPNavBar.has-sidebar .content {
+    padding-right: 20px;
+    padding-left: 0;
   }
 }
 
@@ -1412,13 +1443,31 @@
 /* ---------------------------------------------------- the row's order ---
  *
  * `.content-body` is a flex row, so the slot's content can be moved without
- * moving it in the DOM: search and the menus keep the default 0, the three
- * sites come next, then the marks, then the menu behind the third mark. The
- * hamburger stays last. */
+ * moving it in the DOM. Three groups, in this order:
+ *
+ *   the four sections   hard against the brand, which is what "the menu on
+ *                       the left" means: a reader's eye starts at the mark and
+ *                       the next thing it meets is where they can go
+ *   the search          in the middle, on auto margins - it takes whatever is
+ *                       left between the sections and the marks, so it is
+ *                       centred in the row's free space at every width
+ *                       rather than at a number that is only right on one
+ *                       screen
+ *   the rest            the two marks and the menu behind the last button,
+ *                       right, where they were
+ *
+ * The DOM order is search (`nav-bar-content-before`), then the sections and
+ * the menu (`nav-bar-content-after`); `order` is what makes the row read
+ * left to right. The hamburger stays last. */
 .Layout .VPNav .VPNavBar .bar-nav { order: 1; }
+.Layout .VPNav .VPNavBar .a2ui5-search-button { order: 2; margin: 0 auto; }
 .Layout .VPNav .VPNavBar .social-links { order: 3; }
 .Layout .VPNav .VPNavBar .a2ui5-extra { order: 4; }
 .Layout .VPNav .VPNavBar .hamburger { order: 5; }
+
+/* The theme's own search slot, which is empty now (no `search` provider in
+ * config.mjs) but still laid out with a width and a margin on some widths. */
+.Layout .VPNav .VPNavBar .search { display: none; }
 
 /* The theme's own "…" menu, shown between 768 and 1279px with its appearance
  * switch and its social links in it. The menu behind the third mark replaces
@@ -1444,31 +1493,24 @@
   display: none;
 }
 
-/* ------------------------------------------------------- the three sites ---
+/* ------------------------------------------------------ the four sections ---
  *
  * The catalogue's `.bar-nav`, to the pixel: 5px pills in the dim colour, the
  * hover filling with the PAGE background — lighter than the bar it sits on,
  * which is what makes the pill read as raised rather than as a hole — and the
- * one you are on in full colour and semibold. */
+ * one you are on in full colour and semibold.
+ *
+ * They stand directly after the brand now, which is where the hairline that
+ * used to be in front of them went: the brand draws one of its own
+ * (`a.title::after`), and two lines with 6px between them is not a separator,
+ * it is a stutter. The 6px left margin is the 16 that line stands from the
+ * first word — 10 of the link's own padding, 6 here. */
 .Layout .VPNav .bar-nav {
   display: flex;
   align-items: center;
   gap: 4px;
-  /* The theme's menu links carry 12px of padding; 4 more is the 16 the line
-   * below stands from the word before it. */
-  margin-left: 4px;
+  margin-left: 6px;
   line-height: 1.55;
-}
-
-/* A hairline in front of the three sites, 16px from the word on either side
- * of it: the margin above before it, 2 + the gap 4 + the link's padding 10
- * after. */
-.Layout .VPNav .bar-nav::before {
-  content: "";
-  width: 1px;
-  height: 22px;
-  margin-right: 2px;
-  background: var(--line);
 }
 
 .Layout .VPNav .bar-nav a,
@@ -1663,6 +1705,232 @@
   fill: currentColor;
 }
 
+/* --------------------------------------------------------- the search ---
+ *
+ * One box for the whole project: the pages of this site and every sample in
+ * the three catalogues, over one index (theme/SearchBox.vue, and
+ * scripts/lib/search-index.mjs for what is in it).
+ *
+ * In the bar it is drawn as the FIELD it opens rather than as a glyph. A
+ * magnifier alone is a button somebody has to guess at; a field with a word in
+ * it says both what it does and that it takes text. The shortcut is printed
+ * inside it for the same reason - it is the only place a reader would find it
+ * without being told.
+ *
+ * The numbers are the bar's own: 30px tall like the marks beside it, the 5px
+ * radius of the section pills, the sunken grey's neighbour for the fill so the
+ * field reads as recessed into a bar that is already grey. */
+.Layout .VPNav .a2ui5-search-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  height: 30px;
+  min-width: 220px;
+  max-width: 380px;
+  flex: 0 1 320px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--fg-dim);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.25s, color 0.25s;
+}
+
+.Layout .VPNav .a2ui5-search-button:hover {
+  border-color: var(--fg-dim);
+  color: var(--fg);
+}
+
+.Layout .VPNav .a2ui5-search-button svg {
+  width: 15px;
+  height: 15px;
+  flex: none;
+}
+
+.Layout .VPNav .a2ui5-search-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a2ui5-search-key {
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg-sunken);
+  color: var(--fg-dim);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+/* On a phone the field is a glyph: the row has to hold the brand, the
+ * hamburger and this, and a 220px field is the thing that does not fit. */
+@media (max-width: 767px) {
+  .Layout .VPNav .a2ui5-search-button {
+    min-width: 0;
+    flex: none;
+    padding: 0 7px;
+  }
+
+  .Layout .VPNav .a2ui5-search-label,
+  .Layout .VPNav .a2ui5-search-key {
+    display: none;
+  }
+}
+
+/* ---- what it opens ----
+ *
+ * A dialog over a dimmed page, near the top: the results are read downwards,
+ * and a panel centred vertically puts the first one under the reader's hands
+ * rather than under their eyes. `--vp-z-index-*` is not used - the bar itself
+ * is z-index 30 in this theme and this has to cover it. */
+.a2ui5-search-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  justify-content: center;
+  padding: 12vh 16px 16px;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.a2ui5-search-panel {
+  display: flex;
+  flex-direction: column;
+  width: min(680px, 100%);
+  max-height: 76vh;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.a2ui5-search-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.a2ui5-search-field svg {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  color: var(--fg-dim);
+}
+
+.a2ui5-search-field input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  font-size: 16px;
+  outline: none;
+}
+
+/* The browser's own clear button for `type=search`, which arrives in three
+ * different drawings and none of them this palette's. */
+.a2ui5-search-field input::-webkit-search-cancel-button { display: none; }
+
+.a2ui5-search-close {
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg-sunken);
+  color: var(--fg-dim);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.a2ui5-search-results {
+  padding: 6px;
+  overflow-y: auto;
+}
+
+.a2ui5-search-note {
+  margin: 0;
+  padding: 14px 10px;
+  color: var(--fg-dim);
+  font-size: 13px;
+}
+
+.a2ui5-search-note kbd {
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+}
+
+/* WHICH AREA A RESULT CAME FROM IS THE POINT. The whole reason this box exists
+ * is that the answer is sometimes a page and sometimes one of 772 samples in
+ * another repository, so the group heading is not decoration - it is what
+ * tells the reader which of the two they are about to open. */
+.a2ui5-search-group-head {
+  padding: 10px 10px 4px;
+  color: var(--fg-dim);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.a2ui5-search-hit {
+  display: block;
+  padding: 8px 10px;
+  border-radius: 6px;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.a2ui5-search-hit.active {
+  background: var(--bg-sunken);
+}
+
+.a2ui5-search-hit-title {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.a2ui5-search-hit-where {
+  color: var(--accent);
+  font-size: 13px;
+}
+
+.a2ui5-search-hit-code {
+  display: block;
+  color: var(--fg-dim);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11.5px;
+}
+
+.a2ui5-search-hit-text {
+  display: block;
+  margin-top: 2px;
+  color: var(--fg-dim);
+  font-size: 12.5px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+/* The part you typed, wherever it turned up. Not a background fill: a hit's
+ * title can be half query, and half a row in a highlight colour reads as a
+ * selection rather than as an explanation. */
+.a2ui5-search-hit .hl {
+  color: var(--accent);
+  font-weight: 700;
+}
+
 /* -------------------------------------------------------- and narrower ---
  *
  * The theme folds its menu into a hamburger below 768px, and the three sites
@@ -1676,6 +1944,14 @@
   .Layout .VPNav .VPNavBar .bar-nav,
   .Layout .VPNav .VPNavBar .social-links {
     display: none;
+  }
+
+  /* The search stays. It is the one thing on a phone that answers a question
+   * without a menu first, so it keeps the row and loses its label to the
+   * glyph. */
+  .Layout .VPNav .VPNavBar .a2ui5-search-button {
+    margin-left: auto;
+    margin-right: 4px;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "homepage": "https://github.com/abap2UI5/docs#readme",
   "scripts": {
-    "docs:dev": "node scripts/generate-llms.mjs && vitepress dev docs",
-    "docs:build": "node scripts/generate-llms.mjs && vitepress build docs",
+    "docs:dev": "node scripts/generate-llms.mjs && node scripts/generate-search.mjs && vitepress dev docs",
+    "docs:build": "node scripts/generate-llms.mjs && node scripts/generate-search.mjs && vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "check:examples": "node scripts/check-examples.mjs",
     "check:conventions": "node scripts/check-conventions.mjs",
@@ -29,6 +29,7 @@
     "test": "node --test test/*.test.mjs",
     "check": "npm run test && npm run check:version && npm run docs:build && npm run check:cross-site && npm run check:examples && npm run check:conventions && npm run check:playground && npm run check:api-names && npm run check:api-reference && npm run check:samples",
     "llms": "node scripts/generate-llms.mjs",
+    "search": "node scripts/generate-search.mjs",
     "check:version": "node scripts/check-version.mjs"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:conventions": "node scripts/check-conventions.mjs",
     "fmt:chains": "node scripts/check-conventions.mjs --fix",
     "check:playground": "node scripts/check-playground.mjs",
+    "check:cross-site": "node scripts/check-cross-site.mjs",
     "runnable": "node scripts/list-runnable.mjs",
     "check:api-names": "node scripts/check-api-names.mjs",
     "generate:api": "node scripts/generate-api-reference.mjs",
@@ -26,7 +27,7 @@
     "link:samples": "node scripts/link-samples.mjs",
     "check:samples": "node scripts/link-samples.mjs --check",
     "test": "node --test test/*.test.mjs",
-    "check": "npm run test && npm run check:version && npm run docs:build && npm run check:examples && npm run check:conventions && npm run check:playground && npm run check:api-names && npm run check:api-reference && npm run check:samples",
+    "check": "npm run test && npm run check:version && npm run docs:build && npm run check:cross-site && npm run check:examples && npm run check:conventions && npm run check:playground && npm run check:api-names && npm run check:api-reference && npm run check:samples",
     "llms": "node scripts/generate-llms.mjs",
     "check:version": "node scripts/check-version.mjs"
   },

--- a/scripts/check-cross-site.mjs
+++ b/scripts/check-cross-site.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Can a reader actually get from this site to the ones next to it?
+//
+// The three sites share an origin, and a same-origin link that looks like a
+// page is taken over by VitePress's router — which then cannot find a page of
+// THIS site behind /playground/ and renders the 404 instead. Every link out of
+// the manual and into a neighbouring deployment was broken that way at once:
+// both bar items, the Linter rules row in the menu, and the Run bar's link
+// into the playground. The whole reasoning is at the top of
+// scripts/lib/cross-site.mjs.
+//
+// The fix is one attribute — `target="_self"`, which the router honours as an
+// opt-out and which is also the one-tab behaviour the four bars promise — and
+// an attribute is exactly the kind of thing that gets left off the next link
+// somebody adds. So it is decided here, against the BUILT site: what ships is
+// what a reader clicks.
+//
+// Usage: node scripts/check-cross-site.mjs [--list]
+//   Needs docs/.vitepress/dist, so run it after `npm run docs:build`.
+//   --list prints every cross-site link it found, by destination.
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { crossSiteLinks, SITE } from './lib/cross-site.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = join(ROOT, 'docs/.vitepress/dist');
+const LIST = process.argv.includes('--list');
+
+if (!existsSync(DIST)) {
+  console.error(`check-cross-site: no built site at ${relative(ROOT, DIST)}.`);
+  console.error('This gate reads what ships, not the sources. Run `npm run docs:build` first.');
+  process.exit(1);
+}
+
+const walk = (dir) =>
+  readdirSync(dir).flatMap((e) => {
+    const p = join(dir, e);
+    return statSync(p).isDirectory() ? walk(p) : [p];
+  });
+
+const pages = walk(DIST).filter((f) => f.endsWith('.html')).sort();
+const broken = [];
+const destinations = new Map();
+
+for (const file of pages) {
+  const page = relative(DIST, file);
+  /* The page's own address, because a relative href on it resolves against
+   * THAT and not against the site root. */
+  const from = SITE.origin + SITE.base + page;
+  for (const link of crossSiteLinks(readFileSync(file, 'utf8'), from)) {
+    destinations.set(link.url, (destinations.get(link.url) ?? 0) + 1);
+    if (!link.exempt) broken.push({ page, ...link });
+  }
+}
+
+/* Both floors. A gate that walked nothing and a gate that found nothing wrong
+ * print the same line, and this site has been burned by that once already —
+ * check:examples ran no rules at all for years and reported `0 issue(s)`. The
+ * bar is on every page of the site, so "no cross-site link anywhere" is not a
+ * clean site, it is a broken walk. */
+if (pages.length === 0) {
+  console.error(`check-cross-site: ${relative(ROOT, DIST)} holds no .html at all — did the build fail?`);
+  process.exit(1);
+}
+if (destinations.size === 0) {
+  console.error(`check-cross-site: walked ${pages.length} page(s) and found no link to a neighbouring site.`);
+  console.error('The bar carries three of them on every page, so this is the walk failing, not the');
+  console.error('site being clean — has the bar moved out of the HTML, or the origin changed?');
+  process.exit(1);
+}
+
+const total = [...destinations.values()].reduce((a, b) => a + b, 0);
+console.log(
+  `check-cross-site: ${total} link(s) out of ${pages.length} page(s) into `
+  + `${destinations.size} neighbouring destination(s) on ${SITE.origin}`,
+);
+
+if (LIST) {
+  for (const [url, count] of [...destinations].sort()) console.log(`  ${String(count).padStart(5)}  ${url}`);
+}
+
+if (broken.length) {
+  const byHref = new Map();
+  for (const one of broken) {
+    if (!byHref.has(one.href)) byHref.set(one.href, []);
+    byHref.get(one.href).push(one.page);
+  }
+  console.error(`\n${broken.length} link(s) into a neighbouring site carry no \`target\`:\n`);
+  for (const [href, where] of byHref) {
+    console.error(`  - ${href}`);
+    console.error(`      on ${where.length} page(s), e.g. ${where[0]}`);
+  }
+  console.error('\nA same-origin link that looks like a page is taken over by VitePress\'s router,');
+  console.error('which has no page of THIS site to render at that address and shows the 404 —');
+  console.error('at the neighbour\'s URL, so it reads as the other site being broken.');
+  console.error('\nAdd the attribute where the link is written:');
+  console.error('\n  <a href="https://abap2ui5.github.io/playground/" target="_self">Playground</a>');
+  console.error('\n`_self` because these sites are one site and open in one tab; any `target` opts');
+  console.error('the link out of the router. scripts/lib/cross-site.mjs says why in full.');
+  process.exit(1);
+}
+
+console.log('every link into a neighbouring deployment opts out of the router. All of them lead somewhere.');

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -40,108 +40,19 @@
  */
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
-import config from '../docs/.vitepress/config.mjs';
 import { countCatalogue } from './lib/catalogue.mjs';
+/* The page walk and the two things read out of a page are in lib/pages.mjs,
+ * shared with generate-search.mjs: what counts as a page of this site is one
+ * answer, not one per generator. */
+import {
+  ROOT, DOCS, SITE,
+  sidebarPages, markdownFiles, mdSuffix, linkOf, fileOf,
+  stripFrontmatter, summarise, title,
+} from './lib/pages.mjs';
 
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const DOCS = path.join(ROOT, 'docs');
 const PUBLIC = path.join(DOCS, 'public');
-const SITE = 'https://abap2ui5.github.io/docs';
 
 /* ------------------------------------------------------------- the pages */
-
-/** Every sidebar entry with a local link, in sidebar order, first one wins:
- *  several groups deliberately point their own heading at their first page. */
-function sidebarPages() {
-  const seen = new Set();
-  const out = [];
-  const walk = (nodes, section) => {
-    for (const node of nodes || []) {
-      // a top-level group names the section everything under it belongs to
-      const here = section ?? node.text;
-      if (node.link?.startsWith('/') && !seen.has(node.link)) {
-        seen.add(node.link);
-        out.push({ section: here, text: node.text, link: node.link });
-      }
-      walk(node.items, here);
-    }
-  };
-  walk(config.themeConfig.sidebar, null);
-  return out;
-}
-
-function markdownFiles(dir, out = []) {
-  for (const name of fs.readdirSync(dir)) {
-    if (name === '.vitepress' || name === 'public' || name === 'node_modules') continue;
-    const full = path.join(dir, name);
-    if (fs.statSync(full).isDirectory()) markdownFiles(full, out);
-    else if (full.endsWith('.md')) out.push(full);
-  }
-  return out;
-}
-
-/* A page link and the file behind it are NOT a plain `.md` suffix apart.
- * VitePress serves `<dir>/index.md` at `<dir>/`, so the trailing slash IS the
- * index page, and `docs/index.md` (the home page) is the same rule at the
- * root - which is why the orphan filter below used to carry a hand-written
- * `/index` exception. Everything that converts between the two goes through
- * mdSuffix, or a directory index resolves to `<dir>/.md` and takes the build
- * down, which is exactly what happened the first time a section grew one. */
-const mdSuffix = (link) => (link.endsWith('/') ? `${link}index.md` : `${link}.md`);
-const linkOf = (file) => {
-  const rel = path.relative(DOCS, file).replace(/\\/g, '/');
-  if (rel === 'index.md') return '/';
-  if (rel.endsWith('/index.md')) return `/${rel.slice(0, -'index.md'.length)}`;
-  return `/${rel.replace(/\.md$/, '')}`;
-};
-const fileOf = (link) => path.join(DOCS, mdSuffix(link).slice(1));
-
-/* ------------------------------------------------------------ the content */
-
-const stripFrontmatter = (text) => text.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '');
-
-/** The first real sentence of a page, for the one-line note in the index.
- *
- *  The WHOLE first paragraph is collected before cutting: the sources are hard
- *  wrapped, so stopping at the newline would end half the notes mid-sentence.
- *
- *  Link syntax and `*` emphasis are flattened, and backticks with them - but
- *  NOT the underscore. Almost every identifier this documentation is about
- *  carries one (`_bind`, `check_on_init`, `s_device`), and an index that
- *  advertises `client->bind( )` is worse than no index: it is a plausible,
- *  citable, wrong API name aimed at the one reader least able to notice. */
-function summarise(body) {
-  const lines = stripFrontmatter(body).split('\n');
-  const para = [];
-  let inFence = false;
-  for (const line of lines) {
-    if (line.startsWith('```')) { inFence = !inFence; continue; }
-    if (inFence) continue;
-    const t = line.trim();
-    if (!para.length) {
-      if (!t || t.startsWith('#') || t.startsWith(':::') || t.startsWith('|') || t.startsWith('<')) continue;
-      para.push(t);
-      continue;
-    }
-    if (!t) break; // the paragraph ended
-    para.push(t);
-  }
-  const plain = para.join(' ')
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
-    .replace(/[*`]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (!plain) return '';
-  // cut at the end of the first sentence, but not so early that the note says
-  // nothing; a period inside `sap.m.Table` or `1.71` is not a sentence end
-  const stop = plain.search(/\.(?=\s|$)|:\s—|\s—\s/);
-  const first = stop > 40 ? plain.slice(0, stop + 1) : plain;
-  return first.length > 220 ? `${first.slice(0, 217)}...` : first;
-}
-
-const title = (body, fallback) =>
-  (stripFrontmatter(body).match(/^#\s+(.+?)\s*$/m) || [, fallback])[1].trim();
 
 /* -------------------------------------------------------------------- run */
 

--- a/scripts/generate-search.mjs
+++ b/scripts/generate-search.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// The search index the bar reads: every page of this site, every sample in the
+// three catalogues, one JSON document at /docs/search-index.json.
+//
+// Runs inside `docs:build`, before vitepress, so the file is in docs/public/
+// when the build copies it - the same arrangement as generate-llms.mjs, and
+// for the same reason: it is a projection of the pages and the catalogues next
+// to it, so it is generated on every build and gitignored rather than
+// committed stale.
+//
+// A missing sample catalogue costs its rows and never the build. The pages are
+// different: a build that indexed no page of its own site has not found a
+// catalogue, it has found nothing, and it fails.
+//
+// Usage: node scripts/generate-search.mjs
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { ROOT, DOCS } from './lib/pages.mjs';
+import { buildIndex } from './lib/search-index.mjs';
+
+const OUT = path.join(DOCS, 'public', 'search-index.json');
+
+const index = await buildIndex(ROOT, { log: (line) => console.log(line) });
+
+const docs = index.entries.filter((e) => e.area === 'docs').length;
+const samples = index.entries.length - docs;
+
+/* The floor. An index with no page in it is a broken walk - the sidebar moved,
+ * or config.mjs stopped exporting one - and an empty search box that reports
+ * nothing wrong is how a reader concludes the site has no page about their
+ * question. */
+if (docs === 0) {
+  console.error('generate-search: not one page of this site is in the index.');
+  console.error('The pages come from the sidebar in docs/.vitepress/config.mjs — has it moved?');
+  process.exit(1);
+}
+
+fs.mkdirSync(path.dirname(OUT), { recursive: true });
+fs.writeFileSync(OUT, JSON.stringify(index));
+
+const kb = Math.round(fs.statSync(OUT).size / 1024);
+console.log(`search-index.json: ${docs} page(s) + ${samples} sample(s) (${kb} kB)`);

--- a/scripts/lib/catalogue.mjs
+++ b/scripts/lib/catalogue.mjs
@@ -69,18 +69,62 @@ const PUBLISHED = (repo) => `https://raw.githubusercontent.com/abap2UI5/${repo}/
  *  entries; where the entries themselves are in hand, counting them is the
  *  answer that cannot have gone stale separately. */
 export function countEntries(catalogue) {
-  if (!catalogue || typeof catalogue !== 'object') return 0;
-  let n = 0;
+  return entriesOf(catalogue).length;
+}
+
+/** The entries themselves, by the same shape rule countEntries counts by -
+ *  something with a class name and a pointer to its source file, under
+ *  whatever key this repository happens to keep them (`samples` here and in
+ *  samples-stack, `ports` in samples-controls).
+ *
+ *  countEntries is `entriesOf(...).length` and not a second walk, because the
+ *  search index and the figure in llms.txt disagreeing about what a sample is
+ *  would be a bug nobody could see: both numbers look plausible. */
+export function entriesOf(catalogue) {
+  if (!catalogue || typeof catalogue !== 'object') return [];
+  const out = [];
   for (const value of Object.values(catalogue)) {
     if (!Array.isArray(value)) continue;
     for (const entry of value) {
       if (!entry || typeof entry !== 'object') continue;
       const cls = entry.class;
       const file = entry.file ?? entry.path;
-      if (typeof cls === 'string' && cls.trim() && typeof file === 'string' && file.trim()) n++;
+      if (typeof cls === 'string' && cls.trim() && typeof file === 'string' && file.trim()) out.push(entry);
     }
   }
-  return n;
+  return out;
+}
+
+/** A whole `catalogue.json` for `repo`, for a caller that wants the entries
+ *  rather than how many there are: a checkout's copy first, then the one the
+ *  repository publishes on its default branch, then null.
+ *
+ *  The SAMPLES.md step countCatalogue carries is deliberately not here. That
+ *  parser answers "how many rows", and a row is a title and a class; the index
+ *  wants what an entry declares about itself - its summary, its keywords, the
+ *  library it belongs to. A repository reachable only as a rendered table
+ *  contributes no search entries rather than worse ones. */
+export async function loadCatalogue(repo, root, { fetchFn = globalThis.fetch } = {}) {
+  const dirs = HOMES[repo];
+  if (!dirs) throw new Error(`no catalogue location known for ${repo}`);
+  for (const dir of dirs) {
+    const at = dir.endsWith('_HOME') ? process.env[dir] : path.join(root, dir);
+    if (!at) continue;
+    const json = path.join(at, 'catalogue.json');
+    if (!fs.existsSync(json)) continue;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(json, 'utf8'));
+      if (countEntries(parsed) > 0) return { catalogue: parsed, source: 'checkout catalogue.json' };
+    } catch { /* fall through to the next home, then to the network */ }
+  }
+  try {
+    const res = await fetchFn(PUBLISHED(repo), { signal: AbortSignal.timeout(10_000) });
+    if (res && res.ok) {
+      const parsed = JSON.parse(await res.text());
+      if (countEntries(parsed) > 0) return { catalogue: parsed, source: 'published catalogue.json' };
+    }
+  } catch { /* no network, no entries - never a broken build */ }
+  return null;
 }
 
 /** How many apps `repo` lists today: `{ count, source }`, or null if no

--- a/scripts/lib/cross-site.mjs
+++ b/scripts/lib/cross-site.mjs
@@ -1,0 +1,138 @@
+/*
+ * Which links leave this deployment without leaving the origin — and why every
+ * one of them has to carry a `target`.
+ *
+ * The documentation, the playground, the sample catalogue and the linter's
+ * rule pages are separate deployments on ONE origin
+ * (abap2ui5.github.io/docs, /playground, /playground/samples, /linter). That
+ * shared origin is deliberate: it is what lets the four bars share a theme and
+ * a position memory through one localStorage. It is also what breaks a plain
+ * link between them.
+ *
+ * This site is a single page application. VitePress's router listens for
+ * clicks on the whole window and takes any link over that is same-origin and
+ * looks like a page — `origin === currentUrl.origin && treatAsHtml(pathname)`,
+ * in vitepress/dist/client/app/router.js. `/playground/` passes both tests, so
+ * the router pushed the URL, looked for a page of THIS site to render at it,
+ * found none — the playground is another deployment, not a page of the manual
+ * — and drew this site's own 404 in its place. The address bar said
+ * /playground/ and the document said PAGE NOT FOUND. A reload loaded the real
+ * page, which is exactly what a failed SPA route change looks like from the
+ * outside, and is why this reads as "sometimes broken" rather than as a dead
+ * link.
+ *
+ * Every way out of the manual was affected: both bar items, the Linter rules
+ * row in the menu, and the Run bar's "Switch to Playground with this code".
+ *
+ * The router's own escape hatch is the line above those two tests — a link
+ * carrying a `target` attribute is left alone, whatever the value — so
+ * `target="_self"` opts a link out of the SPA and keeps the one-tab behaviour
+ * the four bars promise. That is what this module decides: which links need
+ * it, so scripts/check-cross-site.mjs can hold the built site to it.
+ *
+ * A link to another HOST needs nothing. The router never looks at github.com,
+ * and VitePress's markdown renderer gives every external link in a page a
+ * `target="_blank"` of its own. Only hand-written markup pointing at
+ * abap2ui5.github.io outside /docs/ can get this wrong, which is why it did.
+ */
+
+/** Where this site is published, and the path that is its own. */
+export const SITE = {
+  origin: 'https://abap2ui5.github.io',
+  base: '/docs/',
+};
+
+/*
+ * VitePress's own extension list, copied out of
+ * vitepress/dist/client/shared.js rather than imported: this runs in Node
+ * against built HTML, that ships to a browser, and a gate that silently
+ * followed a dependency's internal module would stop being a statement about
+ * what the router does. Copied, like the palette the three sites share — with
+ * the same rule: when it moves over there, move it here.
+ *
+ * It matters because it is the difference between a link that needs the
+ * attribute and one that does not. /playground/ has no extension, so the
+ * router treats it as a page and takes it over. /samples/catalogue.json ends
+ * in a known extension, so the router leaves it alone and no attribute is
+ * needed — demanding one there would be a rule nobody could justify from what
+ * the router does.
+ */
+const KNOWN_EXTENSIONS = new Set(
+  ('3g2,3gp,aac,ai,apng,au,avif,bin,bmp,cer,class,conf,crl,css,csv,dll,'
+    + 'doc,eps,epub,exe,gif,gz,ics,ief,jar,jpe,jpeg,jpg,js,json,jsonld,m4a,'
+    + 'man,mid,midi,mjs,mov,mp2,mp3,mp4,mpe,mpeg,mpg,mpp,oga,ogg,ogv,ogx,'
+    + 'opus,otf,p10,p7c,p7m,p7s,pdf,png,ps,qt,roff,rtf,rtx,ser,svg,t,tif,'
+    + 'tiff,tr,ts,tsv,ttf,txt,vtt,wav,weba,webm,webp,woff,woff2,xhtml,xml,'
+    + 'yaml,yml,zip').split(','),
+);
+
+/** Would the router treat this path as a page of the site? */
+export function treatAsHtml(pathname) {
+  const ext = pathname.split('.').pop();
+  return ext == null || !KNOWN_EXTENSIONS.has(ext.toLowerCase());
+}
+
+/**
+ * The URL this href points at, if following it leaves this deployment while
+ * staying on its origin — the one case the router gets wrong. `null` for
+ * everything else: a page of this site, another host, a mailto:, a file the
+ * router would not touch.
+ *
+ * `from` is the page the link is written on, and it is not optional in
+ * practice: a cookbook page links its neighbours as `./../model/x.html`, and
+ * resolving that against the site ROOT rather than against the page turns a
+ * dozen ordinary in-site links into cross-site ones. The default is the front
+ * page, for a caller holding a link and no page.
+ */
+export function leavesTheSite(href, from = SITE.origin + SITE.base) {
+  let url;
+  try {
+    /* Resolved the way the browser resolves it on that page, so the absolute
+     * form, the root-relative one and the relative one are one case. */
+    url = new URL(href, new URL(from, SITE.origin));
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  if (url.origin !== SITE.origin) return null;
+  if (url.pathname.startsWith(SITE.base)) return null;
+  if (!treatAsHtml(url.pathname)) return null;
+  return url;
+}
+
+/* An <a> tag with its attributes, quotes respected so a `>` inside a title
+ * does not end the tag early. */
+const TAG = /<a\b((?:"[^"]*"|'[^']*'|[^>"'])*)>/gi;
+const attribute = (attrs, name) => {
+  const m = new RegExp(`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i').exec(attrs);
+  return m ? (m[1] ?? m[2] ?? m[3]) : null;
+};
+
+/**
+ * Every link in one document that leaves this deployment for a neighbouring
+ * one, each with the two things that decide whether it works: whether it
+ * carries a `target`, and whether it is a download (the router's other
+ * exemption). `from` is the page's own URL, which its relative links are
+ * resolved against.
+ *
+ * What this cannot see is a link built in the browser — the Run bar's
+ * "Switch to Playground with this code" is created by
+ * docs/.vitepress/theme/playground.js from a URL the playground's loader
+ * returns, and is nowhere in the HTML. It carries the attribute where it is
+ * created, and test/cross-site.test.mjs pins that.
+ */
+export function crossSiteLinks(html, from) {
+  const found = [];
+  for (const [, attrs] of html.matchAll(TAG)) {
+    const href = attribute(attrs, 'href');
+    if (href == null) continue;
+    const url = leavesTheSite(href, from);
+    if (!url) continue;
+    found.push({
+      href,
+      url: url.href,
+      exempt: /(?:^|\s)target\s*=/i.test(attrs) || /(?:^|\s)download(?:[\s=]|$)/i.test(attrs),
+    });
+  }
+  return found;
+}

--- a/scripts/lib/pages.mjs
+++ b/scripts/lib/pages.mjs
@@ -1,0 +1,179 @@
+/*
+ * pages — the site's own pages, as the sidebar declares them, plus the two
+ * things every generator wants out of one: its title and its first sentence.
+ *
+ * This was all inside generate-llms.mjs, which was the only program that
+ * needed it. The search index is the second, and a second copy of "what is a
+ * page of this site" is exactly the kind of copy that answers differently six
+ * months later — the sidebar grows a section, one generator learns about it
+ * and the other does not. So the walk lives here, both import it, and a page
+ * added to the sidebar is added to llms.txt AND to the search in one edit.
+ *
+ * The sidebar is the source, not the file tree: a page in no sidebar is a page
+ * nobody navigates to. Those exist (generate-llms.mjs reports them), and each
+ * caller decides what to do with them — `orphanPages( )` is that list.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import config from '../../docs/.vitepress/config.mjs';
+
+export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+export const DOCS = path.join(ROOT, 'docs');
+
+/** Where this site is published. */
+export const SITE = 'https://abap2ui5.github.io/docs';
+
+/** Every sidebar entry with a local link, in sidebar order, first one wins:
+ *  several groups deliberately point their own heading at their first page. */
+export function sidebarPages() {
+  const seen = new Set();
+  const out = [];
+  const walk = (nodes, section) => {
+    for (const node of nodes || []) {
+      // a top-level group names the section everything under it belongs to
+      const here = section ?? node.text;
+      if (node.link?.startsWith('/') && !seen.has(node.link)) {
+        seen.add(node.link);
+        out.push({ section: here, text: node.text, link: node.link });
+      }
+      walk(node.items, here);
+    }
+  };
+  walk(config.themeConfig.sidebar, null);
+  return out;
+}
+
+export function markdownFiles(dir, out = []) {
+  for (const name of fs.readdirSync(dir)) {
+    if (name === '.vitepress' || name === 'public' || name === 'node_modules') continue;
+    const full = path.join(dir, name);
+    if (fs.statSync(full).isDirectory()) markdownFiles(full, out);
+    else if (full.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+/* A page link and the file behind it are NOT a plain `.md` suffix apart.
+ * VitePress serves `<dir>/index.md` at `<dir>/`, so the trailing slash IS the
+ * index page, and `docs/index.md` (the home page) is the same rule at the
+ * root - which is why the orphan filter below used to carry a hand-written
+ * `/index` exception. Everything that converts between the two goes through
+ * mdSuffix, or a directory index resolves to `<dir>/.md` and takes the build
+ * down, which is exactly what happened the first time a section grew one. */
+export const mdSuffix = (link) => (link.endsWith('/') ? `${link}index.md` : `${link}.md`);
+export const linkOf = (file) => {
+  const rel = path.relative(DOCS, file).replace(/\\/g, '/');
+  if (rel === 'index.md') return '/';
+  if (rel.endsWith('/index.md')) return `/${rel.slice(0, -'index.md'.length)}`;
+  return `/${rel.replace(/\.md$/, '')}`;
+};
+export const fileOf = (link) => path.join(DOCS, mdSuffix(link).slice(1));
+
+/** The pages that exist and sit in no sidebar — published, navigated to by
+ *  nothing. The home page is not one of them: the brand and the bar's first
+ *  item are its navigation. */
+export function orphanPages(pages = sidebarPages()) {
+  const linked = new Set(pages.map((p) => p.link));
+  return markdownFiles(DOCS).map(linkOf).filter((l) => !linked.has(l) && l !== '/').sort();
+}
+
+/* ------------------------------------------------------------ the content */
+
+export const stripFrontmatter = (text) => text.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '');
+
+/** The first real sentence of a page, for the one-line note in the index.
+ *
+ *  The WHOLE first paragraph is collected before cutting: the sources are hard
+ *  wrapped, so stopping at the newline would end half the notes mid-sentence.
+ *
+ *  Link syntax and `*` emphasis are flattened, and backticks with them - but
+ *  NOT the underscore. Almost every identifier this documentation is about
+ *  carries one (`_bind`, `check_on_init`, `s_device`), and an index that
+ *  advertises `client->bind( )` is worse than no index: it is a plausible,
+ *  citable, wrong API name aimed at the one reader least able to notice. */
+export function summarise(body) {
+  const lines = stripFrontmatter(body).split('\n');
+  const para = [];
+  let inFence = false;
+  for (const line of lines) {
+    if (line.startsWith('```')) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const t = line.trim();
+    if (!para.length) {
+      if (!t || t.startsWith('#') || t.startsWith(':::') || t.startsWith('|') || t.startsWith('<')) continue;
+      para.push(t);
+      continue;
+    }
+    if (!t) break; // the paragraph ended
+    para.push(t);
+  }
+  const plain = para.join(' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[*`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!plain) return '';
+  // cut at the end of the first sentence, but not so early that the note says
+  // nothing; a period inside `sap.m.Table` or `1.71` is not a sentence end
+  const stop = plain.search(/\.(?=\s|$)|:\s—|\s—\s/);
+  const first = stop > 40 ? plain.slice(0, stop + 1) : plain;
+  return first.length > 220 ? `${first.slice(0, 217)}...` : first;
+}
+
+export const title = (body, fallback) =>
+  (stripFrontmatter(body).match(/^#\s+(.+?)\s*$/m) || [, fallback])[1].trim();
+
+/** Every `##`/`###` heading on a page, flattened — what a reader is actually
+ *  looking for when they type two words into a search box. Anchors are
+ *  VitePress's own slug: lower case, non-word runs to a dash. */
+export function headings(body) {
+  const out = [];
+  let inFence = false;
+  for (const line of stripFrontmatter(body).split('\n')) {
+    if (line.startsWith('```')) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const m = /^(#{2,3})\s+(.+?)\s*$/.exec(line);
+    if (!m) continue;
+    const text = m[2].replace(/\[([^\]]+)\]\([^)]*\)/g, '$1').replace(/[*`]/g, '').trim();
+    if (!text) continue;
+    out.push({
+      text,
+      anchor: text.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '-').replace(/^-|-$/g, ''),
+    });
+  }
+  return out;
+}
+
+/* Words that are in every page of every documentation and therefore identify
+ * none of it. Kept short on purpose: this is a size measure, not a language
+ * model, and a word wrongly dropped is a search that finds nothing. */
+const EVERYWHERE = new Set(('a an and are as at be by can for from has have in into is it its not of on or that the'
+  + ' this to with you your will would there their they them then than so if but do does what when which who how'
+  + ' one two also all any each more most other some such only own same too very just about after before both')
+  .split(' '));
+
+/** Every distinct word on a page, for a search that has to find a chapter by a
+ *  term that appears in its third paragraph.
+ *
+ *  Titles and headings are matched separately and weigh far more; this is the
+ *  long tail - the page that explains carousels without the word in any
+ *  heading. Kept as DISTINCT words rather than as the text: the index is
+ *  fetched by a reader who is mid-keystroke, and prose repeated verbatim is
+ *  weight bought for nothing. Fenced code is deliberately included - a control
+ *  or a method name is exactly what somebody types into this box. */
+export function terms(body) {
+  const seen = new Set();
+  /* The same split the query goes through in theme/search-engine.js: the dot
+   * and the underscore stay INSIDE a word, because `sap.m.Table` and
+   * `nav_app_call` are single things a reader types, and everything else -
+   * `->` above all - is a boundary. The two rules have to agree or a word
+   * indexed as one token is searched for as two. */
+  for (const w of stripFrontmatter(body).toLowerCase().split(/[^\p{L}\p{N}._]+/u)) {
+    const word = w.replace(/^[._]+|[._]+$/g, '');
+    if (word.length < 3 || word.length > 40 || EVERYWHERE.has(word)) continue;
+    if (/^\d+$/.test(word)) continue;
+    seen.add(word);
+  }
+  return [...seen].join(' ');
+}

--- a/scripts/lib/release.mjs
+++ b/scripts/lib/release.mjs
@@ -20,9 +20,17 @@ import path from 'path';
 /** Where the version is written, and how to find it in each file. */
 const SITES = [
   {
-    file: 'docs/.vitepress/config.mjs',
-    what: 'the version in the nav bar',
-    re: /text:\s*"(\d+\.\d+\.\d+)"/,
+    /* The bar, which is theme/SiteBar.vue and not config.mjs any more. The
+     * number used to be a nav dropdown's label - `text: "1.144.0"` - and the
+     * dropdown is gone: its four entries were already in the menu behind the
+     * bar's last button, so the rebuilt bar kept the number and dropped the
+     * duplicate rows. A gate that still matched `text:` in config.mjs would
+     * have found the FIRST nav-shaped string in a 700-line file, which is
+     * exactly the silent wrong answer the shape checks below exist to
+     * prevent. */
+    file: 'docs/.vitepress/theme/SiteBar.vue',
+    what: "the version in the bar's menu",
+    re: /const VERSION = "(\d+\.\d+\.\d+)"/,
   },
   {
     file: 'docs/resources/deprecations.md',

--- a/scripts/lib/search-index.mjs
+++ b/scripts/lib/search-index.mjs
@@ -1,0 +1,134 @@
+/*
+ * search-index — one index for the whole project, built here and read by all
+ * four bars.
+ *
+ * The search in the bar used to be VitePress's own local search, which knows
+ * exactly one thing: the pages of this site. That is half the project. A
+ * reader who types "carousel" wants the cookbook chapter AND the sample that
+ * builds one, and until now those were two searches on two sites, one of which
+ * they had to know existed.
+ *
+ * So the index carries both areas:
+ *
+ *   docs     every page the sidebar declares, with its headings - the
+ *            documentation, from lib/pages.mjs, which is also what llms.txt is
+ *            built from
+ *   samples  every entry in the three sample catalogues, with the title,
+ *            summary and keywords the sample repositories maintain for it, and
+ *            a link to that sample's own page in the catalogue
+ *
+ * The playground is not an area. It has no content to find: its URL carries
+ * the code in the editor, and a result that opened an empty editor would
+ * answer no question anybody typed. It is a destination in the bar, not in the
+ * index — the same reasoning that keeps it out of the position memory.
+ *
+ * WHERE IT IS PUBLISHED, AND WHY THAT IS ENOUGH. `/docs/search-index.json`, on
+ * the origin all four documents share, fetched by whichever of them the reader
+ * opened - lazily, on the first keystroke, so a reader who never searches
+ * never pays for it. One index, one URL, no build-time coupling between the
+ * two repositories: the playground does not import this, it fetches it.
+ *
+ * It is a PROJECTION of pages and catalogues, so it is generated on every
+ * build and gitignored, like llms.txt. Never commit it.
+ */
+import fs from 'node:fs';
+import { entriesOf, loadCatalogue } from './catalogue.mjs';
+import { sidebarPages, fileOf, summarise, title, headings, terms, SITE } from './pages.mjs';
+
+/** The three sample repositories, and where a reader is sent for a hit. */
+export const CORPORA = [
+  { repo: 'samples', label: 'Samples' },
+  { repo: 'samples-controls', label: 'Controls' },
+  { repo: 'samples-stack', label: 'Stack' },
+];
+
+/* The catalogue publishes one static page per sample, at /samples/<class>/ -
+ * tools/sample-pages.mjs in abap2UI5/playground. A hit therefore lands on the
+ * sample itself rather than on a catalogue filtered down to it. */
+const CATALOGUE = 'https://abap2ui5.github.io/playground/samples';
+const samplePage = (cls) => `${CATALOGUE}/${cls.toLowerCase()}/`;
+
+/** The documentation half: one entry per page of this site. */
+export function docEntries(pages = sidebarPages(), read = (link) => fs.readFileSync(fileOf(link), 'utf8')) {
+  return pages.map((p) => {
+    const body = read(p.link);
+    return {
+      area: 'docs',
+      group: p.section,
+      title: title(body, p.text),
+      text: summarise(body),
+      /* The headings are the difference between finding a PAGE and finding the
+       * paragraph somebody meant. They are matched against and shown as the
+       * sub-hits under a page, each with its own anchor. */
+      headings: headings(body).map((h) => [h.text, h.anchor]),
+      /* And every other distinct word on the page, so a chapter can be found
+       * by a term that never made it into a heading. Without this, "carousel"
+       * answered with 30 samples and not one of the pages that explain how to
+       * build one. */
+      terms: terms(body),
+      url: `${SITE}${p.link}${p.link.endsWith('/') ? '' : '.html'}`,
+    };
+  });
+}
+
+/** The samples half: one entry per catalogue entry, from whichever of the
+ *  three catalogues could be reached. A repository that could not is left out
+ *  and reported - it costs its rows, never the build, which is the rule every
+ *  other reader of these catalogues here already follows. */
+export function sampleEntries(catalogue, label) {
+  return entriesOf(catalogue).map((e) => {
+    const cls = String(e.class);
+    /* The three repositories describe an entry with slightly different fields
+     * - `description` and `category` here, `library`/`entity` in
+     * samples-controls, `technology` in samples-stack. They are not
+     * normalised into one shape: what is taken is what a reader would type,
+     * whichever key it arrived under.
+     *
+     * What is NOT taken is anything already in `title` or `text`: the matcher
+     * reads all three, and a field repeated into `terms` is a third of this
+     * file's weight bought twice. */
+    const keywords = Array.isArray(e.keywords) ? e.keywords.join(' ') : (e.keywords || '');
+    return {
+      area: 'samples',
+      group: label,
+      title: [e.title, e.description].filter(Boolean).join(' — ') || cls,
+      text: e.summary || '',
+      /* The class name is what half the searches here are: somebody has a
+       * z2ui5_cl_smpc_app_207 in front of them and wants the sample it came
+       * from. It is matched, and shown under the title. */
+      code: cls.toLowerCase(),
+      terms: [...new Set(
+        `${keywords} ${e.entity || ''} ${e.library || ''} ${e.category || ''} ${e.technology || ''}`
+          .toLowerCase().split(/[^\p{L}\p{N}._]+/u).filter(Boolean),
+      )].join(' '),
+      url: samplePage(cls),
+    };
+  });
+}
+
+/**
+ * The whole index: `{ built, areas, entries }`.
+ *
+ * `areas` names what is in it, so the four bars can label a group of results
+ * without knowing the three repositories by heart, and so a reader can see at
+ * once when a corpus is missing from a build rather than wondering why their
+ * sample is not there.
+ */
+export async function buildIndex(root, { fetchFn = globalThis.fetch, log = () => {} } = {}) {
+  const entries = docEntries();
+  const areas = [{ area: 'docs', label: 'Documentation', count: entries.length }];
+
+  for (const { repo, label } of CORPORA) {
+    const found = await loadCatalogue(repo, root, { fetchFn });
+    if (!found) {
+      log(`  ${repo}: no catalogue reachable — its samples are not in this index`);
+      continue;
+    }
+    const rows = sampleEntries(found.catalogue, label);
+    entries.push(...rows);
+    areas.push({ area: 'samples', repo, label, count: rows.length });
+    log(`  ${repo}: ${rows.length} sample(s) (${found.source})`);
+  }
+
+  return { built: new Date().toISOString(), areas, entries };
+}

--- a/test/cross-site.test.mjs
+++ b/test/cross-site.test.mjs
@@ -1,0 +1,121 @@
+/*
+ * Which links out of this site the gate must object to.
+ *
+ * scripts/check-cross-site.mjs walks the built HTML and demands a `target` on
+ * every link that leaves this deployment for a neighbouring one on the same
+ * origin — because without it VitePress's router takes the link over, finds no
+ * page of this site behind /playground/ and renders the 404 there. The rule
+ * has to be exactly as narrow as the router's own: too wide and it demands an
+ * attribute on links that work perfectly (another host, a JSON file); too
+ * narrow and the bar breaks again in silence.
+ *
+ * That boundary is what is pinned here, plus the one link the gate CANNOT see:
+ * the Run bar's "Switch to Playground with this code" is created in a browser,
+ * from a URL the playground's loader returns, and appears in no built page.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { leavesTheSite, crossSiteLinks } from '../scripts/lib/cross-site.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('a link into a neighbouring deployment is the case the router gets wrong', () => {
+  for (const href of [
+    'https://abap2ui5.github.io/playground/',
+    'https://abap2ui5.github.io/playground/samples/',
+    'https://abap2ui5.github.io/playground/samples/?q=table&lib=sap.m',
+    'https://abap2ui5.github.io/playground/#src=CLASS%20zcl',
+    'https://abap2ui5.github.io/linter/',
+    'https://abap2ui5.github.io/samples/',
+    /* Written root-relative rather than absolute: the same link, and the
+     * router does not care which form it was written in. */
+    '/playground/',
+    '/linter/rules.html',
+  ]) {
+    assert.ok(leavesTheSite(href), `${href} leaves the site and needs a target`);
+  }
+});
+
+test('a page of this site is the router\'s own job', () => {
+  for (const href of [
+    '/docs/',
+    '/docs/resources/changelog.html',
+    'https://abap2ui5.github.io/docs/get_started/quickstart.html',
+    '#a-heading-on-this-page',
+    'cookbook/view/definition.html',
+  ]) {
+    assert.equal(leavesTheSite(href), null, `${href} is a page of this site`);
+  }
+});
+
+test('a relative link is resolved against the page it is written on', () => {
+  /* The cookbook links its neighbours as `./../model/x.html`. Against the site
+   * ROOT that reads as a link out of the manual, and a gate that resolved it
+   * that way objected to a dozen perfectly ordinary in-site links. */
+  const page = 'https://abap2ui5.github.io/docs/cookbook/device_capabilities/info.html';
+  assert.equal(leavesTheSite('./../model/device_model.html', page), null);
+  assert.equal(leavesTheSite('./../../configuration/ui5_versions.html', page), null);
+  /* Far enough up and it really does leave: two more levels and this is
+   * /playground/, not a page of the manual. */
+  assert.ok(leavesTheSite('./../../../playground/', page));
+});
+
+test('another host is never touched by the router, whatever it points at', () => {
+  for (const href of [
+    'https://github.com/abap2UI5/abap2UI5',
+    'https://www.linkedin.com/company/abap2ui5/',
+    'http://localhost:5173/playground/',
+    'mailto:someone@example.org',
+    'javascript:void 0',
+  ]) {
+    assert.equal(leavesTheSite(href), null, `${href} is not this origin`);
+  }
+});
+
+test('a file the router would not treat as a page needs no attribute', () => {
+  /* The extension list is VitePress's, copied. Demanding the attribute here
+   * would be a rule that cannot be justified from what the router does. */
+  for (const href of [
+    'https://abap2ui5.github.io/playground/samples/catalogue.json',
+    'https://abap2ui5.github.io/linter/rules.txt',
+    'https://abap2ui5.github.io/playground/embed/abap2ui5-embed.js',
+  ]) {
+    assert.equal(leavesTheSite(href), null, `${href} is not a page`);
+  }
+  assert.ok(leavesTheSite('https://abap2ui5.github.io/playground/index.html'), '.html is a page');
+});
+
+test('the scan reads the attributes off the tag, quotes and all', () => {
+  const html = `
+    <a href="https://abap2ui5.github.io/playground/">Playground</a>
+    <a href="https://abap2ui5.github.io/linter/" target="_self">Linter rules</a>
+    <a href="https://abap2ui5.github.io/playground/samples/" title="a > b in a title">Samples</a>
+    <a href="/docs/resources/api.html">API</a>
+    <a href="https://github.com/abap2UI5/docs" target="_blank" rel="noopener">docs</a>
+  `;
+  const found = crossSiteLinks(html);
+  assert.equal(found.length, 3, 'three links leave the site; the docs page and github.com do not');
+  assert.deepEqual(found.map((f) => f.exempt), [false, true, false]);
+});
+
+test('the Run bar\'s link into the playground carries the attribute too', () => {
+  /* The gate cannot reach this one: it is built in the browser, out of a URL
+   * the playground's loader hands back, so it is in no built page. It is the
+   * same link with the same fault - it was the fourth way out of the manual
+   * that led to this site's 404 - so it is checked here, as the text that
+   * creates it. */
+  const source = readFileSync(join(ROOT, 'docs/.vitepress/theme/playground.js'), 'utf8');
+  const bar = source.slice(source.indexOf("open.className = 'a2ui5-play-open'"));
+  assert.ok(bar, "the Run bar still builds a link with the class 'a2ui5-play-open'");
+  const untilAppended = bar.slice(0, bar.indexOf('bar.append('));
+  assert.match(
+    untilAppended,
+    /open\.target\s*=\s*'_self'/,
+    'the link into the playground must opt out of the router, or it lands on this site\'s 404',
+  );
+});

--- a/test/search.test.mjs
+++ b/test/search.test.mjs
@@ -1,0 +1,201 @@
+/*
+ * The search: what goes into the index, and what comes back out of it.
+ *
+ * Two halves, both pinned here because both are the kind of thing that breaks
+ * quietly. An index built from the wrong field still builds; a matcher that
+ * lost its ranking still answers. Neither reports anything, and the box goes
+ * on looking like a working search box while it hands back the wrong page.
+ *
+ * The third half - does the box open, does the arrow key move - is a browser's
+ * question and not one this repository can ask; it is the same limit that
+ * keeps the position memory's round trip in the playground's Playwright suite.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { sampleEntries, docEntries } from '../scripts/lib/search-index.mjs';
+import { search, grouped, highlight } from '../docs/.vitepress/theme/search-engine.js';
+import { terms, headings } from '../scripts/lib/pages.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/* One row of each of the three catalogue shapes. They are three repositories'
+ * files, kept over there, and they do NOT agree on their field names - which
+ * is the whole reason sampleEntries reads several. */
+const SAMPLES = {
+  samples: [{
+    class: 'z2ui5_cl_smp_app_493',
+    file: 'src/01/z2ui5_cl_smp_app_493.clas.abap',
+    category: 'Basics',
+    title: 'Basics I',
+    description: 'Hello World, the Smallest App',
+    summary: 'The smallest app that runs.',
+    keywords: ['hello', 'world', 'minimal'],
+  }],
+};
+const CONTROLS = {
+  ports: [{
+    class: 'z2ui5_cl_smpc_app_398',
+    file: 'src/01/01/z2ui5_cl_smpc_app_398.clas.abap',
+    library: 'sap.m',
+    entity: 'sap.m.Carousel',
+    title: 'Carousel',
+    summary: 'A sample of a Carousel that contains images.',
+    keywords: 'carousel images swipe',
+  }],
+};
+const STACK = {
+  samples: [{
+    class: 'Z2UI5_CL_SMPS_APP_010',
+    path: 'src/z2ui5_cl_smps_app_010.clas.abap',
+    technology: 'OData',
+    title: 'OData V2 Service',
+    summary: 'An app talking to an OData service.',
+    keywords: ['odata', 'v2'],
+  }],
+};
+
+test('a sample entry is built from whichever fields its repository uses', () => {
+  const [basics] = sampleEntries(SAMPLES, 'Samples');
+  assert.equal(basics.area, 'samples');
+  assert.equal(basics.group, 'Samples');
+  assert.equal(basics.title, 'Basics I — Hello World, the Smallest App');
+  assert.equal(basics.code, 'z2ui5_cl_smp_app_493');
+  /* The class name decides the URL, and the pages the catalogue publishes are
+   * lower case - an upper-case class in the JSON (samples-stack writes them
+   * that way) must not produce a link to a page that is not there. */
+  const [stack] = sampleEntries(STACK, 'Stack');
+  assert.equal(stack.url, 'https://abap2ui5.github.io/playground/samples/z2ui5_cl_smps_app_010/');
+
+  const [carousel] = sampleEntries(CONTROLS, 'Controls');
+  assert.match(carousel.terms, /carousel/);
+  assert.match(carousel.terms, /sap\.m/, 'the library and the entity are searchable');
+  /* `terms` is the words the other fields do NOT already carry. A summary
+   * repeated into it is a third of the index's weight bought twice. */
+  assert.doesNotMatch(carousel.terms, /images that contains/);
+});
+
+test('every catalogue shape is recognised, and nothing else is', () => {
+  assert.equal(sampleEntries(SAMPLES, 'x').length, 1);
+  assert.equal(sampleEntries(CONTROLS, 'x').length, 1);
+  assert.equal(sampleEntries(STACK, 'x').length, 1);
+  /* The shape rule is `class` + `file`/`path`, shared with countEntries: the
+   * search and the figure in llms.txt must not disagree about what a sample
+   * is. A list of something else in the same file is not one. */
+  assert.equal(sampleEntries({ categories: ['sap.m', 'sap.ui.table'] }, 'x').length, 0);
+  assert.equal(sampleEntries({ counts: { total: 636 } }, 'x').length, 0);
+});
+
+test('a page is indexed by its headings and by its words', () => {
+  const body = '# Carousels\n\nHow to build one.\n\n## Adding pages\n\nUse the builder.\n';
+  const [page] = docEntries([{ section: 'Cookbook', text: 'Carousels', link: '/cookbook/carousel' }], () => body);
+  assert.equal(page.area, 'docs');
+  assert.equal(page.group, 'Cookbook');
+  assert.equal(page.title, 'Carousels');
+  assert.deepEqual(page.headings, [['Adding pages', 'adding-pages']]);
+  assert.equal(page.url, 'https://abap2ui5.github.io/docs/cookbook/carousel.html');
+  /* A directory index is served at the trailing slash and must not become
+   * `<dir>/.html`, which is a 404 the reader meets after the search worked. */
+  const [index] = docEntries([{ section: 'Tutorial', text: 'Walkthrough', link: '/tutorials/walkthrough/' }], () => body);
+  assert.equal(index.url, 'https://abap2ui5.github.io/docs/tutorials/walkthrough/');
+});
+
+test('the words of a page are distinct, and the noise is left out', () => {
+  const words = terms('# Title\n\nThe carousel and the CAROUSEL, with a `client->nav_app_call( )` and 42.\n').split(' ');
+  assert.ok(words.includes('carousel'));
+  assert.equal(words.filter((w) => w === 'carousel').length, 1, 'once, whatever the case');
+  assert.ok(words.includes('nav_app_call'), 'an API name is exactly what somebody types');
+  assert.ok(!words.includes('the') && !words.includes('and'), 'words that are on every page identify none');
+  assert.ok(!words.includes('42'));
+});
+
+test('a heading anchor is the one VitePress generates', () => {
+  assert.deepEqual(headings('## Why abap2UI5?\n').map((h) => h.anchor), ['why-abap2ui5']);
+  /* `check_on_event` is `id="check-on-event"` in the built resources/api.html:
+   * the underscore is a dash in an anchor, whatever it is in the name. */
+  assert.deepEqual(headings('## `client->view_display( )`\n').map((h) => h.anchor), ['client-view-display']);
+  /* A fenced block is code, not an outline: a comment starting with ## in an
+   * ABAP example is not a section of the page. */
+  assert.equal(headings('```abap\n## not a heading\n```\n').length, 0);
+});
+
+/* ------------------------------------------------------------ the matcher */
+
+const INDEX = [
+  { area: 'docs', group: 'Cookbook', title: 'Popups', text: 'How to open one.', headings: [['Anchored popovers', 'anchored-popovers']], terms: 'popup popover dialog anchored', url: '/docs/cookbook/popup.html' },
+  { area: 'docs', group: 'Resources', title: 'Client API', text: 'Every method.', headings: [], terms: 'popup nav_app_call carousel', url: '/docs/resources/api.html' },
+  { area: 'samples', group: 'Controls', title: 'Carousel', text: 'A carousel with images.', code: 'z2ui5_cl_smpc_app_398', terms: 'carousel images sap.m', url: '/playground/samples/z2ui5_cl_smpc_app_398/' },
+  { area: 'samples', group: 'Samples', title: 'Popup — Message Box', text: 'A message box.', code: 'z2ui5_cl_smp_app_100', terms: 'popup message box', url: '/playground/samples/z2ui5_cl_smp_app_100/' },
+];
+
+test('a title beats a mention, whatever area it is in', () => {
+  const [best] = search(INDEX, 'popup');
+  assert.equal(best.entry.title, 'Popups');
+});
+
+test('a class name finds its sample', () => {
+  const hits = search(INDEX, 'z2ui5_cl_smpc_app_398');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].entry.title, 'Carousel');
+});
+
+test('a second word narrows the answer rather than widening it', () => {
+  /* The failure this pins: terms treated as alternatives. Typing more would
+   * then return MORE, which reads as the box ignoring what you typed. */
+  const one = search(INDEX, 'popup');
+  const two = search(INDEX, 'popup message');
+  assert.ok(two.length < one.length);
+  assert.equal(two[0].entry.code, 'z2ui5_cl_smp_app_100');
+  assert.equal(search(INDEX, 'popup carousel zzz').length, 0, 'every word has to be somewhere');
+});
+
+test('a heading hit says which heading, so the link can carry its anchor', () => {
+  const [hit] = search(INDEX, 'anchored');
+  assert.equal(hit.entry.title, 'Popups');
+  assert.equal(hit.heading.anchor, 'anchored-popovers');
+});
+
+test('the documentation is offered before seven hundred samples of it', () => {
+  const groups = grouped(search(INDEX, 'popup'));
+  assert.equal(groups[0].label, 'Documentation');
+  assert.deepEqual(groups.map((g) => g.label).sort(), ['Controls', 'Documentation', 'Samples'].filter((l) => groups.some((g) => g.label === l)).sort());
+});
+
+test('one corpus cannot bury the others', () => {
+  const many = Array.from({ length: 40 }, (_, i) => ({
+    area: 'samples', group: 'Controls', title: `List ${i}`, text: '', code: `z2ui5_cl_smpc_app_${i}`, terms: 'list', url: `/x/${i}/`,
+  }));
+  many.push({ area: 'docs', group: 'Cookbook', title: 'Lists', text: '', headings: [], terms: 'list', url: '/docs/list.html' });
+  const groups = grouped(search(many, 'list'));
+  assert.equal(groups[0].label, 'Documentation');
+  assert.ok(groups[1].hits.length <= 6);
+});
+
+test('an empty query is not a search for everything', () => {
+  assert.deepEqual(search(INDEX, ''), []);
+  assert.deepEqual(search(INDEX, '   '), []);
+});
+
+test('the highlight marks what was typed and nothing else', () => {
+  assert.deepEqual(highlight('Popups and popovers', 'popup'), [['Popup', true], ['s and popovers', false]]);
+  assert.deepEqual(highlight('Carousel', 'zzz'), [['Carousel', false]]);
+  assert.deepEqual(highlight('', 'popup'), [['', false]]);
+  /* Two terms that overlap must not produce overlapping runs, or the row is
+   * rendered with a piece of its own title repeated. */
+  const parts = highlight('carousel', 'car carousel');
+  assert.equal(parts.map(([t]) => t).join(''), 'carousel');
+});
+
+test('the search box in the bar carries the cross-site attribute on a sample hit', () => {
+  /* The same rule as the Run bar's link and for the same reason: a sample hit
+   * leaves this deployment for the catalogue, and a link the router swallows
+   * lands on this site's 404 (scripts/lib/cross-site.mjs). The gate cannot see
+   * it - the results are built in a browser - so it is checked as source. */
+  const box = readFileSync(join(ROOT, 'docs/.vitepress/theme/SearchBox.vue'), 'utf8');
+  const fn = box.slice(box.indexOf('function hrefOf'), box.indexOf('function go'));
+  assert.match(fn, /target:\s*'_self'/);
+});

--- a/test/site-memory.test.mjs
+++ b/test/site-memory.test.mjs
@@ -113,3 +113,18 @@ test('a storage that refuses everything does not throw', () => {
     globalThis.localStorage = before.localStorage;
   }
 });
+
+test('a scope wider than the link is what restores a section from a deep href', () => {
+  /* The other three bars point Documentation at the first page of the manual
+   * and still come back to wherever the reader was in it. Without a scope the
+   * containment test is against that one page, so every restore falls back -
+   * a memory that silently does not work. Written here with the key this file
+   * stubs; the case is the shape, not the section. */
+  const deep = 'https://abap2ui5.github.io/playground/samples/all/';
+  const last = '/playground/samples/z2ui5_cl_smp_app_001/';
+  assert.equal(on(SITE, last, () => lastVisited('samples', deep)), deep,
+    'without a scope, a sibling page is not inside the link');
+  assert.equal(on(SITE, last, () => lastVisited('samples', deep, SAMPLES)), last);
+  /* And the scope is a fence, not a door: outside it, the written link stands. */
+  assert.equal(on(SITE, '/docs/cookbook/view/definition.html', () => lastVisited('samples', deep, SAMPLES)), deep);
+});


### PR DESCRIPTION
## Summary

Replaces VitePress's local search (which only indexed documentation pages) with a unified search box that indexes both the documentation and all three sample catalogues. The search box is now positioned in the center of the navigation bar and uses a shared index built at `/docs/search-index.json`.

## Key Changes

- **New search component** (`SearchBox.vue`): Vue component for the search box in the navigation bar with keyboard shortcuts (`/` or `Ctrl+K`), arrow key navigation, and result grouping by area (docs vs samples)

- **Search engine** (`search-engine.js`): Framework-free matching and ranking logic shared across four deployments (docs, playground, catalogue, per-sample pages). Implements prefix matching with field-weighted scoring (title > code > heading > text/terms/group)

- **Unified index generation** (`generate-search.mjs`, `search-index.mjs`): Builds a single JSON index containing:
  - All documentation pages from the sidebar with their headings and content
  - All entries from three sample catalogues (samples, samples-controls, samples-stack)
  - Published at `/docs/search-index.json` and lazily loaded on first search

- **Page utilities** (`pages.mjs`): Extracted sidebar walking, page discovery, and content parsing logic shared between `generate-llms.mjs` and the new search index generator to ensure consistency

- **Cross-site link validation** (`cross-site.mjs`, `check-cross-site.mjs`): New gate that validates links leaving the documentation deployment for neighbouring deployments (playground, catalogue, linter) carry the required `target="_self"` attribute to prevent VitePress's router from intercepting them

- **Navigation bar layout** (`style.css`): Restructured to place the brand inline with the four section links (no longer absolutely positioned), with the search box centered using flexbox `order` and `margin: auto`

- **Configuration updates** (`config.mjs`): Removed VitePress's built-in local search provider; search box is now rendered via the custom theme component

- **Tests**: Added comprehensive test suites for search indexing, matching, and cross-site link validation

## Implementation Details

- The search index is generated during `docs:build` and published with the site, allowing the playground and catalogue to fetch the same index
- Search results distinguish between documentation (internal navigation) and samples (external links with `target="_blank"`)
- The bar layout now reads as a single row at all widths: brand + sections + search (centered) + marks/menu
- Version number moved from nav dropdown to the menu (SiteBar.vue) since the dropdown was otherwise empty

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW