### PR TITLE
Regenerate the client API reference, which is blocking the deploy

### DIFF
--- a/docs/public/api/client-api.json
+++ b/docs/public/api/client-api.json
@@ -443,7 +443,7 @@
           "name": "arg",
           "type": "clike",
           "optional": true,
-          "doc": "appended rather than slotted next to t_arg, where it would read better: rule 5 allows a new optional parameter at the END of the list - inserting one reorders a public signature the ONE-VALUE spelling of t_arg: `arg = x` is exactly `t_arg = VALUE #( ( x ) )`, byte for byte, and the handler reads it back with the same `get_event_arg( )`. It exists because the single argument is what most wires carry - a row key, a `${$source>/...}`, one event parameter - and there the table constructor is longer than the value inside it. From two values on, t_arg is the right parameter and stays it; arg deliberately does not grow into arg2/arg3, which would only put the positional numbering the table already spells out back into the parameter names. Passing both APPENDS arg behind the t_arg rows - a defined composition, not a guess between two readings."
+          "doc": "appended rather than slotted next to t_arg, where it would read better: rule 5 allows a new optional parameter at the END of the list - inserting one reorders a public signature the ONE-VALUE spelling of t_arg: `arg = x` is exactly `t_arg = VALUE #( ( x ) )`, byte for byte, and the handler reads it back with the same `get_event_arg( )`. It exists because the single argument is what most wires carry - a row key, a `${$source>/...}`, one event parameter - and there the table constructor is longer than the value inside it. From two values on, t_arg is the right parameter and stays it; arg deliberately does not grow into arg2/arg3, which would only put the positional numbering the table already spells out back into the parameter names. Passing both APPENDS arg behind the t_arg rows - a defined composition, not a guess between two readings. An argument that starts with `$` or `{` (or an .eB( expression) is written RAW, as live UI5 expression syntax - that is how `${$source>/KEY}` reaches the handler as the row's value. Data that may start with those characters (text a user typed, a key from a foreign system) is therefore evaluated, not passed: set s_ctrl-check_arg_literal to have every argument of the wire quoted as a string instead."
         }
       ],
       "returns": "string"
@@ -494,7 +494,7 @@
           "name": "json",
           "type": "abap_bool",
           "default": "abap_false",
-          "doc": "the bound string already CONTAINS JSON - splice it into the model as a JSON node instead of sending it as a quoted string. For a control property that must receive an OBJECT, which no typed ABAP value can be (a sap.ui.integration Card manifest: its keys `sap.app`/`sap.card` are not valid ABAP field names, and a string is read as a manifest URL). Outbound only - see z2ui5_cl_ui5_srv_model."
+          "doc": "the bound string already CONTAINS JSON - splice it into the model as a JSON node instead of sending it as a quoted string. For a control property that must receive an OBJECT, which no typed ABAP value can be (a sap.ui.integration Card manifest: its keys `sap.app`/`sap.card` are not valid ABAP field names, and a string is read as a manifest URL). Outbound only - see z2ui5_cl_ui5_srv_model. Ignored for a CELL (tab supplied): whether a value is JSON is decided on the table's bind. custom_mapper, custom_filter and the omit_initial pair are passed on to the table there, like a _bind( ) of the table itself would store them."
         }
       ],
       "returns": "string"
@@ -1321,6 +1321,11 @@
           "name": "prevent_default_expr",
           "type": "string",
           "label": "the same veto, but decided PER FIRING instead of per wire: a client"
+        },
+        {
+          "name": "check_arg_literal",
+          "type": "abap_bool",
+          "label": "quote EVERY argument of this wire as a string. An argument that"
         }
       ]
     }

--- a/docs/resources/api.md
+++ b/docs/resources/api.md
@@ -126,7 +126,7 @@ Display the MAIN view. A new main view is a new screen, so an open popup and pop
 | `switch_default_model` | `abap_bool` | `abap_false` |  |
 | `omit_initial` | `abap_bool` | `abap_false` | keep INITIAL fields out of the serialized model instead of sending them as `` / 0. An ABAP field is never absent - it is initial - so by default every field reaches the client as an explicit value, which overrides the UI5 property default the original view relies on (and an enum-typed property rejects the empty string outright). Set it when a bound template's rows fill different subsets of the same properties. |
 | `omit_initial_paths` | `string_table` | *optional* | the same omission SCOPED to the listed fields (upper-cased column names, the last path segment). Use it when the blanket flag is too coarse: an abap_false that MUST reach the client is itself initial, so omit_initial would drop it and the control would fall back to its own default - list the numeric/enum columns instead and leave the booleans. |
-| `json` | `abap_bool` | `abap_false` | the bound string already CONTAINS JSON - splice it into the model as a JSON node instead of sending it as a quoted string. For a control property that must receive an OBJECT, which no typed ABAP value can be (a sap.ui.integration Card manifest: its keys `sap.app`/`sap.card` are not valid ABAP field names, and a string is read as a manifest URL). Outbound only - see z2ui5_cl_ui5_srv_model. |
+| `json` | `abap_bool` | `abap_false` | the bound string already CONTAINS JSON - splice it into the model as a JSON node instead of sending it as a quoted string. For a control property that must receive an OBJECT, which no typed ABAP value can be (a sap.ui.integration Card manifest: its keys `sap.app`/`sap.card` are not valid ABAP field names, and a string is read as a manifest URL). Outbound only - see z2ui5_cl_ui5_srv_model. Ignored for a CELL (tab supplied): whether a value is JSON is decided on the table's bind. custom_mapper, custom_filter and the omit_initial pair are passed on to the table there, like a _bind( ) of the table itself would store them. |
 
 Returns `string`.
 
@@ -155,7 +155,7 @@ Register a backend event and return the handler expression for a view attribute 
 | `val` | `clike` | *optional* |  |
 | `t_arg` | `string_table` | *optional* |  |
 | `s_ctrl` | `ty_s_event_control` | *optional* |  |
-| `arg` | `clike` | *optional* | appended rather than slotted next to t_arg, where it would read better: rule 5 allows a new optional parameter at the END of the list - inserting one reorders a public signature the ONE-VALUE spelling of t_arg: `arg = x` is exactly `t_arg = VALUE #( ( x ) )`, byte for byte, and the handler reads it back with the same `get_event_arg( )`. It exists because the single argument is what most wires carry - a row key, a `${$source>/...}`, one event parameter - and there the table constructor is longer than the value inside it. From two values on, t_arg is the right parameter and stays it; arg deliberately does not grow into arg2/arg3, which would only put the positional numbering the table already spells out back into the parameter names. Passing both APPENDS arg behind the t_arg rows - a defined composition, not a guess between two readings. |
+| `arg` | `clike` | *optional* | appended rather than slotted next to t_arg, where it would read better: rule 5 allows a new optional parameter at the END of the list - inserting one reorders a public signature the ONE-VALUE spelling of t_arg: `arg = x` is exactly `t_arg = VALUE #( ( x ) )`, byte for byte, and the handler reads it back with the same `get_event_arg( )`. It exists because the single argument is what most wires carry - a row key, a `${$source>/...}`, one event parameter - and there the table constructor is longer than the value inside it. From two values on, t_arg is the right parameter and stays it; arg deliberately does not grow into arg2/arg3, which would only put the positional numbering the table already spells out back into the parameter names. Passing both APPENDS arg behind the t_arg rows - a defined composition, not a guess between two readings. An argument that starts with `$` or `{` (or an .eB( expression) is written RAW, as live UI5 expression syntax - that is how `${$source>/KEY}` reaches the handler as the row's value. Data that may start with those characters (text a user typed, a key from a foreign system) is therefore evaluated, not passed: set s_ctrl-check_arg_literal to have every argument of the wire quoted as a string instead. |
 
 Preferred parameter: `val` — a positional call passes it.
 
@@ -500,5 +500,6 @@ The per-wire options of _event( ) - see the documentation on the method for what
 | `check_allow_multi_req` | `abap_bool` |
 | `check_prevent_default` | `abap_bool` |
 | `prevent_default_expr` | `string` |
+| `check_arg_literal` | `abap_bool` |
 
 <!-- api:end -->


### PR DESCRIPTION
**The site is not being published right now.** [The deploy of #225](https://github.com/abap2UI5/docs/actions/runs/33972498327) failed at exactly one step — *API reference freshness* — so the build, the new cross-site gate and the upload were all skipped and the `Deploy` job never ran. The new bar is on `main` and not on abap2ui5.github.io/docs.

```
✓ unit tests        ✓ ABAP examples      ✓ API names
✓ release version   ✓ Run-button cov.    ✗ API reference freshness   ←
                                          ⊘ Build with VitePress    (skipped)
                                          ⊘ cross-site links        (skipped)
                                          ⊘ Upload artifact         (skipped)
```

## What was stale, and why it is not #225's fault

`z2ui5_if_client` moved on the framework's `main` while the committed reference still described the shape before it:

- `check_arg_literal` is new on `ty_s_event_control`
- the doc on `_event( )`'s `arg` grew the paragraph about `$`/`{` arguments being written raw, and how to opt out
- the doc on `_bind( )`'s `json` grew the paragraph about a cell ignoring it

This was already red on a clean tree before any of the bar work — verified by stashing that work and running the gate on `main`'s content. The gate is doing its job: it refuses to publish a reference that describes an interface nobody has any more, and that refusal correctly costs the whole deploy.

## The change

`npm run generate:api`, which is what AGENTS.md prescribes for this gate, and nothing else. The whole diff is inside the generated block — two doc strings and one added field — because the file is generated and never edited by hand.

## Verified

`npm run check` passes **all ten gates** on this tree, `check:api-reference` included:

```
check-version:      the three places agree with each other - OK
check-cross-site:   1030 link(s) out of 333 page(s) — all of them lead somewhere
check-examples:     69 view-building example(s) from 54 page(s) — all compile
check-conventions:  100 view chain(s) and 83 app class(es) — layout matches
check-playground:   82 app class(es), 63 buttoned, 19 excluded on purpose
check-api-names:    1901 name(s) and 7 source link(s) — OK
check-api-reference: the committed API reference matches the interface - OK
check-samples:      up to date
```

Once this is on `main` the deploy goes through and the bar from #225 is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_