### PR TITLE
The bar stops moving, the box finds the middle, and Home introduces the project

### DIFF
--- a/docs/.vitepress/theme/SiteBar.vue
+++ b/docs/.vitepress/theme/SiteBar.vue
@@ -73,21 +73,40 @@ const onHome = computed(() => page.value.relativePath === "index.md");
  * scripts/check-cross-site.mjs holds the built site to it. */
 const SAME_TAB = "_self";
 
-/* The catalogue's front page until the browser says otherwise. This is what
- * the server renders, what a crawler is given and what a first visit follows;
- * onMounted only ever replaces it with a deeper page of the same site. */
+/* The two links the memory can move, as the SERVER renders them: the front
+ * page of each section. That is what a crawler is given and what a first visit
+ * follows; onMounted only ever replaces one with a deeper page of the same
+ * section. */
 const samplesHref = ref(SAMPLES);
+const docsHref = ref(DOCS);
 const extra = ref(null);
 /* Lifted on mount, and again whenever it can have moved while this page stayed
  * open: the catalogue narrowed in another tab, a Back that brought this page
  * out of the back-forward cache. The click itself is the lift that cannot be
  * missed - the href is set on the element there, before the browser follows
  * it, because a ref set in the handler reaches the DOM a tick too late. */
+/* Documentation restores WHEREVER IN THE MANUAL you were, which is why it
+ * passes a scope: the link is written at the manual's first page, and a stored
+ * /docs/cookbook/... is not inside that page. Without the third argument the
+ * containment test is against `get_started/about` alone and every restore
+ * falls back - which is exactly how this item behaved on this site while the
+ * other three bars restored it correctly. The scope is a value passed HERE,
+ * never one out of storage.
+ *
+ * The Home page is deliberately not part of it: rememberHere() does not write
+ * it (theme/index.js), so going Home and back does not overwrite the page you
+ * were reading with the front door. */
 const lift = () => {
   samplesHref.value = lastVisited("samples", SAMPLES);
+  docsHref.value = lastVisited("docs", DOCS, HOME);
 };
+/* The lift that cannot be missed: on the click itself, on the element, because
+ * a ref set in the handler reaches the DOM a tick too late. */
 const liftNow = (e) => {
-  e.currentTarget.href = lastVisited("samples", SAMPLES);
+  const el = e.currentTarget;
+  el.href = el.dataset.site === "docs"
+    ? lastVisited("docs", DOCS, HOME)
+    : lastVisited("samples", SAMPLES);
 };
 onMounted(() => {
   lift();
@@ -134,10 +153,10 @@ watch(isDark, (dark) => {
          two sections of THIS deployment now - the section that used to be one
          non-clickable word ("Documentation") is two places a reader can move
          between, which is what the brand alone could not offer. -->
-    <a :href="HOME" :class="{ here: onHome }" :aria-current="onHome ? 'page' : undefined" title="abap2UI5 in one page">Home</a>
-    <a :href="DOCS" :class="{ here: !onHome }" :aria-current="!onHome ? 'page' : undefined" title="The manual: guide, cookbook, reference">Documentation</a>
-    <a :href="samplesHref" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
-    <a :href="PLAYGROUND" :target="SAME_TAB" title="Write ABAP and run it in the browser">Playground</a>
+    <a :href="HOME" data-text="Home" :class="{ here: onHome }" :aria-current="onHome ? 'page' : undefined" title="abap2UI5 in one page">Home</a>
+    <a :href="docsHref" data-text="Documentation" data-site="docs" :class="{ here: !onHome }" :aria-current="!onHome ? 'page' : undefined" title="The manual, where you left it" @click="liftNow">Documentation</a>
+    <a :href="samplesHref" data-text="Samples" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
+    <a :href="PLAYGROUND" data-text="Playground" :target="SAME_TAB" title="Write ABAP and run it in the browser">Playground</a>
   </nav>
   <!-- The rest of abap2UI5 behind one more button: light or dark, then the
        practical links (issues, release notes, install, support), the project's

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -40,11 +40,21 @@ export default {
     // single page application: the first page would otherwise be the only one
     // ever written down. `onAfterRouteChange` rather than `onBeforeRouteChange`
     // - the location is the new one only after the change has happened.
+    // THE HOME PAGE IS NOT WRITTEN DOWN. Every other page is, and the
+    // Documentation item on all four bars comes back to whatever was written
+    // last. If the front door counted as a page of the manual, going Home
+    // would overwrite the chapter you were reading with `/docs/`, and
+    // Documentation would then open the home page - which is what the Home
+    // item is for and not what the word Documentation promises. Home stays a
+    // place you go to, never a place you are returned to.
+    const rememberUnlessHome = () => {
+      if (!location.pathname.replace(/index\.html$/, '').match(/\/docs\/?$/)) rememberHere('docs')
+    }
     if (!import.meta.env.SSR) {
-      rememberHere('docs')
+      rememberUnlessHome()
       const onAfter = router.onAfterRouteChange
       router.onAfterRouteChange = (to) => {
-        rememberHere('docs')
+        rememberUnlessHome()
         onAfter?.(to)
       }
     }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1461,6 +1461,54 @@
  * left to right. The hamburger stays last. */
 .Layout .VPNav .VPNavBar .bar-nav { order: 1; }
 .Layout .VPNav .VPNavBar .a2ui5-search-button { order: 2; margin: 0 auto; }
+
+/* THE BOX IS CENTRED ON THE BAR, NOT ON WHAT IS LEFT OVER.
+ *
+ * `margin: 0 auto` above centres it in the free space of `.content-body`, and
+ * that is not the middle of anything a reader can see: the row it sits in
+ * starts AFTER the brand, and the group on its left (four words) is far wider
+ * than the group on its right (three glyphs). Measured, it stood 181px right
+ * of the window's centre at every width - which is what it looked like.
+ *
+ * So above the width where the row is comfortable it is placed absolutely,
+ * against `.container` - the element that spans the whole bar, brand included.
+ * The auto margins stay for narrower windows, where an absolutely placed box
+ * would sooner or later sit on top of the words on either side of it.
+ *
+ * The two `position: relative` rules being undone here are the theme's, and
+ * they were for the layout this bar no longer uses: they raised the content
+ * strip above the brand back when the brand was placed absolutely over the
+ * sidebar's column. The brand is in the row now (see "ONE ROW" above), so
+ * there is nothing left for them to lift, and while they stood they were the
+ * nearest positioned ancestor - which would have centred the box on the strip
+ * again, the very thing this rule is for. */
+@media (min-width: 1100px) {
+  .Layout .VPNav .VPNavBar .container {
+    position: relative;
+  }
+
+  .Layout .VPNav .VPNavBar.has-sidebar .content,
+  .Layout .VPNav .VPNavBar:not(.home.top) .content-body {
+    position: static;
+  }
+
+  .Layout .VPNav .VPNavBar .a2ui5-search-button {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    margin: 0;
+    transform: translate(-50%, -50%);
+  }
+
+  /* And the sections hold the left themselves. `.content-body` justifies to
+   * the END, so while the box was in the row its auto margins were what kept
+   * the four words against the brand; the moment it left the flow they packed
+   * to the right with the marks - 820px away from the mark they belong to.
+   * This is that job, done by the group that needs it. */
+  .Layout .VPNav .VPNavBar .bar-nav {
+    margin-right: auto;
+  }
+}
 .Layout .VPNav .VPNavBar .social-links { order: 3; }
 .Layout .VPNav .VPNavBar .a2ui5-extra { order: 4; }
 .Layout .VPNav .VPNavBar .hamburger { order: 5; }
@@ -1521,6 +1569,39 @@
   font-size: 14px;
   text-decoration: none;
   white-space: nowrap;
+}
+
+/* EVERY ITEM IS AS WIDE AS ITS OWN BOLD SELF, ALWAYS.
+ *
+ * The one you are on is semibold, and semibold is wider - "Documentation"
+ * measures 114px at 400 and 122 at 600. So the moment the marked item changed,
+ * everything after it moved: clicking Documentation on the home page pushed
+ * Samples and Playground 6px to the right, and the row twitched under the
+ * cursor. It never showed before this bar had two items of ITS OWN to move
+ * between - the marked one used to be the same word on every page of the site.
+ *
+ * So each item carries its own label a second time, in bold, in a
+ * pseudo-element with no height: it is never seen, it only reserves the width.
+ * The link is a column so the two overlap rather than stack. `data-text` is
+ * what the copy reads - the label has to be in the markup twice, and an
+ * attribute is the copy that cannot fall out of step with the text, since the
+ * gate below would not notice a typo but the reader would see the jump come
+ * back. */
+.Layout .VPNav .bar-nav a,
+.Layout .VPNav .bar-nav .here {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.Layout .VPNav .bar-nav a::after,
+.Layout .VPNav .bar-nav .here::after {
+  content: attr(data-text);
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+  font-weight: 600;
+  pointer-events: none;
 }
 
 .Layout .VPNav .bar-nav a:hover {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1017,6 +1017,28 @@
   transform: translate(2px, -2px);
 }
 
+/* A CARD THAT STAYS ON THIS SITE SAYS SO BY NOT SAYING THE OPPOSITE.
+ *
+ * The tint and the arrow are this row's whole signal: it is drawn differently
+ * from the feature cards above it so that a card which LEAVES is recognisable
+ * as one before it is clicked. The home page now has a row mixing both - two
+ * of its three "around the framework" cards are pages of this manual - and a
+ * card that is tinted and arrowed and then lands on /docs/resources/addons
+ * spends that signal on nothing. So a card that stays takes the outline the
+ * feature cards have, and drops the arrow. */
+.a2ui5-out .a2ui5-out-card.is-inside {
+  background-color: transparent;
+  border-color: var(--vp-c-divider);
+}
+
+.a2ui5-out .a2ui5-out-card.is-inside:hover {
+  border-color: var(--a2ui5-c-link);
+}
+
+.a2ui5-out .a2ui5-out-card.is-inside .a2ui5-out-title::after {
+  content: none;
+}
+
 .a2ui5-out .a2ui5-out-details {
   display: block;
   padding-top: 8px;

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,74 +3,158 @@
 layout: home
 title: Home
 
+# THIS PAGE IS THE PROJECT'S FRONT DOOR, NOT THE MANUAL'S.
+#
+# It used to be the documentation's home page, reachable by clicking the mark
+# and by nothing else, and it read like one: a hero, then three ways into three
+# sections of this site. The bar names four places now — Home, Documentation,
+# Samples, Playground — and Home is the one that has to answer "what IS this"
+# for somebody who arrived from a conference talk, a LinkedIn post or a
+# colleague's link, and who has not decided to read a manual yet.
+#
+# So the page answers, in this order: what it is, what one app looks like (with
+# a button that RUNS it, right here), where to go next, what it runs on, and
+# what is built around it. A reader who wants the manual is one word away in
+# the bar; this page does not compete with it.
 hero:
   name: abap2UI5
   text: Build UI5 Apps Purely in ABAP
-  tagline: "No JavaScript, OData, or RAP needed.\nKeep it simple. Keep it ABAP."
+  tagline: "One ABAP class is one UI5 app. No JavaScript, no OData service, no RAP, no frontend project.\nInstall it with abapGit and run it on anything from NetWeaver 7.02 to ABAP Cloud."
   image:
     src: /logo.png
     alt: abap2UI5 Logo
     width: 200px
     height: 200px
-  # Two buttons: install it, and understand what it is. The second one was
-  # "What's New?" on the changelog — a page for the reader who is already
-  # here every month, reached from the hero of the page written for the one
-  # who is not. It is not lost: the version number in the nav bar opens a
-  # menu whose first entry is Release Notes, which is where somebody looking
-  # for what changed goes anyway. "In a Nutshell" was the gap — the page
-  # that answers "what IS this" had no path from the home page at all, only
-  # the Guide dropdown. It carries the label the sidebar gives it, so a
-  # reader who clicks knows where they landed.
+  # Three buttons, in the order a stranger needs them: try it without
+  # installing anything, install it, understand it. The playground is first on
+  # purpose — it is the one claim on this page a reader can check in ten
+  # seconds, and it costs them nothing. It is an absolute URL, so VitePress
+  # draws it as an external link and gives it a `target` of its own, which is
+  # also what keeps this site's router off a neighbouring deployment
+  # (scripts/lib/cross-site.mjs).
   actions:
     - theme: brand
-      text: Quickstart
+      text: Try it in the browser
+      link: https://abap2ui5.github.io/playground/
+    - theme: alt
+      text: Install with abapGit
       link: /get_started/quickstart
     - theme: alt
-      text: In a Nutshell
+      text: What it is
       link: /get_started/about
 
-# Two rows of three. The first, the theme's own, is the three ways INTO the
-# documentation, in the order a reader meets them: learn it, look things up
-# while building, take it to production. The Cookbook is the middle one on
-# purpose — it used to be left off on the argument that it answers a question
-# a first-time visitor does not have yet, but most visits here are not first
-# visits, and the reader who arrives already stuck was being sent through a
-# nav dropdown to find the page written for them. Quickstart is still not a
-# card: the hero's first button is that jump, and a card repeating it is a
-# card spent twice. Technical Insight is not one either — it is what you read
-# after the thing runs, not a way in.
-#
-# Three cards give VPFeatures `grid-3`, which is why the second row below —
-# the three places that are NOT pages of this site: the repository, LinkedIn
-# and the playground — is set to the same three columns at the same
-# breakpoint. Two rows of three, one grid. They are drawn differently (a
-# tinted fill where these are outlined) so that a card which leaves this site
-# is recognisable as one before it is clicked.
-#
-# Every `details` line is written to be clicked rather than read: it opens on
-# what the reader gets to DO there, and names the concrete things they came
-# looking for. A card that only describes its section is a card that loses to
-# the search box.
+# The other three places the bar names, in the order the bar names them. Not
+# three sections of this site any more: a reader on this page is choosing
+# between reading, browsing and trying, and two of those are somewhere else.
 features:
-  - title: Tutorial
-    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 3 1.4 7.6 12 12.2l10.6-4.6z"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M5.6 10.3v4.8c0 1.8 2.9 3.2 6.4 3.2s6.4-1.4 6.4-3.2v-4.8"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M21.4 8.7v5.6"/></svg>
-    details: Start here — one app you build step by step, from a first message box to a tested app running in production.
-    link: /tutorials/walkthrough/
-  - title: Cookbook
+  - title: Documentation
     icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" d="M12 6.9C10.4 5.5 8.2 4.8 5.4 4.8H2.4v12.6h3c2.8 0 5 .7 6.6 2.1 1.6-1.4 3.8-2.1 6.6-2.1h3V4.8h-3c-2.8 0-5 .7-6.6 2.1z"/><path fill="none" stroke="currentColor" stroke-width="1.7" d="M12 6.9v12.6"/></svg>
-    details: Look it up — tables, popups, navigation, file upload and download. One page per problem, each with code to copy.
-    link: /cookbook/view/definition
-  - title: Configuration
-    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" d="M9.89 4.65 10.11 1.82h3.78l.22 2.83 1.6.66 2.15-1.84 2.67 2.67-1.84 2.15.66 1.6 2.83.22v3.78l-2.83.22-.66 1.6 1.84 2.15-2.67 2.67-2.15-1.84-1.6.66-.22 2.83h-3.78l-.22-2.83-1.6-.66-2.15 1.84-2.67-2.67 1.84-2.15-.66-1.6-2.83-.22v-3.78l2.83-.22.66-1.6-1.84-2.15 2.67-2.67 2.15 1.84z"/><circle cx="12" cy="12" r="3.2" fill="none" stroke="currentColor" stroke-width="1.7"/></svg>
-    details: Go live — setup, security, performance, transport and the launchpad. Everything between your first app and real users.
-    link: /configuration/setup
+    details: The manual — a tutorial you build along with, a cookbook of tables, popups, navigation and uploads, and everything between your first app and real users.
+    link: /get_started/about
+  - title: Samples
+    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.6" y="4.2" width="18.8" height="15.6" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M2.6 9.1h18.8M8.2 9.1v10.7"/></svg>
+    details: Over 700 working apps, searchable by control, by library and by what your system can run — the UI5 demo kit rebuilt in ABAP, plus everything that needs OData, RAP or a launchpad.
+    link: https://abap2ui5.github.io/playground/samples/
+    target: _self
+  - title: Playground
+    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9.75" fill="none" stroke="currentColor" stroke-width="1.7"/><path d="M9.6 7.9v8.2a.5.5 0 0 0 .76.43l6.6-4.1a.5.5 0 0 0 0-.86l-6.6-4.1a.5.5 0 0 0-.76.43z" fill="currentColor"/></svg>
+    details: Write ABAP in the browser and watch the app run beside it. The whole framework compiled into a page — no server, no system, nothing to install.
+    link: https://abap2ui5.github.io/playground/
+    target: _self
 ---
 
-<!-- The second row of cards - see the note above the features. Every card is
-     one link, opened in a new tab: all three are somewhere else. The marks
-     are inline rather than Font Awesome's, the same three the nav bar
-     carries: an icon that is an empty square until a stylesheet from a CDN
-     arrives is worse than one that never needed it. -->
+## One class, one app
+
+This is a complete abap2UI5 application. It has a public attribute the view
+binds to, a view built in ABAP, and an event handler — nothing else. Press
+**Run this example** and it starts in your browser, on the real framework.
+
+```abap
+CLASS zcl_app_hello DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    DATA recipient TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+CLASS zcl_app_hello IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+
+    IF client->check_on_navigated( ).
+
+      recipient = `World`.
+
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+          )->ele( n = `View` ns = `mvc`
+              )->a( n = `xmlns`     v = `sap.m`
+              )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc`
+
+              )->ele( `Shell`
+                  )->ele( `Page`
+                      )->a( n = `title` v = `Hello abap2UI5`
+
+                      )->tag( `Input`
+                          )->a( n = `value` v = client->_bind( recipient )
+                      )->tag( `Button`
+                          )->a( n = `text`  v = `Say Hello`
+                          )->a( n = `press` v = client->_event( `SAY_HELLO` ) ).
+
+      client->view_display( view->stringify( ) ).
+
+    ELSEIF client->check_on_event( `SAY_HELLO` ).
+
+      client->message_toast_display( |Hello { recipient }!| ).
+
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- **The attribute is the model.** `recipient` travels to the browser, comes
+  back edited, and is a plain ABAP string on both sides. The framework
+  serializes your instance between roundtrips, so the class keeps its state
+  without any session handling of your own.
+- **The view is ABAP.** No XML file in a repository, no frontend project, no
+  build step — the view is built at runtime and sent as data.
+- **Events come back as ABAP.** `check_on_event( )` is where the button press
+  arrives, in the same class, with the model already updated.
+
+## What it needs, and what it does not
+
+| | |
+|---|---|
+| **Runs on** | NetWeaver 7.02 and up, S/4HANA, ABAP Cloud, on-premise, private and public cloud, and the trial systems |
+| **Installed with** | [abapGit](/get_started/quickstart) — one repository, no transport of frontend artefacts, no BSP application to maintain |
+| **Needs no** | JavaScript, OData service, RAP business object, CDS view, frontend project or Node toolchain |
+| **Speaks** | UI5, over stateless HTTP roundtrips against the framework's own service |
+| **Licence** | MIT, and the code is [on GitHub](https://github.com/abap2UI5/abap2UI5) |
+
+Old releases matter here: apps written on 7.02 use the same API as apps on ABAP
+Cloud, and [Downporting](/advanced/downporting) explains what the framework
+does so that they can.
+
+## Around the framework
+
+<div class="a2ui5-out">
+  <a class="a2ui5-out-card is-inside" href="/docs/resources/addons">
+    <span class="a2ui5-out-title">Add-ons</span>
+    <span class="a2ui5-out-details">Optional repositories for the things not every app needs: popups, HTTP and RFC connectors, a lock manager, table maintenance, launchpad KPIs.</span>
+  </a>
+  <a class="a2ui5-out-card" href="https://abap2ui5.github.io/linter/" target="_self">
+    <span class="a2ui5-out-title">Linter</span>
+    <span class="a2ui5-out-details">Rules that read abap2UI5 code as abap2UI5 — view chains, bindings, event wiring — with a rule reference you can read on its own.</span>
+  </a>
+  <a class="a2ui5-out-card is-inside" href="/docs/advanced/mcp_server">
+    <span class="a2ui5-out-title">Tooling</span>
+    <span class="a2ui5-out-details">A VS Code extension, an MCP server so an AI assistant answers from the real API, and an app template to start from.</span>
+  </a>
+</div>
+
+## Built in the open
+
 <div class="a2ui5-out">
   <a class="a2ui5-out-card" href="https://github.com/abap2UI5/abap2UI5/" target="_blank" rel="noreferrer">
     <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg></span>
@@ -82,9 +166,9 @@ features:
     <span class="a2ui5-out-title">LinkedIn</span>
     <span class="a2ui5-out-details">Follow along — new releases, articles, and what people are building with it right now.</span>
   </a>
-  <a class="a2ui5-out-card" href="https://abap2ui5.github.io/playground/" target="_blank" rel="noreferrer">
-    <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9.75" fill="none" stroke="currentColor" stroke-width="1.7"/><path d="M9.6 7.9v8.2a.5.5 0 0 0 .76.43l6.6-4.1a.5.5 0 0 0 0-.86l-6.6-4.1a.5.5 0 0 0-.76.43z" fill="currentColor"/></svg></span>
-    <span class="a2ui5-out-title">Playground</span>
-    <span class="a2ui5-out-details">Try it right now — write ABAP in the browser and watch it run. Nothing to install, nothing to sign up for.</span>
+  <a class="a2ui5-out-card is-inside" href="/docs/resources/sponsor">
+    <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 21s-7.6-4.9-9.5-9.2C1.1 8.4 3 5 6.4 5c2 0 3.4 1.1 4.3 2.3l1.3 1.7 1.3-1.7C14.2 6.1 15.6 5 17.6 5c3.4 0 5.3 3.4 3.9 6.8C19.6 16.1 12 21 12 21z"/></svg></span>
+    <span class="a2ui5-out-title">Sponsor</span>
+    <span class="a2ui5-out-details">The framework is free and maintained by volunteers. If it saved your project time, there is a way to give some back.</span>
   </a>
 </div>


### PR DESCRIPTION
Three things reported on the live bar, all measured before and after — plus the home page the bar's first item now names.

## The row twitched on every click

The item you are on is semibold, and semibold is **wider**: `Documentation` measures 114px at weight 400 and 122 at 600. So when the marked item changed, everything after it moved — stepping from Home to a page of the manual pushed Samples and Playground 6px sideways under the cursor.

This is new with this bar. The marked item used to be the same word on every page of the site, so nothing ever moved; with two sections on one deployment it moves on every click.

Each item now carries its own label a second time, in bold, in a pseudo-element with no height — never seen, it only reserves the width.

| | Home | Documentation | Samples | Playground |
|---|---|---|---|---|
| shift before | 0px | −1px | **+6px** | **+6px** |
| shift after | 0px | 0px | 0px | 0px |

## The search box was not in the middle

`margin: 0 auto` centres it in the free space of `.content-body`, which is not the middle of anything a reader can see: that row starts *after* the brand, and the group on its left is far wider than the three glyphs on its right.

Measured: **181px right of the window's centre**, at 1200, 1440 and 1920. Above 1100px it is now placed against `.container` — the element that spans the whole bar, brand included — and is off by **0px** at every width. Below that the auto margins stay: an absolutely placed box in a narrow row sooner or later sits on top of the words beside it.

The two `position: relative` rules undone to make that possible are the theme's own, and they were for the layout this bar stopped using when the brand came into the row.

## Documentation did not come back to where you were

On the other three bars it does; on this one it was a fixed link to the manual's first page, so Home → Documentation lost the chapter you were reading while Samples → Documentation kept it. Two halves were missing:

- the item is **lifted** from the stored position, with `/docs/` as the scope (the link is written deeper than the section it restores inside);
- `rememberHere()` no longer writes the **home page**. That second half is what makes the first work: if the front door were recorded, going Home would overwrite the chapter with `/docs/` and Documentation would open the home page — which is what the Home item is for.

Verified in a browser: read a chapter, click Home (stored value unchanged), click Documentation, land back on the chapter. With nothing stored it opens the manual's first page, as the markup says.

## A home page for the project

The Home item names this page, and it was still the documentation's front page — a hero, then three ways into three sections of *this* site. Somebody arriving from a talk or a colleague's link has not decided to read a manual yet.

It now answers, in order: **what it is** (hero, three buttons — try it, install it, understand it), **what one app looks like**, **where to go** (the bar's other three sections as cards), **what it needs and does not**, and **what is built around it**.

The example is a complete class with a **Run button**: not a screenshot of an app, the app, started on the page, on the real framework. The rule engine offers the button by itself and `check:playground` counts it — 83 app classes on the site, 64 with a button.

One supporting change in `style.css`: the tint and the ↗ on those cards are the row's whole signal, that a card *leaves* this site. Two of the new ones are pages of this manual, so a card that stays takes the feature cards' outline and drops the arrow.

## Verified

`npm run check` passes **all ten gates**; 68 unit tests green. Measurements and the browser checks were run against the built site at 1200/1440/1920px, in light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_