### PR TITLE
The bar is ours, the type is one, and a gate holds the four documents in step

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,6 +64,20 @@ jobs:
           sparse-checkout: SAMPLES.md
           sparse-checkout-cone-mode: false
 
+      # The playground's stylesheet, for the shared-design gate. One file, and
+      # continue-on-error because the gate falls back to the published copy
+      # over the network; when neither is reachable it fails rather than
+      # passing on one stylesheet agreeing with itself.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        continue-on-error: true
+        with:
+          repository: abap2UI5/playground
+          ref: main
+          path: .playground
+          fetch-depth: 1
+          sparse-checkout: src/catalogue/catalogue.css
+          sparse-checkout-cone-mode: false
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
@@ -101,6 +115,18 @@ jobs:
       - name: cross-site links
         if: ${{ !cancelled() }}
         run: npm run check:cross-site
+
+      # the values the four bars are made of - the palette, the two type
+      # stacks, the two radii - against the copy abap2UI5/playground keeps.
+      # They are copied by hand on purpose (a stylesheet fetched across two
+      # deployments would be a request in front of the first paint), and until
+      # this gate nothing compared the copies: they agreed because whoever
+      # touched one remembered the other. One had already drifted - two font
+      # stacks that lead with different families, which is one bar in two
+      # typefaces on Linux
+      - name: shared design values
+        if: ${{ !cancelled() }}
+        run: npm run check:design
 
       # the ABAP in the fenced blocks, against the real framework: does it
       # compile, and does the view it builds name controls and properties that

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,21 @@ jobs:
           sparse-checkout: SAMPLES.md
           sparse-checkout-cone-mode: false
 
+      # The playground's stylesheet, for the shared-design gate. One file, and
+      # continue-on-error because the gate falls back to the published copy
+      # over the network; when neither is reachable it fails rather than
+      # passing on one stylesheet agreeing with itself.
+      - name: Playground stylesheet
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        continue-on-error: true
+        with:
+          repository: abap2UI5/playground
+          ref: main
+          path: .playground
+          fetch-depth: 1
+          sparse-checkout: src/catalogue/catalogue.css
+          sparse-checkout-cone-mode: false
+
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -101,6 +116,9 @@ jobs:
       - name: release version
         if: ${{ !cancelled() }}
         run: npm run check:version
+      - name: shared design values
+        if: ${{ !cancelled() }}
+        run: npm run check:design
       - name: ABAP examples
         if: ${{ !cancelled() }}
         run: npm run check:examples

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,17 +30,19 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `docs/.vitepress/theme/style.css` | Everything this site looks like. Its palette is the playground's, copied — see *One site in three places* below |
 | `docs/.vitepress/theme/SiteBar.vue` | The right-hand end of the bar: the three sites, and the menu behind the bar's last button — the light/dark switch, the project's tools and its repositories. Rendered into `nav-bar-content-after` by `theme/index.js`; the marks between them are VitePress's own `socialLinks`, ordered by `style.css` |
 | `docs/.vitepress/theme/site-memory.js` | Where the reader was, on each site, so the bar comes back to it; pinned by `test/site-memory.test.mjs` |
+| `docs/.vitepress/theme/TheBar.vue` | The bar, as one element this repository owns: the brand, `SiteNav.vue` (the four sections), `SearchBox.vue`, the two marks, `SiteMenu.vue` (the menu behind the last button, and the version number `check:version` reads). It used to be the theme's bar with our parts in its slots and 85 override lines arguing its own parts out of the way; the theme now keeps two things, the hamburger and the screen it opens on a phone |
 | `docs/.vitepress/theme/SearchBox.vue` | The box in the middle of the bar and what it opens. `theme/search-engine.js` is the matching, framework-free because the other three bars carry a copy of it; both are pinned by `test/search.test.mjs` |
+| `scripts/check-design.mjs` | The palette, the type and the radii the four bars share, against `abap2UI5/playground`'s copy of them — needs a checkout (`PLAYGROUND_HOME`, `.playground`, `../playground`) or the network, and fails rather than passing without one. The table of what is shared, and both spellings of each value, is `scripts/lib/design.mjs` |
 | `scripts/check-cross-site.mjs` | Every link out of this deployment and into a neighbouring one on the same origin carries a `target`, or VitePress's router swallows it and shows this site's 404 at the other site's URL. Reads the BUILT html, so it runs after `docs:build`; the rule and the reasoning are in `scripts/lib/cross-site.mjs` |
 
 ## Build & verify — run before every commit
 
 ```bash
-npm run check          # test + check:version + docs:build + check:cross-site + check:examples + check:conventions + check:playground + check:api-names + check:api-reference + check:samples
+npm run check          # test + check:version + docs:build + check:cross-site + check:design + check:examples + check:conventions + check:playground + check:api-names + check:api-reference + check:samples
 ```
 
-A documentation repository has no compiler for its prose, but ten things in
-it are decidable, and all ten are decided before a merge:
+A documentation repository has no compiler for its prose, but eleven things in
+it are decidable, and all eleven are decided before a merge:
 
 | | |
 |---|---|
@@ -53,6 +55,7 @@ it are decidable, and all ten are decided before a merge:
 | `check:conventions` | the fenced ABAP against the house style the reader meets next: the view-chain layout, and the three section blocks of an app class. `check:examples` asks whether an example compiles and names real API — both questions about the framework; neither can see that a snippet is written in a different style from every sample. Measured against [samples-controls](https://github.com/abap2UI5/samples-controls) (637 classes, gated, at zero): five chains here showed the reader a different tree than the one that renders, and 57 of 86 app classes carried neither `PROTECTED SECTION.` nor `PRIVATE SECTION.`. What this gate deliberately does NOT take over is the blank-line and `t_arg` continuation rules — those are pattern-lint *warnings* over there and that corpus carries 382 of them |
 | `check:playground` | every complete app class on the site either carries a **Run** button or a marker on its page saying why it cannot run. The rules that offer the button fail towards *not* offering one, so without this an example nobody ever measured is indistinguishable from an example that can never run — which is exactly how the coverage ledger below went stale. What stays undecidable by CI — does a *buttoned* example actually start — is the measurement the Run-button section describes |
 | `check:cross-site` | every link that leaves this deployment for a neighbouring one on the same origin — the playground, the catalogue, the linter's rule pages — carries a `target`. Without it VitePress's router treats the link as a route of THIS site, finds no page behind `/playground/` and renders the 404 *at that URL*, which reads as the other site being broken. Every way out of the manual was in that state at once: both bar items, the Linter rules row in the menu and the Run bar's link. Judges the built HTML, so it runs straight after `docs:build`. What it cannot see is the Run bar's link — built in a browser, in no built page — which is why `test/cross-site.test.mjs` pins that one as source |
+| `check:design` | the values the four bars are made of — the seven palette colours, the two type stacks, the two radii — against the copy [abap2UI5/playground](https://github.com/abap2UI5/playground) keeps, in **both** schemes. They are copied by hand on purpose (a stylesheet fetched across two deployments is a request in front of the first paint), and until this gate nothing compared the copies: they agreed because whoever touched one remembered the other. One had already drifted — two font stacks leading with different families, which is the same face on macOS and Windows and two different ones on Linux, so the same four words in the same bar measured 59/122/78/97px here and 65/141/87/110 there. It compares the EFFECTIVE value (a property the dark block does not redeclare keeps its light one), because the two sides switch schemes differently: `.dark` here, `[data-theme]` over there |
 | `check:samples` | the **Working Samples** blocks, against [abap2UI5/samples](https://github.com/abap2UI5/samples) |
 
 **All four walking gates carry a floor.** A gate that checked nothing reports
@@ -64,7 +67,7 @@ page layout or the builder name is the likely cause. `check:cross-site` carries
 the same floor twice over: no HTML in `dist` at all, and no cross-site link on
 a site whose bar carries three of them on every page.
 
-`.github/workflows/check.yml` runs the same ten, in the same order. Keep the
+`.github/workflows/check.yml` runs the same eleven, in the same order. Keep the
 two in step: a step that exists only in `package.json` is a step no pull
 request has to pass, which is how `npm test` — the pin added *because* the
 catalogue parser broke twice in silence — went a release without CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
 All project guidance lives in **[AGENTS.md](AGENTS.md)** — the single source of
-truth for this repository (how the site is built, the ten gates, the playground rule engine, and what may be written where).
+truth for this repository (how the site is built, the eleven gates, the playground rule engine, and what may be written where).
 
 Read `AGENTS.md` before making any change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,4 @@ Nothing here is a source of truth about the framework: the API reference, the
 sample catalogue and the corpus figures are generated or checked against
 `abap2UI5`, `abap2UI5/samples` and its siblings. If a fact is wrong, it is
 usually wrong there first. [AGENTS.md](AGENTS.md) is the full contract — how
-the site is built, the ten gates, and what may be written where.
+the site is built, the eleven gates, and what may be written where.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ Every contribution makes the documentation better for the community!
 ```sh
 npm ci
 npm run docs:dev     # the site, with hot reload
-npm run check        # what CI runs, all ten steps
+npm run check        # what CI runs, all eleven steps
 ```
 
 ### What CI checks
 
-A documentation repository has no compiler for its prose, but ten things in
-it are decidable, and `npm run check` decides all ten before a merge — the
-prose builds (`docs:build`), every link into a neighbouring site on this origin
+A documentation repository has no compiler for its prose, but eleven things in
+it are decidable, and `npm run check` decides all eleven before a merge — the
+prose builds (`docs:build`), the four bars are still made of the same palette,
+type and radii as the playground's (`check:design`), every link into a
+neighbouring site on this origin
 — the playground, the catalogue — still leads there rather than to this site's
 own 404 (`check:cross-site`), the fenced ABAP examples compile and the views
 they build name real UI5 API (`check:examples`), those examples are written
@@ -43,7 +45,7 @@ passed. Several of these go stale without anybody touching this repository (a
 release is published elsewhere, a sample class is renamed elsewhere), which is
 why the deploy re-runs them rather than trusting the merge.
 
-**[AGENTS.md](AGENTS.md) describes each of the ten**, what a failure means and
+**[AGENTS.md](AGENTS.md) describes each of the eleven**, what a failure means and
 which of them need a sibling checkout to say anything at all — read it before
 changing anything beyond prose.
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -706,29 +706,12 @@ export default defineConfig({
     // (src/shell/index.html, src/catalogue/index.html), so the end of the bar
     // is the same two shapes on all four documents rather than two drawings of
     // the same two brands.
-    socialLinks: [
-      {
-        icon: {
-          svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>',
-        },
-        link: "https://www.linkedin.com/company/abap2ui5/",
-        ariaLabel: "abap2UI5 on LinkedIn",
-      },
-      {
-        icon: {
-          svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>',
-        },
-        link: "https://github.com/abap2UI5/abap2UI5",
-        ariaLabel: "abap2UI5 on GitHub",
-      },
-      // Two marks and no more, which is what the playground's bar and the
-      // catalogue's each carry. The playground used to be a third one here -
-      // a play triangle in a ring - and it is a NAV ITEM now
-      // (theme/SiteBar.vue), beside Samples and Docs: it is one of the three
-      // places this project lives, and naming it beats a glyph somebody has
-      // to hover. The Support page could never sit in this row for the
-      // opposite reason and still cannot; it stays under the version menu and
-      // in the sidebar.
-    ],
+    // EMPTY: the two marks are drawn by theme/TheBar.vue now, with the same
+    // inline paths the other three bars carry. They were `socialLinks` here,
+    // which the theme renders at the end of its own row - and holding them
+    // where this project's bar wants them took a block of margin and order
+    // overrides that is gone with them. A mark added here would reappear
+    // outside our bar, at the theme's size, in the theme's place.
+    socialLinks: [],
   },
 });

--- a/docs/.vitepress/theme/SiteMenu.vue
+++ b/docs/.vitepress/theme/SiteMenu.vue
@@ -1,119 +1,34 @@
 <script setup>
 /*
- * The right-hand end of the bar, which is the playground's right-hand end and
- * the sample catalogue's (src/shell/index.html, src/catalogue/catalogue.css in
- * abap2UI5/playground) down to the numbers: a hairline, where in this project
- * you are, a hairline, the two marks, then one more button, drawn as a third
- * mark, that opens the menu - the switch for light and dark, the project's
- * tools and its repositories. Four documents carry that group now - this one,
- * the playground, the catalogue and the per-sample pages - and somebody moving
- * between them reads ONE bar, so it is kept identical by hand rather than left
- * to four interpretations of a house style.
+ * The menu behind the bar's last button, drawn as a third mark: the switch for
+ * light and dark, the practical links, the project's tools and its
+ * repositories. The same rows in the same order as the other three bars carry
+ * (src/shell/index.html, src/catalogue/index.html, tools/sample-pages.mjs in
+ * abap2UI5/playground), kept in step by hand.
  *
- * The two marks are not here: they are VitePress's own `socialLinks`, which
- * draws the same LinkedIn and GitHub inline. The hairlines are in style.css,
- * where the ordering that puts the three sites before the marks and the menu
- * after them also is.
- *
- * The menu is a <details>, so it opens and closes with no script; the two
- * listeners below close it the two ways a menu is expected to close and a
- * <details> does not - a click anywhere outside it, and Escape. The same lines
- * as setUpExtra() in the playground's catalogue.mjs and extra.mjs.
+ * It is a <details>, so it opens and closes with no script; the two listeners
+ * below close it the two ways a menu is expected to close and a <details> does
+ * not - a click anywhere outside it, and Escape. The same lines as
+ * setUpExtra() in the playground's catalogue.mjs and extra.mjs.
  */
-import { computed, inject, onMounted, ref, watch } from "vue";
+import { inject, onMounted, ref, watch } from "vue";
 import { useData } from "vitepress";
-import { lastVisited } from "./site-memory.js";
 
-const { isDark, page } = useData();
+const { isDark } = useData();
 
 /* The released framework version - z2ui5_if_app=>version in
  * abap2UI5/src/02/z2ui5_if_app.intf.abap is where the number comes from, and
  * check:version (scripts/lib/release.mjs) holds this line against the newest
  * release tag, the deprecations page and the changelog. It stood in a nav
  * dropdown of its own until the bar was rebuilt around the four sections; the
- * four entries under it - release notes, support, contribute, sponsor - were
- * already in the menu below, so what was left of that dropdown was the
- * NUMBER, and this is where the number went. Moving it means moving the
- * pattern in release.mjs with it. */
+ * four entries under it were already in this menu, so what was left of that
+ * dropdown was the NUMBER, and this is where it went. Moving it means moving
+ * the pattern in release.mjs with it. */
 const VERSION = "1.144.0";
 
-/* The same three items serve the bar and the menu a phone opens instead of it
- * (`nav-screen-content-after`). Only the menu behind the third mark differs:
- * down there VitePress draws its own appearance control and the Links group,
- * and two of each in one screen is one too many. */
-defineProps({ theme: { type: Boolean, default: true } });
-
-const PLAYGROUND = "https://abap2ui5.github.io/playground/";
-const SAMPLES = "https://abap2ui5.github.io/playground/samples/";
-/* The two sections of THIS deployment. Home is the page the brand has always
- * opened and nothing else ever named; Documentation opens on the first page of
- * the manual, which is where the Guide dropdown used to send a reader who
- * clicked its first entry. Both are pages of this site, so neither needs the
- * `target` the two above carry. */
-const HOME = "/docs/";
-const DOCS = "/docs/get_started/about";
-
-/* Which of the two is the one you are on. `relativePath` rather than the URL:
- * it is what the server rendered as well, so the bar is right in the HTML and
- * not only after hydration. */
-const onHome = computed(() => page.value.relativePath === "index.md");
-
-/* EVERY LINK OUT OF THIS SITE AND INTO A NEIGHBOURING ONE CARRIES A `target`,
- * and it is not decoration: without it the link does not arrive.
- *
- * The three sites share an origin - the thing that makes the shared theme and
- * the shared position memory possible - and that is also what breaks a plain
- * link between them. This site is a single page application: VitePress's
- * router takes over any link that is same-origin and looks like a page, and
- * /playground/ is both. It then has no page of THIS site to render there, so
- * it drew this site's 404 at the playground's URL. `_self` is the value
- * because it is the behaviour these items already promised - one site, one
- * tab. A link to another host needs nothing; only abap2ui5.github.io outside
- * /docs/ is affected. scripts/lib/cross-site.mjs is the whole story, and
- * scripts/check-cross-site.mjs holds the built site to it. */
-const SAME_TAB = "_self";
-
-/* The two links the memory can move, as the SERVER renders them: the front
- * page of each section. That is what a crawler is given and what a first visit
- * follows; onMounted only ever replaces one with a deeper page of the same
- * section. */
-const samplesHref = ref(SAMPLES);
-const docsHref = ref(DOCS);
 const extra = ref(null);
-/* Lifted on mount, and again whenever it can have moved while this page stayed
- * open: the catalogue narrowed in another tab, a Back that brought this page
- * out of the back-forward cache. The click itself is the lift that cannot be
- * missed - the href is set on the element there, before the browser follows
- * it, because a ref set in the handler reaches the DOM a tick too late. */
-/* Documentation restores WHEREVER IN THE MANUAL you were, which is why it
- * passes a scope: the link is written at the manual's first page, and a stored
- * /docs/cookbook/... is not inside that page. Without the third argument the
- * containment test is against `get_started/about` alone and every restore
- * falls back - which is exactly how this item behaved on this site while the
- * other three bars restored it correctly. The scope is a value passed HERE,
- * never one out of storage.
- *
- * The Home page is deliberately not part of it: rememberHere() does not write
- * it (theme/index.js), so going Home and back does not overwrite the page you
- * were reading with the front door. */
-const lift = () => {
-  samplesHref.value = lastVisited("samples", SAMPLES);
-  docsHref.value = lastVisited("docs", DOCS, HOME);
-};
-/* The lift that cannot be missed: on the click itself, on the element, because
- * a ref set in the handler reaches the DOM a tick too late. */
-const liftNow = (e) => {
-  const el = e.currentTarget;
-  el.href = el.dataset.site === "docs"
-    ? lastVisited("docs", DOCS, HOME)
-    : lastVisited("samples", SAMPLES);
-};
+
 onMounted(() => {
-  lift();
-  addEventListener("pageshow", lift);
-  document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") lift();
-  });
   document.addEventListener("click", (e) => {
     const el = extra.value;
     if (el?.open && !el.contains(e.target)) el.open = false;
@@ -147,23 +62,12 @@ watch(isDark, (dark) => {
 </script>
 
 <template>
-  <nav class="bar-nav" aria-label="abap2UI5 sites">
-    <!-- The four sections of the project, left to right in the order a reader
-         meets them, and the one you are on marked. Home and Documentation are
-         two sections of THIS deployment now - the section that used to be one
-         non-clickable word ("Documentation") is two places a reader can move
-         between, which is what the brand alone could not offer. -->
-    <a :href="HOME" data-text="Home" :class="{ here: onHome }" :aria-current="onHome ? 'page' : undefined" title="abap2UI5 in one page">Home</a>
-    <a :href="docsHref" data-text="Documentation" data-site="docs" :class="{ here: !onHome }" :aria-current="!onHome ? 'page' : undefined" title="The manual, where you left it" @click="liftNow">Documentation</a>
-    <a :href="samplesHref" data-text="Samples" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
-    <a :href="PLAYGROUND" data-text="Playground" :target="SAME_TAB" title="Write ABAP and run it in the browser">Playground</a>
-  </nav>
   <!-- The rest of abap2UI5 behind one more button: light or dark, then the
        practical links (issues, release notes, install, support), the project's
        tools and its repositories by kind - the same rows, in the same order,
        as the other three bars carry. The switch says what a press does and
        swaps its whole label with the theme (style.css). -->
-  <details v-if="theme" ref="extra" class="a2ui5-extra">
+  <details ref="extra" class="a2ui5-extra">
     <summary class="a2ui5-extra-button" title="More: light or dark, and the rest of abap2UI5" aria-label="More: light or dark, and the rest of abap2UI5">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="5" cy="12" r="2.2"/><circle cx="12" cy="12" r="2.2"/><circle cx="19" cy="12" r="2.2"/></svg>
     </summary>
@@ -181,9 +85,16 @@ watch(isDark, (dark) => {
       <a href="/docs/resources/sponsor">Sponsor</a>
       <span class="a2ui5-menu-head">Tools</span>
       <a href="https://github.com/abap2UI5/linter" target="_blank" rel="noopener">Linter</a>
-      <!-- Same origin, another deployment: the attribute above, not the
-           `target="_blank"` the github.com rows carry. -->
-      <a href="https://abap2ui5.github.io/linter/" :target="SAME_TAB">Linter rules</a>
+      <!-- SAME ORIGIN, ANOTHER DEPLOYMENT: `target="_self"`, not the
+           `target="_blank"` the github.com rows carry, and not nothing - a
+           link to abap2ui5.github.io outside /docs/ that carries no target at
+           all is taken over by VitePress's router and lands on this site's
+           404 (scripts/lib/cross-site.mjs). It was bound to a constant that
+           stayed behind in SiteNav.vue when this menu became its own
+           component, which made it exactly that link for one build;
+           check:cross-site caught it. Written out, so the next split cannot
+           lose it again. -->
+      <a href="https://abap2ui5.github.io/linter/" target="_self">Linter rules</a>
       <a href="https://github.com/abap2UI5/vscode-extension" target="_blank" rel="noopener">VS Code extension</a>
       <a href="/docs/advanced/mcp_server">MCP server</a>
       <a href="https://github.com/abap2UI5/app-template" target="_blank" rel="noopener">App template</a>

--- a/docs/.vitepress/theme/SiteNav.vue
+++ b/docs/.vitepress/theme/SiteNav.vue
@@ -1,0 +1,102 @@
+<script setup>
+/*
+ * The four sections of the project — the same four, in the same order, as the
+ * playground's bar, the catalogue's and every per-sample page's
+ * (src/shell/index.html, src/catalogue/index.html, tools/sample-pages.mjs in
+ * abap2UI5/playground). Somebody moving between the four documents reads ONE
+ * bar, so the group is kept identical by hand rather than left to four
+ * interpretations of a house style.
+ *
+ * This component is used twice: in the bar (TheBar.vue) and in the menu a
+ * phone opens instead of it, where the same four items are a list rather than
+ * a strip.
+ */
+import { computed, onMounted, ref } from "vue";
+import { useData } from "vitepress";
+import { lastVisited } from "./site-memory.js";
+
+const { page } = useData();
+
+/* EVERY LINK OUT OF THIS SITE AND INTO A NEIGHBOURING ONE CARRIES A `target`,
+ * and it is not decoration: without it the link does not arrive.
+ *
+ * The three sites share an origin - the thing that makes the shared theme and
+ * the shared position memory possible - and that is also what breaks a plain
+ * link between them. This site is a single page application: VitePress's
+ * router takes over any link that is same-origin and looks like a page, and
+ * /playground/ is both. It then has no page of THIS site to render there, so
+ * it drew this site's 404 at the playground's URL. `_self` is the value
+ * because it is the behaviour these items already promised - one site, one
+ * tab. A link to another host needs nothing; only abap2ui5.github.io outside
+ * /docs/ is affected. scripts/lib/cross-site.mjs is the whole story, and
+ * scripts/check-cross-site.mjs holds the built site to it. */
+const SAME_TAB = "_self";
+
+const PLAYGROUND = "https://abap2ui5.github.io/playground/";
+const SAMPLES = "https://abap2ui5.github.io/playground/samples/";
+/* The two sections of THIS deployment. Home is the page the brand has always
+ * opened and nothing else ever named; Documentation opens the manual. Both are
+ * pages of this site, so neither needs the `target` the two above carry. */
+const HOME = "/docs/";
+const DOCS = "/docs/get_started/about";
+
+/* Which of the two is the one you are on. `relativePath` rather than the URL:
+ * it is what the server rendered as well, so the bar is right in the HTML and
+ * not only after hydration. */
+const onHome = computed(() => page.value.relativePath === "index.md");
+
+/* The two links the memory can move, as the SERVER renders them: the front
+ * page of each section. That is what a crawler is given and what a first visit
+ * follows; onMounted only ever replaces one with a deeper page of the same
+ * section. */
+const samplesHref = ref(SAMPLES);
+const docsHref = ref(DOCS);
+
+/* Documentation restores WHEREVER IN THE MANUAL you were, which is why it
+ * passes a scope: the link is written at the manual's first page, and a stored
+ * /docs/cookbook/... is not inside that page. Without the third argument every
+ * restore falls back - which is how this item behaved on this site while the
+ * other three bars restored it correctly. The scope is a value passed HERE,
+ * never one out of storage.
+ *
+ * The Home page is deliberately not part of it: rememberHere() does not write
+ * it (theme/index.js), so going Home and back does not overwrite the page you
+ * were reading with the front door. */
+const lift = () => {
+  samplesHref.value = lastVisited("samples", SAMPLES);
+  docsHref.value = lastVisited("docs", DOCS, HOME);
+};
+/* The lift that cannot be missed: on the click itself, on the element, because
+ * a ref set in the handler reaches the DOM a tick too late. */
+const liftNow = (e) => {
+  const el = e.currentTarget;
+  el.href = el.dataset.site === "docs"
+    ? lastVisited("docs", DOCS, HOME)
+    : lastVisited("samples", SAMPLES);
+};
+
+/* Lifted on mount, and again whenever the stored position can have moved while
+ * this page stayed open: the catalogue narrowed in another tab, a Back that
+ * brought this page out of the back-forward cache. */
+onMounted(() => {
+  lift();
+  addEventListener("pageshow", lift);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") lift();
+  });
+});
+</script>
+
+<template>
+  <nav class="bar-nav" aria-label="abap2UI5 sites">
+    <!-- The four sections of the project, left to right in the order a reader
+         meets them, and the one you are on marked. Home and Documentation are
+         two sections of THIS deployment now - the section that used to be one
+         non-clickable word ("Documentation") is two places a reader can move
+         between, which is what the brand alone could not offer. -->
+    <a :href="HOME" data-text="Home" :class="{ here: onHome }" :aria-current="onHome ? 'page' : undefined" title="abap2UI5 in one page">Home</a>
+    <a :href="docsHref" data-text="Documentation" data-site="docs" :class="{ here: !onHome }" :aria-current="!onHome ? 'page' : undefined" title="The manual, where you left it" @click="liftNow">Documentation</a>
+    <a :href="samplesHref" data-text="Samples" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
+    <a :href="PLAYGROUND" data-text="Playground" :target="SAME_TAB" title="Write ABAP and run it in the browser">Playground</a>
+  </nav>
+</template>

--- a/docs/.vitepress/theme/TheBar.vue
+++ b/docs/.vitepress/theme/TheBar.vue
@@ -1,0 +1,72 @@
+<script setup>
+/*
+ * THE BAR, AS ONE ELEMENT THIS REPOSITORY OWNS.
+ *
+ * It used to be VitePress's bar with our parts pushed into its slots and its
+ * own parts argued out of the way in CSS: 85 selector lines under
+ * `.Layout .VPNav …`, fighting 42 theme elements — the brand's absolute
+ * placement over the sidebar column, the flex `order` of five slot children,
+ * the theme's `position: relative` on two wrappers, its "…" menu, its
+ * appearance switch, its social links' margins. Every fix in that layout had
+ * to undo something first; centring the search box needed two of the theme's
+ * own rules taken back before it could be measured at all.
+ *
+ * So the bar is one element now, rendered into `nav-bar-content-before`, and
+ * everything inside it is ours: the brand, the four sections, the search box,
+ * the two marks, the menu. The theme keeps exactly two things, because they
+ * are worth keeping and are not worth rebuilding: the hamburger and the screen
+ * it opens on a phone (`nav-screen-content-after` carries the same SiteNav).
+ *
+ * What this buys, beyond the deleted CSS: the four documents now carry the
+ * same MARKUP, not four readings of one description — this template is
+ * `src/shell/index.html`'s bar, in Vue.
+ */
+import { withBase } from "vitepress";
+import SearchBox from "./SearchBox.vue";
+import SiteNav from "./SiteNav.vue";
+import SiteMenu from "./SiteMenu.vue";
+
+/* Through `withBase`, not written out: a bare `/docs/logo.png` in a template
+ * is an import to Vite, which then tries to resolve it as a module and fails
+ * the build. It is also the one place the site's base path would have to be
+ * repeated by hand. */
+const HOME = withBase("/");
+const LOGO = withBase("/logo.png");
+</script>
+
+<template>
+  <div class="a2ui5-bar">
+    <!-- The mark and the name, closed by a hairline. A link to the home page,
+         which is what a brand is everywhere else on this origin; the nav says
+         which section you are in, so the brand does not say it too. -->
+    <a class="a2ui5-brand" :href="HOME">
+      <img :src="LOGO" alt="" width="20" height="20">
+      <span>abap2UI5</span>
+    </a>
+
+    <SiteNav />
+
+    <!-- Centred on THIS element, which spans the whole bar — the reason the
+         box can simply be placed at 50% now instead of being pushed towards
+         the middle by auto margins in a row that starts after the brand. -->
+    <SearchBox />
+
+    <!-- The two marks, inline SVG rather than by name: VitePress draws a named
+         icon from a CSS mask and, if that mask was not generated, fetches the
+         glyph from a CDN. These are the exact paths the other three bars
+         carry, so the end of the bar is the same two shapes on all four
+         documents rather than two drawings of the same two brands. -->
+    <div class="a2ui5-socials">
+      <a href="https://www.linkedin.com/company/abap2ui5/" target="_blank" rel="noopener"
+         aria-label="abap2UI5 on LinkedIn" title="abap2UI5 on LinkedIn">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>
+      </a>
+      <a href="https://github.com/abap2UI5/abap2UI5" target="_blank" rel="noopener"
+         aria-label="abap2UI5 on GitHub" title="abap2UI5 on GitHub">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+      </a>
+    </div>
+
+    <SiteMenu />
+  </div>
+</template>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -3,8 +3,8 @@ import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
 import { setUpPlayground } from './playground.js'
-import SiteBar from './SiteBar.vue'
-import SearchBox from './SearchBox.vue'
+import TheBar from './TheBar.vue'
+import SiteNav from './SiteNav.vue'
 import { rememberHere } from './site-memory.js'
 
 /** @type {import('vitepress').Theme} */
@@ -17,19 +17,17 @@ export default {
   // lands: the slot renders after VitePress's own appearance switch and
   // social links, and CSS orders the sites back in front of the marks and the
   // menu after them.
+  // ONE ELEMENT, AND IT IS OURS (TheBar.vue). The theme's own bar keeps
+  // exactly two parts, because they are worth keeping and not worth
+  // rebuilding: the hamburger, and the screen it opens on a phone - which
+  // carries the same four sections as a list.
   Layout() {
     return h(DefaultTheme.Layout, null, {
-      // The search, in the middle of the row. `nav-bar-content-before` is the
-      // FIRST thing in `.content-body`; style.css gives it auto margins, which
-      // is what centres it between the four sections on the left and the marks
-      // on the right. It is not in SiteBar because SiteBar is rendered twice -
-      // the bar and the screen a phone opens instead of it - and two search
-      // boxes in one document is two ids, two shortcuts and one of them wrong.
-      'nav-bar-content-before': () => h(SearchBox),
-      'nav-bar-content-after': () => h(SiteBar),
-      'nav-screen-content-after': () => h(SiteBar, { theme: false }),
+      'nav-bar-content-before': () => h(TheBar),
+      'nav-screen-content-after': () => h(SiteNav),
     })
   },
+
   enhanceApp({ app, router, siteData }) {
     // The Run button under a runnable ABAP example. One delegated listener for
     // the whole site — the browser half of docs/.vitepress/playground.mjs.

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -104,11 +104,50 @@
  * `config.mjs` and applied by nothing: no rule in this file, or anywhere
  * else, ever named them. They are gone from the head with this change. */
 :root {
-  --vp-font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI",
-                         "Noto Sans", Helvetica, Arial, sans-serif,
+  /* THE SAME TWO STACKS AS THE OTHER THREE DOCUMENTS, character for character
+   * (`--font-ui` / `--font-mono` in src/catalogue/catalogue.css and
+   * src/shell/shell.css over there). They were two stacks that agreed on every
+   * platform but one: this one led with `-apple-system` and the playground's
+   * with `system-ui`, which resolve to the same face on macOS and to the same
+   * fallback on Windows - and to DIFFERENT fonts on Linux, where
+   * `-apple-system` means nothing. Measured there, the four bars drew the same
+   * four words at 59/122/78/97px here and 65/141/87/110 over there: one bar in
+   * two typefaces.
+   *
+   * `system-ui` leads now, with `-apple-system` behind it for the Safari
+   * versions that predate it, and the union of both mono lists. Both files
+   * carry the same string, and check:design holds them to it - the palette
+   * below has been copied by hand between the repositories since it was
+   * written, and until that gate existed nothing but care kept it true. */
+
+  /* TWO RADII, NAMED, AND THE SAME TWO IN ALL FOUR DOCUMENTS.
+   *
+   * Neither side of this project had a scale before: measured across the two
+   * stylesheets there were 5, 6, 8, 4, 10 and 999px in use, and the spread
+   * INSIDE each was as wide as the spread between them. So this is not "the
+   * catalogue's number, adopted" - there was no number to adopt. It is one
+   * decision, written down once:
+   *
+   *   control   what you click or type in - a pill, a button, an input, the
+   *             search box in the bar. 5px, which is what the bar already
+   *             carried on all four documents.
+   *   surface   what things sit ON - a panel, a dialog, a card. 8px.
+   *
+   * What is deliberately NOT swept into them is every existing 6px in this
+   * file: the reading column's own furniture (code blocks, custom blocks, the
+   * feature cards) is VitePress's scale, it is internally consistent, and
+   * re-cutting twenty corners for a pixel nobody can see next to a page they
+   * are not looking at would be a large diff buying nothing. The tokens are
+   * for what the four documents SHARE, and check:design holds those to the
+   * same values on both sides. */
+  --radius-control: 5px;
+  --radius-surface: 8px;
+
+  --vp-font-family-base: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+                         Roboto, "Noto Sans", Helvetica, Arial, sans-serif,
                          "Apple Color Emoji", "Segoe UI Emoji";
-  --vp-font-family-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
-                         Consolas, "Liberation Mono", monospace;
+  --vp-font-family-mono: ui-monospace, SFMono-Regular, "SF Mono", "Cascadia Mono",
+                         Menlo, Consolas, "Liberation Mono", monospace;
 
   /* Body links in the accent.
    *
@@ -1275,86 +1314,60 @@
   }
 }
 
-/* ============================================== the bar the three sites share ===
+/* ============================================== the bar the four sites share ===
  *
- * The playground, the sample catalogue and this site are three deployments on
- * one origin, and from here on they wear ONE bar: the mark and the name,
- * closed by a hairline; at the other end a hairline, the three sites with the
- * one you are on in bold, a hairline, LinkedIn and GitHub, then the button
- * that opens the menu - light or dark, the project's tools and repositories.
- * The numbers below are the catalogue's own (src/catalogue/catalogue.css in
- * abap2UI5/playground) — 46px tall on the sunken grey, 5px pills, 18px marks
- * in a 30px box, every hairline 16px from what is on either side of it —
- * because a reader crossing between them should read one bar and not three
- * interpretations of a house style.
+ * The playground, the sample catalogue, the per-sample pages and this site are
+ * four deployments on one origin, and they wear ONE bar: the mark and the
+ * name, closed by a hairline; the four sections of the project with the one
+ * you are on in bold; the search box in the middle; then a hairline, LinkedIn
+ * and GitHub, then the button that opens the menu - light or dark, the
+ * project's tools and repositories.
  *
- * What is NOT the catalogue's is everything this site has that a catalogue
- * does not: the search box, the Guide and Links menus, the version menu.
- * Those keep VitePress's own drawing and only lose their size, so they sit in
- * the row rather than setting its height.
+ * THE BAR IS ONE ELEMENT OF OURS NOW (theme/TheBar.vue), rendered into
+ * `nav-bar-content-before`. It used to be the theme's bar with our parts
+ * pushed into its slots and its own parts argued out of the way here: 85
+ * selector lines under `.Layout .VPNav …` against 42 theme elements - the
+ * brand placed absolutely over the sidebar's column, five slot children
+ * ordered by hand, two wrappers made `position: relative` by the theme, its
+ * own "…" menu, its appearance switch, its social links' margins. Every
+ * change in that layout had to undo something first: centring the search box
+ * needed two of the theme's rules taken back before it could be measured.
  *
- * The three items and the menu are theme/SiteBar.vue, rendered into the
- * `nav-bar-content-after` slot — which is the LAST thing in the row, after
- * VitePress's own appearance switch and social links. `order` puts each half
- * where it belongs, the sites before the marks and the menu after them; see
- * below.
+ * What is left below is the small half of that: the theme's bar is now a
+ * CONTAINER for one element, so what it needs is a height, a colour, a
+ * hairline, and its own parts told not to draw. Everything else in this
+ * section styles our own markup and reads like the catalogue's stylesheet,
+ * because it is the same bar - 46px on the sunken grey, 5px pills, 18px marks
+ * in a 30px box, every hairline 16px from what is on either side of it.
+ *
+ * The theme keeps exactly two things, because they are worth keeping and not
+ * worth rebuilding: the hamburger, and the screen it opens on a phone.
  *
  * Specificity, as everywhere in this file: the theme's rules are Vue SCOPED
  * styles and compile with a `[data-v-…]` attribute, so a bare class here would
  * lose to them. `.Layout .VPNav` in front of a rule takes it to three units
- * and past most of them; where the theme's own selector is longer than that,
- * the rule below says so and carries more.
+ * and past most of them.
  */
 
 :root {
   /* 46px, the catalogue's bar height. Everything the theme lays out under the
-   * bar — the sidebar's top, the scroll offset a `#hash` lands at, the home
-   * page's hero padding — is written against this variable, so the one number
+   * bar - the sidebar's top, the scroll offset a `#hash` lands at, the home
+   * page's hero padding - is written against this variable, so the one number
    * moves all of it. */
   --vp-nav-height: 46px;
   --vp-nav-bg-color: var(--bg-sunken);
-  /* The mark, at the size the other three bars draw it. */
-  --vp-nav-logo-height: 20px;
 }
 
 /* The bar is the sunken grey at every width and on every page, the home page
- * included. The theme leaves it TRANSPARENT at the top of the home page and
- * paints only the `.content-body` strip on a page with a sidebar; both are
- * good decisions for a site whose bar is its own, and neither survives the
- * bar being shared with two other documents. `:not(.screen-open)` is not a
- * condition, it is a fourth unit of specificity — the theme's own rule for an
- * open mobile menu paints the same colour anyway. */
+ * included. `:not(.screen-open)` is not a condition, it is a fourth unit of
+ * specificity - the theme's own rule for an open mobile menu paints the same
+ * colour anyway. */
 .Layout .VPNav .VPNavBar:not(.screen-open) {
   background-color: var(--bg-sunken);
 }
 
-/* NOTHING INSIDE IT CARRIES A FILL. The theme draws this bar in pieces — a
- * transparent bar with a painted brand and a painted content strip, so that
- * the strip can fade in over the home page's hero — and both pieces are
- * `var(--vp-nav-height)` tall, which is one pixel MORE than the bar's content
- * box now that the bar carries the hairline as its own bottom border. Each of
- * them therefore painted over that pixel: the fill under the brand hid the
- * line beneath the mark, the fill under the content hid it from the search box
- * rightwards, and what was left read as a rule with two gaps in it. With the
- * whole bar painted above, neither fill has anything left to do. */
-.Layout .VPNav .VPNavBar .title,
-.Layout .VPNav .VPNavBar .content-body {
-  background-color: transparent;
-}
-
-/* And the content strip is held INSIDE the bar's content box, one pixel short
- * of it, rather than only asked not to paint. The theme's own fill for that
- * strip is `.VPNavBar:not(.home.top) .content-body` — five units against the
- * four above it, so it wins the colour argument on a page that is not the home
- * page at the top, and the hairline came back missing from the sidebar's edge
- * rightwards. It cannot cover a row it does not reach; the height rule is two
- * units in the theme, so this one wins it outright. */
-.Layout .VPNav .VPNavBar .content-body {
-  height: calc(var(--vp-nav-height) - 1px);
-}
-
 /* One hairline under the bar, and one only. The theme draws its own as a
- * `.divider` element BELOW the 46px — so the bar came to 47px and the line was
+ * `.divider` element BELOW the 46px - so the bar came to 47px and the line was
  * two pixels thick everywhere the brand did not cover it. The border is inside
  * the 46, which is where the catalogue's is. */
 .Layout .VPNav .VPNavBar {
@@ -1365,42 +1378,29 @@
   display: none;
 }
 
-/* The brand: the mark and the name (`siteTitle` in config.mjs), closed by a
- * hairline 16px from it - 8 of the gap, 8 of its own margin - as on the other
- * three bars. The theme sets 16px semibold, which is a heading; over there it
- * is body text. */
-.Layout .VPNav .VPNavBar .title {
-  font-size: 14px;
-  font-weight: 400;
-  gap: 8px;
+/* THE THEME'S OWN PARTS, TOLD NOT TO DRAW. Each one is replaced by something
+ * in TheBar.vue: its brand by ours, its search slot by our box, its nav menu
+ * by the four sections, its appearance switch and its "…" menu by the menu
+ * behind the last mark, its social links by the two marks we draw. They are
+ * hidden rather than removed because the theme still mounts them, and two of
+ * them still do work while invisible: the appearance switch is what `isDark`
+ * is read and written through. */
+.Layout .VPNav .VPNavBar .title,
+.Layout .VPNav .VPNavBar .search,
+.Layout .VPNav .VPNavBar .menu,
+.Layout .VPNav .VPNavBar .translations,
+.Layout .VPNav .VPNavBar .appearance,
+.Layout .VPNav .VPNavBar .social-links,
+.Layout .VPNav .VPNavBar .extra {
+  display: none;
 }
 
-.Layout .VPNav .VPNavBar a.title::after {
-  content: "";
-  width: 1px;
-  height: 22px;
-  margin-left: 8px;
-  background: var(--line);
-}
-
-.Layout .VPNav .VPNavBar .title .logo {
-  margin-right: 0;
-}
-
-/* ------------------------------------------------------- the measure ---
- *
- * The catalogue's bar stands 20px from either edge at every width, over the
- * whole width, and 12px on a phone (catalogue.css); the theme's stands 24 and
- * then 32, and from 1440px it is centred with the page under it. A reader
- * crossing from the catalogue saw the brand step 12px to the right and the
- * menu's button step in from the edge - the one difference left between the
- * four bars, and one with no reason behind it. So: the catalogue's numbers,
- * for the two layouts the theme has. On a page without a sidebar the bar is
- * one `.wrapper` with padding and a centred `.container`; on a page with one,
- * from 960px, the wrapper's padding goes and the brand is placed absolutely
- * at the left, with the content strip padded to sit beside it. The sidebar's
- * own text stays where the theme puts it (32px): it is a column of the page,
- * not part of the bar. */
+/* And the row that holds ours: the whole width, 20px from either edge, 12px on
+ * a phone - the catalogue's measure, for the two layouts the theme has. On a
+ * page with a sidebar the theme pads this strip by the sidebar's width so it
+ * lines up with the column below; that was right when the brand sat
+ * absolutely over that column and is a 272px hole now that the brand is in
+ * the row. */
 .Layout .VPNav .VPNavBar .wrapper {
   padding: 0 20px;
 }
@@ -1409,49 +1409,29 @@
   max-width: none;
 }
 
-/* ONE ROW, AND THE BRAND IS PART OF IT.
- *
- * The theme has two nav layouts, and the second one is the reason this block
- * exists. On a page with a sidebar it places the brand ABSOLUTELY over the
- * sidebar's column and pads the content strip by the sidebar's width, so that
- * the two line up with the columns below them. That is a good decision for a
- * bar whose only job is to sit on top of this site - and it puts a 272px gap
- * between the brand and the first thing after it, which is exactly where the
- * four sections now go. Left of the gap: the mark. Right of it: everything.
- *
- * So the brand is placed in the row like any other item, at every width, and
- * the content strip beside it starts where the brand ends. The bar reads as
- * one row across the whole width - which is what the catalogue's bar already
- * was, and what the sections needed to sit next to the name. */
+.Layout .VPNav .VPNavBar .content {
+  flex: 1;
+}
+
+.Layout .VPNav .VPNavBar .content-body {
+  height: calc(var(--vp-nav-height) - 1px);
+  background: transparent;
+}
+
 @media (min-width: 960px) {
   .Layout .VPNav .VPNavBar.has-sidebar .wrapper {
-    padding: 0 0 0 20px;
-  }
-
-  .Layout .VPNav .VPNavBar.has-sidebar .title {
-    position: static;
-    padding: 0;
-    width: auto;
+    padding: 0 20px;
   }
 
   .Layout .VPNav .VPNavBar.has-sidebar .content {
-    padding-right: 20px;
+    padding-right: 0;
     padding-left: 0;
   }
 }
 
-/* The same two rules again for the width at which the theme centres the bar
- * over the page: from 1440px it recomputes the brand's width and the strip's
- * padding from the layout's max width, and both terms are the sidebar again.
- * Left as they were, the gap comes back on a wide screen only. */
 @media (min-width: 1440px) {
-  .Layout .VPNav .VPNavBar.has-sidebar .title {
-    padding-left: 0;
-    width: auto;
-  }
-
   .Layout .VPNav .VPNavBar.has-sidebar .content {
-    padding-right: 20px;
+    padding-right: 0;
     padding-left: 0;
   }
 }
@@ -1462,105 +1442,45 @@
   }
 }
 
-/* ---------------------------------------------------- the row's order ---
+/* ------------------------------------------------------------ our bar ---
  *
- * `.content-body` is a flex row, so the slot's content can be moved without
- * moving it in the DOM. Three groups, in this order:
- *
- *   the four sections   hard against the brand, which is what "the menu on
- *                       the left" means: a reader's eye starts at the mark and
- *                       the next thing it meets is where they can go
- *   the search          in the middle, on auto margins - it takes whatever is
- *                       left between the sections and the marks, so it is
- *                       centred in the row's free space at every width
- *                       rather than at a number that is only right on one
- *                       screen
- *   the rest            the two marks and the menu behind the last button,
- *                       right, where they were
- *
- * The DOM order is search (`nav-bar-content-before`), then the sections and
- * the menu (`nav-bar-content-after`); `order` is what makes the row read
- * left to right. The hamburger stays last. */
-.Layout .VPNav .VPNavBar .bar-nav { order: 1; }
-.Layout .VPNav .VPNavBar .a2ui5-search-button { order: 2; margin: 0 auto; }
-
-/* THE BOX IS CENTRED ON THE BAR, NOT ON WHAT IS LEFT OVER.
- *
- * `margin: 0 auto` above centres it in the free space of `.content-body`, and
- * that is not the middle of anything a reader can see: the row it sits in
- * starts AFTER the brand, and the group on its left (four words) is far wider
- * than the group on its right (three glyphs). Measured, it stood 181px right
- * of the window's centre at every width - which is what it looked like.
- *
- * So above the width where the row is comfortable it is placed absolutely,
- * against `.container` - the element that spans the whole bar, brand included.
- * The auto margins stay for narrower windows, where an absolutely placed box
- * would sooner or later sit on top of the words on either side of it.
- *
- * The two `position: relative` rules being undone here are the theme's, and
- * they were for the layout this bar no longer uses: they raised the content
- * strip above the brand back when the brand was placed absolutely over the
- * sidebar's column. The brand is in the row now (see "ONE ROW" above), so
- * there is nothing left for them to lift, and while they stood they were the
- * nearest positioned ancestor - which would have centred the box on the strip
- * again, the very thing this rule is for. */
-@media (min-width: 1100px) {
-  .Layout .VPNav .VPNavBar .container {
-    position: relative;
-  }
-
-  .Layout .VPNav .VPNavBar.has-sidebar .content,
-  .Layout .VPNav .VPNavBar:not(.home.top) .content-body {
-    position: static;
-  }
-
-  .Layout .VPNav .VPNavBar .a2ui5-search-button {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    margin: 0;
-    transform: translate(-50%, -50%);
-  }
-
-  /* And the sections hold the left themselves. `.content-body` justifies to
-   * the END, so while the box was in the row its auto margins were what kept
-   * the four words against the brand; the moment it left the flow they packed
-   * to the right with the marks - 820px away from the mark they belong to.
-   * This is that job, done by the group that needs it. */
-  .Layout .VPNav .VPNavBar .bar-nav {
-    margin-right: auto;
-  }
-}
-.Layout .VPNav .VPNavBar .social-links { order: 3; }
-.Layout .VPNav .VPNavBar .a2ui5-extra { order: 4; }
-.Layout .VPNav .VPNavBar .hamburger { order: 5; }
-
-/* The theme's own search slot, which is empty now (no `search` provider in
- * config.mjs) but still laid out with a width and a margin on some widths. */
-.Layout .VPNav .VPNavBar .search { display: none; }
-
-/* The theme's own "…" menu, shown between 768 and 1279px with its appearance
- * switch and its social links in it. The menu behind the third mark replaces
- * it at every width. */
-.Layout .VPNav .VPNavBar .extra { display: none; }
-
-/* The theme's own appearance switch, which SiteBar.vue replaces with the
- * button the other three bars carry. It is still mounted and still doing the
- * work — `isDark` is read and written through it — it is simply not drawn. */
-.Layout .VPNav .VPNavBar .appearance {
-  display: none;
+ * One flex row across the whole width. Everything in it is ours, so there is
+ * no `order` to juggle and nothing to push out of the way: the brand, the
+ * sections, the marks and the menu sit in the order they are written, and the
+ * search box is placed at the middle of THIS element - which spans the bar,
+ * brand included, and is why the box can simply be centred instead of being
+ * pushed towards the middle by auto margins in a row that starts after the
+ * brand. */
+.Layout .VPNav .a2ui5-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: calc(var(--vp-nav-height) - 1px);
 }
 
-/* The theme's dividers between the groups it knows about. They are drawn from
- * `.menu + .appearance::before` and friends, and with the appearance switch
- * gone they land in the wrong places. The one in front of the marks is the
- * same pseudo-element as the marks' own line below, so it is not hidden here
- * but restyled there - with one class more than the theme's `.appearance +
- * .social-links::before`, which otherwise wins the margins. */
-.Layout .VPNav .VPNavBar .menu + .translations::before,
-.Layout .VPNav .VPNavBar .menu + .appearance::before,
-.Layout .VPNav .VPNavBar .translations + .appearance::before {
-  display: none;
+/* The mark and the name, closed by a hairline 16px from the first word after
+ * it - 8 of the line's own margin, 6 of the nav's, 10 of the link's padding.
+ * The theme sets its brand in 16px semibold, which is a heading; on the other
+ * three bars it is body text. */
+.Layout .VPNav .a2ui5-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  color: var(--fg);
+  font-size: 14px;
+  font-weight: 400;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.Layout .VPNav .a2ui5-brand::after {
+  content: "";
+  width: 1px;
+  height: 22px;
+  margin-left: 8px;
+  background: var(--line);
 }
 
 /* ------------------------------------------------------ the four sections ---
@@ -1586,7 +1506,7 @@
 .Layout .VPNav .bar-nav a,
 .Layout .VPNav .bar-nav .here {
   padding: 5px 10px;
-  border-radius: 5px;
+  border-radius: var(--radius-control);
   color: var(--fg-dim);
   font-size: 14px;
   text-decoration: none;
@@ -1769,43 +1689,66 @@
 
 /* ------------------------------------------------------------ the marks ---
  *
- * One hairline, then the two of them, then the menu's button — the end of the
- * bar on all four documents. The line stands 16px from the word (the link's
- * padding 10 + 6) and 16px from the mark (10 + the 6 a glyph sits inside its
- * box). The theme draws a `.VPSocialLink` at 36px with a 20px glyph; the
- * catalogue draws 30px with an 18px glyph, and the slow colour change on hover
- * is its own. */
-.Layout .VPNav .VPNavBar .content-body .social-links::before {
+ * One hairline, then the two of them, then the menu's button - the end of the
+ * bar on all four documents. The line stands 16px from the word before it (the
+ * link's padding 10 + 6) and 16px from the mark (10 + the 6 a glyph sits
+ * inside its box). They are our own markup now (TheBar.vue): the theme drew a
+ * `.VPSocialLink` at 36px with a 20px glyph and pulled the group 8px past the
+ * row's end, and holding that to the catalogue's 30px box and 18px glyph took
+ * four overrides that are gone with it.
+ *
+ * `margin-left: auto` is what holds this group, and the menu after it, at the
+ * right-hand end - the one auto margin left in the bar, and the only one it
+ * needs now that everything in the row is ours. */
+.Layout .VPNav .a2ui5-socials {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+.Layout .VPNav .a2ui5-socials::before {
   content: "";
-  display: block;
   width: 1px;
   height: 22px;
   margin: 0 10px 0 6px;
   background: var(--line);
 }
 
-/* The theme pulls the marks 8px past the row's end; here the menu's button is
- * last and carries that margin instead. */
-.Layout .VPNav .VPNavBar .social-links {
+.Layout .VPNav .a2ui5-socials a {
   display: flex;
   align-items: center;
-  margin-right: 0;
-}
-
-.Layout .VPNav .VPSocialLink {
+  justify-content: center;
   width: 30px;
   height: 30px;
   color: var(--fg-dim);
   transition: color 0.5s;
 }
 
-.Layout .VPNav .VPSocialLink:hover { color: var(--fg); }
+.Layout .VPNav .a2ui5-socials a:hover { color: var(--fg); }
 
-.Layout .VPNav .VPSocialLink svg,
-.Layout .VPNav .VPSocialLink > span {
+.Layout .VPNav .a2ui5-socials svg {
   width: 18px;
   height: 18px;
   fill: currentColor;
+}
+
+/* THE BOX IS CENTRED ON THE BAR, and now that is one rule: `.a2ui5-bar` spans
+ * the whole row, brand included, and is positioned, so the box is placed at
+ * its middle. It took three rules and two UNDONE theme rules while the bar was
+ * the theme's - the box lived in a strip that starts after the brand, so
+ * `margin: 0 auto` centred it 181px right of the window's middle, and the
+ * nearest positioned ancestor was that strip rather than the bar.
+ *
+ * Only above the width where the row is comfortable; below it the box stays in
+ * the flow, where it cannot come to rest on top of the words beside it. */
+@media (min-width: 1100px) {
+  .Layout .VPNav .a2ui5-search-button {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    margin: 0;
+    transform: translate(-50%, -50%);
+  }
 }
 
 /* --------------------------------------------------------- the search ---
@@ -1826,6 +1769,10 @@
 .Layout .VPNav .a2ui5-search-button {
   display: flex;
   align-items: center;
+  /* Below 1100px the box is a flex child again and takes the free space
+   * between the sections and the marks - not the middle of the window, but
+   * never on top of a word either. */
+  margin: 0 auto;
   gap: 6px;
   padding: 0 8px;
   height: 30px;
@@ -1833,7 +1780,7 @@
   max-width: 380px;
   flex: 0 1 320px;
   border: 1px solid var(--line);
-  border-radius: 5px;
+  border-radius: var(--radius-control);
   background: var(--bg);
   color: var(--fg-dim);
   font-size: 13px;
@@ -1909,7 +1856,7 @@
   width: min(680px, 100%);
   max-height: 76vh;
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: var(--radius-surface);
   background: var(--bg);
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.25);
   overflow: hidden;
@@ -2044,15 +1991,15 @@
  * for before anything is read. The menu stays: the theme switch is in it, and
  * GitHub is one of its rows. */
 @media (max-width: 767px) {
-  .Layout .VPNav .VPNavBar .bar-nav,
-  .Layout .VPNav .VPNavBar .social-links {
+  .Layout .VPNav .a2ui5-bar .bar-nav,
+  .Layout .VPNav .a2ui5-bar .a2ui5-socials {
     display: none;
   }
 
   /* The search stays. It is the one thing on a phone that answers a question
    * without a menu first, so it keeps the row and loses its label to the
    * glyph. */
-  .Layout .VPNav .VPNavBar .a2ui5-search-button {
+  .Layout .VPNav .a2ui5-search-button {
     margin-left: auto;
     margin-right: 4px;
   }
@@ -2070,4 +2017,24 @@
 .Layout .VPNavScreen .bar-nav a,
 .Layout .VPNavScreen .bar-nav .here {
   padding: 8px 12px;
+}
+
+/* ONE FOCUS RING, AND THE DOCUMENTATION HAD NONE OF ITS OWN.
+ *
+ * The catalogue draws `2px solid var(--accent)` with a 2px offset on anything
+ * that takes focus (catalogue.css); here it was whatever the browser and the
+ * default theme happened to agree on, which on the same origin, in the same
+ * bar, is two different rings a keyboard reader meets one tab apart. Same
+ * ring, same offset, same colour - and `:focus-visible`, so a mouse click does
+ * not draw it. */
+.Layout a:focus-visible,
+.Layout button:focus-visible,
+.Layout summary:focus-visible,
+.Layout input:focus-visible,
+.a2ui5-search-scrim a:focus-visible,
+.a2ui5-search-scrim button:focus-visible,
+.a2ui5-search-scrim input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-control);
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "fmt:chains": "node scripts/check-conventions.mjs --fix",
     "check:playground": "node scripts/check-playground.mjs",
     "check:cross-site": "node scripts/check-cross-site.mjs",
+    "check:design": "node scripts/check-design.mjs",
     "runnable": "node scripts/list-runnable.mjs",
     "check:api-names": "node scripts/check-api-names.mjs",
     "generate:api": "node scripts/generate-api-reference.mjs",
@@ -27,7 +28,7 @@
     "link:samples": "node scripts/link-samples.mjs",
     "check:samples": "node scripts/link-samples.mjs --check",
     "test": "node --test test/*.test.mjs",
-    "check": "npm run test && npm run check:version && npm run docs:build && npm run check:cross-site && npm run check:examples && npm run check:conventions && npm run check:playground && npm run check:api-names && npm run check:api-reference && npm run check:samples",
+    "check": "npm run test && npm run check:version && npm run docs:build && npm run check:cross-site && npm run check:design && npm run check:examples && npm run check:conventions && npm run check:playground && npm run check:api-names && npm run check:api-reference && npm run check:samples",
     "llms": "node scripts/generate-llms.mjs",
     "search": "node scripts/generate-search.mjs",
     "check:version": "node scripts/check-version.mjs"

--- a/scripts/check-design.mjs
+++ b/scripts/check-design.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Do the four bars still agree on what they are made of?
+//
+// The palette, the two type stacks and the two radii are copied by hand
+// between this repository and abap2UI5/playground - deliberately, for the
+// reasons in scripts/lib/design.mjs - and until this check existed nothing
+// compared the copies. They agreed because whoever last touched one remembered
+// the other. One value had already drifted: the two font stacks led with
+// different families, the same face on macOS and Windows and two different
+// ones on Linux, so the same four words in the same bar measured 59/122/78/97px
+// on one site and 65/141/87/110 on the next.
+//
+// A bar in two greys does not read as a bug in the bar. It reads as a bug in
+// the OTHER site - which is how the router's 404 read too.
+//
+// Usage: node scripts/check-design.mjs [--list]
+//   Needs a playground checkout (PLAYGROUND_HOME, .playground or ../playground)
+//   or the network; without either it FAILS rather than passing quietly.
+//   --list prints every shared value and both sides of it.
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { palette, compare, SHARED, theirStylesheet } from './lib/design.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const LIST = process.argv.includes('--list');
+
+const mine = palette(readFileSync(join(ROOT, 'docs/.vitepress/theme/style.css'), 'utf8'), 'docs');
+
+/* The floor. A palette this walk could not read is not a palette that agrees:
+ * the block moved, or was renamed, and every comparison below would then pass
+ * on two empty maps. */
+if (mine.light.size === 0 || mine.dark.size === 0) {
+  console.error('check-design: no palette found in theme/style.css.');
+  console.error('The light block is `:root {`, the dark one `.dark {`.');
+  console.error('One of them changed shape - fix the pattern in scripts/lib/design.mjs,');
+  console.error('or this gate silently stops comparing anything.');
+  process.exit(1);
+}
+
+const found = await theirStylesheet(ROOT);
+if (!found) {
+  console.error('check-design: no playground stylesheet to compare against.');
+  console.error('Set PLAYGROUND_HOME, clone abap2UI5/playground as a sibling, or run with network.');
+  console.error('Passing without the other side would be this gate reporting that one');
+  console.error('stylesheet agrees with itself.');
+  process.exit(1);
+}
+
+const theirs = palette(found.css, 'playground');
+if (theirs.light.size === 0) {
+  console.error(`check-design: read ${found.source}, and found no palette in it.`);
+  console.error('The block moved over there - fix the pattern in scripts/lib/design.mjs.');
+  process.exit(1);
+}
+
+const drift = compare(mine, theirs);
+
+console.log(
+  `check-design: ${SHARED.length} shared value(s), light and dark, against ${found.source}`,
+);
+
+if (LIST) {
+  for (const scheme of ['light', 'dark']) {
+    console.log(`\n  ${scheme}:`);
+    for (const row of SHARED) {
+      const a = mine[scheme].get(row.ours);
+      if (a === undefined) continue;
+      console.log(`    ${row.ours.padEnd(24)} ${a}`);
+    }
+  }
+}
+
+if (drift.length) {
+  console.error(`\n${drift.length} value(s) have drifted apart:\n`);
+  for (const d of drift) {
+    console.error(`  ${d.scheme}  ${d.what}`);
+    console.error(`      here  ${d.ours}: ${d.mine}`);
+    console.error(`      there ${d.theirs}: ${d.yours}`);
+  }
+  console.error('\nThese four documents are read as one bar by anybody moving between them.');
+  console.error('Change both sides in one go - theme/style.css here, src/catalogue/catalogue.css');
+  console.error('and src/shell/shell.css over there - or change this table if a value is');
+  console.error('deliberately no longer shared.');
+  process.exit(1);
+}
+
+console.log('the four bars are made of the same values, in both schemes.');

--- a/scripts/lib/design.mjs
+++ b/scripts/lib/design.mjs
@@ -1,0 +1,152 @@
+/*
+ * design — the values four documents have to agree on, and where each one
+ * keeps them.
+ *
+ * The documentation, the playground, the sample catalogue and the per-sample
+ * pages are four deployments wearing one bar. The palette, the two type stacks
+ * and the two radii behind that bar are COPIED between the repositories by
+ * hand — deliberately: a stylesheet fetched across two deployments would be a
+ * request in front of the first paint, and a shared package between two
+ * repositories that release separately would have to be versioned to say
+ * something this simple.
+ *
+ * What was never true is that anything checked the copies. They agreed because
+ * whoever last touched one remembered the other, and the day that stopped
+ * being true nothing would have said so: a bar in two greys reads as a bug in
+ * the OTHER site, which is exactly how the router's 404 read. One value drifted
+ * already and was found by eye — the two font stacks led with different
+ * families, which is the same face on macOS and Windows and two different ones
+ * on Linux, so the same four words in the same bar measured 59/122/78/97px on
+ * one site and 65/141/87/110 on the next.
+ *
+ * So the copies are declared here and compared by scripts/check-design.mjs.
+ * The playground's half is `src/catalogue/catalogue.css` (and `shell.css`,
+ * which carries the same block); a checkout of it is optional, and without one
+ * the check says so rather than passing quietly.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Where a playground checkout might be, in the order countCatalogue looks. */
+const HOMES = ['PLAYGROUND_HOME', '.playground', '../playground'];
+
+/** The published copy, for a run with no checkout at hand. */
+const PUBLISHED = 'https://abap2ui5.github.io/playground/samples/catalogue.css';
+
+/**
+ * The values both sides declare, by the name each side gives them.
+ *
+ * `ours` is the custom property in docs/.vitepress/theme/style.css; `theirs` is
+ * the one in catalogue.css. They are not always spelled the same - this site
+ * writes the type stacks as VitePress's own variables, because that is what
+ * the theme reads - and that is the whole reason this table exists rather than
+ * a diff of two files.
+ */
+export const SHARED = [
+  { ours: '--bg', theirs: '--bg', what: 'the page' },
+  { ours: '--bg-sunken', theirs: '--bg-sunken', what: 'the bar, and anything recessed into it' },
+  { ours: '--fg', theirs: '--fg', what: 'text' },
+  { ours: '--fg-dim', theirs: '--fg-dim', what: 'text that is not the point' },
+  { ours: '--line', theirs: '--line', what: 'every hairline' },
+  { ours: '--accent', theirs: '--accent', what: 'a link, a button, the mark on the one you are on' },
+  { ours: '--accent-fg', theirs: '--accent-fg', what: 'text on the accent' },
+  { ours: '--vp-font-family-base', theirs: '--font-ui', what: 'the type the bar is set in' },
+  { ours: '--vp-font-family-mono', theirs: '--font-mono', what: 'the type ABAP is set in' },
+  { ours: '--radius-control', theirs: '--radius-control', what: 'a pill, a button, an input, the search box' },
+  { ours: '--radius-surface', theirs: '--radius-surface', what: 'a panel, a dialog' },
+];
+
+/* Both sides declare the palette twice - once for light and once for dark -
+ * and the dark half is what a reader crossing at night sees, so both are
+ * compared. They do NOT declare it the same way, and that is not drift: this
+ * site is a VitePress application whose appearance script puts `.dark` on the
+ * root, and the catalogue is a static page that follows the system unless a
+ * choice is stored, so its dark values live under a media query AND under
+ * `[data-theme="dark"]`. Two mechanisms, one set of values - which is exactly
+ * why this table names the block per side instead of diffing two files.
+ *
+ * The playground's `[data-theme="dark"]` block is the one read: it is the
+ * explicit choice, and it carries the same values as the media query above it.
+ */
+const BLOCK = {
+  docs: {
+    light: /^:root[^{]*\{([\s\S]*?)^\}/gm,
+    dark: /^\.dark[^{]*\{([\s\S]*?)^\}/gm,
+  },
+  playground: {
+    light: /^:root\s*\{([\s\S]*?)^\}/gm,
+    dark: /^:root\[data-theme=["']dark["']\]\s*\{([\s\S]*?)^\}/gm,
+  },
+};
+
+/** Every `--name: value;` in a block of CSS, whitespace flattened so that a
+ *  value wrapped over three lines compares equal to the same value on one. */
+export function declarations(css) {
+  const out = new Map();
+  for (const m of css.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/gi)) {
+    out.set(m[1], m[2].replace(/\s+/g, ' ').trim());
+  }
+  return out;
+}
+
+/** The light and dark declarations of one stylesheet. `side` is which of the
+ *  two mechanisms above to read it by. */
+export function palette(css, side) {
+  const blocks = BLOCK[side];
+  if (!blocks) throw new Error(`no palette blocks known for ${side}`);
+  /* EVERY block of that shape, merged, not the first one. A stylesheet may
+   * open `:root` more than once - this one does: the palette is one block and
+   * the type and the radii are another, four hundred lines apart - and a walk
+   * that stopped at the first would report the rest as "not declared", which
+   * is drift that is not there. `[^{]*` so that a grouped selector
+   * (`:root, .dark {`) is read as both. */
+  const read = (which) => {
+    const out = new Map();
+    for (const m of css.matchAll(blocks[which])) {
+      for (const [k, v] of declarations(m[1])) out.set(k, v);
+    }
+    return out;
+  };
+  return { light: read('light'), dark: read('dark') };
+}
+
+/** A playground checkout's catalogue.css, or null. `source` says which. */
+export async function theirStylesheet(root, { fetchFn = globalThis.fetch } = {}) {
+  for (const dir of HOMES) {
+    const at = dir.endsWith('_HOME') ? process.env[dir] : path.join(root, dir);
+    if (!at) continue;
+    const file = path.join(at, 'src', 'catalogue', 'catalogue.css');
+    if (fs.existsSync(file)) return { css: fs.readFileSync(file, 'utf8'), source: `checkout ${path.relative(root, at) || at}` };
+  }
+  try {
+    const res = await fetchFn(PUBLISHED, { signal: AbortSignal.timeout(10_000) });
+    if (res && res.ok) return { css: await res.text(), source: 'the published catalogue.css' };
+  } catch { /* no network, no comparison - the caller reports that */ }
+  return null;
+}
+
+/**
+ * What the two sides disagree about: `[{ what, ours, theirs, mine, yours }]`,
+ * empty when they agree. A value missing on either side is a disagreement too
+ * - a token that was renamed on one side is exactly the drift this looks for.
+ */
+export function compare(mine, theirs) {
+  const out = [];
+  for (const scheme of ['light', 'dark']) {
+    for (const row of SHARED) {
+      /* THE EFFECTIVE VALUE, WHICH IS WHAT A READER SEES. A custom property
+       * that the dark block does not redeclare keeps its light value - that is
+       * how the cascade works, and it is how both sides write the values that
+       * do not change with the scheme (the two type stacks, the two radii).
+       * One side happens to declare them in a `:root, .dark` group and the
+       * other in `:root` alone; comparing the blocks literally reported four
+       * differences where a reader sees none. */
+      const a = mine[scheme].get(row.ours) ?? mine.light.get(row.ours);
+      const b = theirs[scheme].get(row.theirs) ?? theirs.light.get(row.theirs);
+      if (a === undefined && b === undefined) continue;
+      if (a === b) continue;
+      out.push({ scheme, ...row, mine: a ?? '(not declared)', yours: b ?? '(not declared)' });
+    }
+  }
+  return out;
+}

--- a/scripts/lib/release.mjs
+++ b/scripts/lib/release.mjs
@@ -28,7 +28,7 @@ const SITES = [
      * have found the FIRST nav-shaped string in a 700-line file, which is
      * exactly the silent wrong answer the shape checks below exist to
      * prevent. */
-    file: 'docs/.vitepress/theme/SiteBar.vue',
+    file: 'docs/.vitepress/theme/SiteMenu.vue',
     what: "the version in the bar's menu",
     re: /const VERSION = "(\d+\.\d+\.\d+)"/,
   },

--- a/test/design.test.mjs
+++ b/test/design.test.mjs
@@ -1,0 +1,134 @@
+/*
+ * The values four documents have to agree on, and the reading of a stylesheet
+ * that decides whether they do.
+ *
+ * check:design compares this repository's palette with abap2UI5/playground's.
+ * Both halves of that comparison are easy to get wrong in a way that still
+ * reports success: a block pattern that matches nothing compares two empty
+ * maps, and a comparison that reads blocks literally reports drift where the
+ * CASCADE says a reader sees none. Both mistakes were made while writing it —
+ * the first found by the gate's own floor, the second by four false positives
+ * on values that simply are not redeclared for dark.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { declarations, palette, compare, SHARED } from '../scripts/lib/design.mjs';
+
+/* The two mechanisms, as the two sides really write them: this site is a
+ * VitePress application whose appearance script puts `.dark` on the root; the
+ * catalogue is a static page that follows the system unless a choice is
+ * stored. */
+const DOCS = `
+:root {
+  --bg: #ffffff;
+  --accent: #0a6ed1;
+}
+
+.dark {
+  --bg: #16171a;
+  --accent: #4aa3ff;
+}
+
+/* four hundred lines later, a second block of the same shape */
+:root,
+.dark {
+  --radius-control: 5px;
+  --vp-font-family-base: system-ui, -apple-system,
+                         "Segoe UI", sans-serif;
+}
+`;
+
+const PLAYGROUND = `
+:root {
+  --bg: #ffffff;
+  --accent: #0a6ed1;
+  --radius-control: 5px;
+  --font-ui: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #16171a;
+    --accent: #4aa3ff;
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg: #16171a;
+  --accent: #4aa3ff;
+}
+`;
+
+test('every declaration in a block is read, however it is wrapped', () => {
+  const d = declarations('--a: 1px;\n  --b: system-ui,\n       -apple-system;\n');
+  assert.equal(d.get('--a'), '1px');
+  /* A stack wrapped over three lines has to compare equal to the same stack on
+   * one, or the two sides "differ" by whitespace. */
+  assert.equal(d.get('--b'), 'system-ui, -apple-system');
+});
+
+test('all the blocks of a stylesheet are read, not the first', () => {
+  const p = palette(DOCS, 'docs');
+  assert.equal(p.light.get('--bg'), '#ffffff');
+  assert.equal(p.dark.get('--bg'), '#16171a');
+  /* The second `:root` block, four hundred lines down. A walk that stopped at
+   * the first reported these as "not declared" - drift that is not there. */
+  assert.equal(p.light.get('--radius-control'), '5px');
+  assert.match(p.light.get('--vp-font-family-base'), /^system-ui, -apple-system, "Segoe UI", sans-serif$/);
+  /* `:root, .dark {` is both blocks, so the value is in the dark one too. */
+  assert.equal(p.dark.get('--radius-control'), '5px');
+});
+
+test("the playground's dark block is read through its own mechanism", () => {
+  const p = palette(PLAYGROUND, 'playground');
+  assert.equal(p.light.get('--accent'), '#0a6ed1');
+  assert.equal(p.dark.get('--accent'), '#4aa3ff');
+});
+
+test('two stylesheets that say the same thing differently do not count as drift', () => {
+  const drift = compare(palette(DOCS, 'docs'), palette(PLAYGROUND, 'playground'));
+  assert.deepEqual(drift, [], JSON.stringify(drift, null, 1));
+});
+
+test('a value not redeclared for dark keeps its light value, on both sides', () => {
+  /* The cascade, which is what a reader sees. One side groups the radius into
+   * `:root, .dark` and the other declares it in `:root` alone; comparing the
+   * blocks literally reported a difference nobody could see. */
+  const theirs = palette(PLAYGROUND, 'playground');
+  assert.equal(theirs.dark.get('--radius-control'), undefined, 'not in the dark block');
+  assert.equal(compare(palette(DOCS, 'docs'), theirs).length, 0);
+});
+
+test('a value that really differs is reported, in the scheme it differs in', () => {
+  /* replaceAll, not replace: the playground declares its dark values TWICE -
+   * once under the media query for a reader who has expressed no choice, once
+   * under [data-theme="dark"] for one who has - and it is the second that the
+   * gate reads. Changing only the first is a fixture that proves nothing, and
+   * for one run this test passed a broken comparison because of it. */
+  const drift = compare(palette(DOCS, 'docs'), palette(PLAYGROUND.replaceAll('--accent: #4aa3ff', '--accent: #ff0000'), 'playground'));
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].scheme, 'dark');
+  assert.equal(drift[0].ours, '--accent');
+  assert.equal(drift[0].mine, '#4aa3ff');
+  assert.equal(drift[0].yours, '#ff0000');
+});
+
+test('a value renamed on one side is drift, not a value that vanished quietly', () => {
+  const drift = compare(palette(DOCS, 'docs'), palette(PLAYGROUND.replace('--font-ui:', '--font-family:'), 'playground'));
+  assert.equal(drift.length, 2, 'light and dark');
+  assert.equal(drift[0].yours, '(not declared)');
+});
+
+test('the table names both spellings of every shared value', () => {
+  /* The two sides do not spell them the same - this one writes the type stacks
+   * as VitePress's own variables, because that is what the theme reads - which
+   * is the whole reason the table exists rather than a diff of two files. */
+  for (const row of SHARED) {
+    assert.match(row.ours, /^--[a-z-]+$/);
+    assert.match(row.theirs, /^--[a-z-]+$/);
+    assert.ok(row.what.length > 3, `${row.ours} says what it is for`);
+  }
+  assert.ok(SHARED.some((r) => r.ours !== r.theirs), 'at least one is spelled differently');
+});


### PR DESCRIPTION
Closer to the samples' design — measured first, so the work went where the difference actually was. The playground's half is [abap2UI5/playground#63](https://github.com/abap2UI5/playground/pull/63).

## What was measured

The two designs were already ~90% the same. What differs, and what should:

| | Documentation | Samples | |
|---|---|---|---|
| palette (7 values) | identical | identical | ✓ |
| h1 | 26px | 26px | ✓ |
| paragraph | 14px / 22 | 12px / 18.6 | **keep** — prose vs. a 770-row table |
| measure | 640px | 1160px | **keep** — same reason |
| UI type | `-apple-system, …` | `system-ui, …` | fixed |
| mono type | `…SFMono-Regular…` | `…"Cascadia Mono"…` | fixed |
| radii | 6px (8×), 5px (4×), 4px (3×) | 5px (6×), 8px (3×), 6px (3×) | named |

Aligning the prose size and measure would not be unification — it would make one of the two worse. What a reader takes for "one product" is the chrome, not the body size.

## One typeface

`-apple-system` and `system-ui` are the same face on macOS and the same fallback on Windows — and two different fonts on Linux. Measured there, the four bars drew the same four words at **59/122/78/97px** here and **65/141/87/110** over there. One string now, the union of both lists. The bars measure identically.

## Two named radii

There was no scale to align to: 5, 6, 8, 4, 10 and 999px were all in use, and the spread *inside* each stylesheet was as wide as the spread between them. So: one decision, named once — `--radius-control` (5px) for what you click or type in, `--radius-surface` (8px) for what things sit on — applied to what the four documents share. The reading column keeps VitePress's 6px deliberately.

## One focus ring

The catalogue draws 2px of accent with a 2px offset; here it was whatever the browser and the theme agreed on. Two rings a keyboard reader meets one tab apart, in one bar.

## The bar is one element we own

It was the theme's bar with our parts in its slots and its own parts argued out of the way: **85 selector lines** under `.Layout .VPNav …` against **42 theme elements** — the brand placed absolutely over the sidebar column, five slot children ordered by hand, two wrappers the theme made `position: relative`, its "…" menu, its appearance switch, its social links' margins. Every change had to undo something first; centring the search box needed two of the theme's own rules taken back before it could be measured.

Now the brand, the four sections (`SiteNav.vue`), the search, the two marks and the menu (`SiteMenu.vue`) are one element (`TheBar.vue`). What is left is a container told its height, colour and hairline, plus seven of its own parts told not to draw. The centring is one rule. The theme keeps two things worth keeping: the hamburger and the phone screen.

**Is VitePress still right? Yes.** 165 markdown pages, the sidebar as the single source for `llms.txt` *and* the search index, a markdown-it plugin for the Run button, Shiki, nine gates built on `config.mjs`. Replacing it is weeks of work for no functional gain. The friction was never the SSG — it was overriding the default theme's layout, and that is what this commit ends.

## And a gate, so it stays true

The palette has been copied between the repositories by hand since it was written, and **nothing ever compared the copies**. They agreed because whoever touched one remembered the other. `check:design` reads both stylesheets and holds eleven values — seven colours, two type stacks, two radii — in **both** schemes. It compares the *effective* value (a property the dark block does not redeclare keeps its light one), because the two sides switch schemes differently: `.dark` here, `[data-theme]` there. Without a checkout or the network it **fails** rather than reporting that one stylesheet agrees with itself.

Two mistakes it caught while being written — a walk that stopped at the first `:root` block, and four values not redeclared for dark — are pinned in `test/design.test.mjs`. And `check:cross-site` caught a third *in this branch*: splitting the bar left the Linter rules row bound to a constant that stayed behind in the other half, so for one build it was a cross-site link with no `target`. Exactly the bug that gate exists for.

## Verified

All **eleven** gates pass, 76 unit tests. Measured after: bar gap 6px (identical to the catalogue's), item shift 0px, search box off-centre by 0px at 1200/1440/1920, and Home → Documentation still returns to the chapter you were reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_