### PR TITLE
The deploy runs all eleven gates, the bar remembers where on the page you were, and every section carries its mark

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,10 +107,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # The same list check.yml runs for a pull request, in the same order, and
-      # the reason each one is here is written above it there. `!cancelled()`
-      # so one failure still reports the others: a deploy that is going to be
-      # refused should say everything that is wrong with it in one run.
+      # The same eleven gates check.yml runs for a pull request, and the reason
+      # each one is here is written above it there. The ORDER is the one thing
+      # that cannot match: this job has to build the site it publishes, so
+      # `docs:build` and `check:cross-site` - which judges the built HTML -
+      # come after the eight that need neither, instead of third and fourth.
+      # What has to stay in step is the SET; a gate that runs for a pull
+      # request and not for the deploy is a gate main can be published past.
+      # `!cancelled()` so one failure still reports the others: a deploy that
+      # is going to be refused should say everything that is wrong with it in
+      # one run.
       - name: unit tests
         run: npm test
       - name: release version
@@ -122,6 +128,9 @@ jobs:
       - name: ABAP examples
         if: ${{ !cancelled() }}
         run: npm run check:examples
+      - name: house conventions
+        if: ${{ !cancelled() }}
+        run: npm run check:conventions
       - name: Run-button coverage
         if: ${{ !cancelled() }}
         run: npm run check:playground

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,12 +224,14 @@ menu ever got this wrong. `check:cross-site` now holds the whole built site to
 it, and the direction back needs nothing: the other three documents are static
 pages with no router in front of them.
 
-**One origin means one localStorage**, which is what two things here rely on:
+**One origin means one localStorage**, which is what four things here rely on:
 
 | | |
 |---|---|
 | the theme | The key is the playground's (`abap2ui5-playground:theme`). A head script in `config.mjs` reads it before the first paint and hands it to VitePress's own appearance handling; `SiteMenu.vue` writes it back when the button is pressed. A reader crossing from a dark playground gets a dark page, with no flash |
 | where you were | `theme/site-memory.js`. Every page writes its own path down; the Samples item is lifted to whatever the catalogue last wrote. A stored value is **checked, not followed** — resolved against this origin and kept only if it is still inside the section the markup declares: the href it carries, or a wider `scope` the caller names for a link written deeper than what it restores (the other three bars point Documentation at the first page of the manual and still come back to wherever the reader was in it). A poisoned or stale key costs a restored position and nothing else. The cases are `test/site-memory.test.mjs` |
+| where **on** the page you were | `theme/site-memory.js` again, keys `:scroll` (a small map of path → offset, the twelve most recent) and `:returning`. Restored **on arrival by the bar and nowhere else**: a bar item writes one record saying where it is sending the reader, and the page that *is* that, arriving within half a minute and with no hash of its own, honours it. Restoring on every load would fight the browser's own back-and-forward restoration and would drop a reader who followed an ordinary link into the middle of a page with nothing to explain it. A stored offset is checked the same way a stored path is — `scrollTo` takes whatever it is given. `test/scroll-memory.test.mjs` |
+| the last thing you searched for | `theme/search-engine.js`, key `:search`. A hit opens another page, often another deployment, and the box that opens there was empty; the query is written down as a hit is opened and the next box starts with it, selected, so the first keystroke replaces it. Checked (a string, short, and less than half an hour old) rather than used. `test/search.test.mjs` |
 
 The playground is consulted by both and remembered by neither: its URL carries
 the code in the editor, so an item that reopened yesterday's sample would be a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,10 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `scripts/check-conventions.mjs` | The two house conventions the sample corpora gate and this one did not: the view-chain layout in every fenced chain (the linter's `chain-house-layout`, which is opt-in — `check-examples.mjs` writes its config without a `rules` block, so the rule was never emitted), and the three class section blocks in every fenced app class. `--fix` (`npm run fmt:chains`) reformats a drifted chain; the sections are a judgement and stay by hand |
 | `scripts/lib/catalogue.mjs` | Parses and counts a sample catalogue, for `link-samples.mjs` and for the figures `generate-llms.mjs` writes into `llms.txt` — from a sibling checkout when one is here, else from the `catalogue.json` each sample repository commits at its root; pinned by `test/catalogue.test.mjs`, because it has stopped matching twice and both times answered wrongly instead of failing |
 | `docs/.vitepress/theme/style.css` | Everything this site looks like. Its palette is the playground's, copied — see *One site in three places* below |
-| `docs/.vitepress/theme/SiteBar.vue` | The right-hand end of the bar: the three sites, and the menu behind the bar's last button — the light/dark switch, the project's tools and its repositories. Rendered into `nav-bar-content-after` by `theme/index.js`; the marks between them are VitePress's own `socialLinks`, ordered by `style.css` |
 | `docs/.vitepress/theme/site-memory.js` | Where the reader was, on each site, so the bar comes back to it; pinned by `test/site-memory.test.mjs` |
 | `docs/.vitepress/theme/TheBar.vue` | The bar, as one element this repository owns: the brand, `SiteNav.vue` (the four sections), `SearchBox.vue`, the two marks, `SiteMenu.vue` (the menu behind the last button, and the version number `check:version` reads). It used to be the theme's bar with our parts in its slots and 85 override lines arguing its own parts out of the way; the theme now keeps two things, the hamburger and the screen it opens on a phone |
+| `docs/.vitepress/theme/SiteNav.vue` | The four sections, in the bar and again in the phone screen the theme's hamburger opens. Every item that leaves this deployment carries a `target` (`check:cross-site`), and three of the four are lifted to where the reader last was (`site-memory.js`) |
+| `docs/.vitepress/theme/SiteMenu.vue` | The menu behind the bar's last button: the light/dark switch, the project's tools and its repositories, and the version number `check:version` reads (`VERSION`) |
 | `docs/.vitepress/theme/SearchBox.vue` | The box in the middle of the bar and what it opens. `theme/search-engine.js` is the matching, framework-free because the other three bars carry a copy of it; both are pinned by `test/search.test.mjs` |
 | `scripts/check-design.mjs` | The palette, the type and the radii the four bars share, against `abap2UI5/playground`'s copy of them — needs a checkout (`PLAYGROUND_HOME`, `.playground`, `../playground`) or the network, and fails rather than passing without one. The table of what is shared, and both spellings of each value, is `scripts/lib/design.mjs` |
 | `scripts/check-cross-site.mjs` | Every link out of this deployment and into a neighbouring one on the same origin carries a `target`, or VitePress's router swallows it and shows this site's 404 at the other site's URL. Reads the BUILT html, so it runs after `docs:build`; the rule and the reasoning are in `scripts/lib/cross-site.mjs` |
@@ -47,7 +48,7 @@ it are decidable, and all eleven are decided before a merge:
 | | |
 |---|---|
 | `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate — and the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow |
-| `check:version` | the release number in the bar's menu (`VERSION` in `theme/SiteBar.vue` — it was a nav dropdown's label in `config.mjs` until the bar was rebuilt), the deprecations page and the changelog, against the newest release tag of the framework — this one goes stale without anybody touching this repository |
+| `check:version` | the release number in the bar's menu (`VERSION` in `theme/SiteMenu.vue` — it was a nav dropdown's label in `config.mjs` until the bar was rebuilt, and in `SiteBar.vue` until the bar was split), the deprecations page and the changelog, against the newest release tag of the framework — this one goes stale without anybody touching this repository |
 | `docs:build` | a page that does not build is a page nobody can read |
 | `check:examples` | the ABAP in the fenced blocks, against the real framework: does it compile, and does the view it builds name controls and properties that exist on the UI5 floor this documentation targets. **It ran no abaplint rules at all until 2026-09-04** — the generated config had no `rules` block, so abaplint walked 139 files, ran nothing, and printed `0 issue(s) found` for years. Ten examples with an unbalanced parenthesis were sitting behind that. The three compile rules it runs now (`parser_error`, `check_syntax`, `unknown_types`) are the sample repositories' own; the reasoning for stopping there, measured against the full 188-rule set, is in the file |
 | `check:api-names` | every `client->` name on the site — method, parameter, `cs_*` constant — against `z2ui5_if_client` on `main`, plus every `blob/main/` link into the framework's tree, plus **no name from the frozen package** (`src/99`: `z2ui5_cl_util*`, `z2ui5_cl_pop_*`, `z2ui5_cl_xml_view*`, `z2ui5_if_exit`, `z2ui5_if_types`, …) anywhere but on the deprecations page and in the changelog. `check:examples` compiles the fenced blocks that are whole CLASSES; this is the rest of the page: the sentence, the two-line snippet, the constant block a page reproduces, the source link. Four pages taught API that 1.143.0 had deleted and nothing was red |
@@ -67,10 +68,18 @@ page layout or the builder name is the likely cause. `check:cross-site` carries
 the same floor twice over: no HTML in `dist` at all, and no cross-site link on
 a site whose bar carries three of them on every page.
 
-`.github/workflows/check.yml` runs the same eleven, in the same order. Keep the
-two in step: a step that exists only in `package.json` is a step no pull
-request has to pass, which is how `npm test` — the pin added *because* the
-catalogue parser broke twice in silence — went a release without CI.
+The eleven are written out in **three** places, and all three have to name the
+same set: `package.json`'s `check` script, `.github/workflows/check.yml` for a
+pull request, and `.github/workflows/deploy.yml` before the site is published.
+`check.yml` runs them in the script's order; `deploy.yml` cannot, because it
+has to build the site it publishes, so `docs:build` and `check:cross-site` —
+which judges the built HTML — move to the end there. The SET is what has to
+stay in step, and it is the thing that quietly does not: a step that exists
+only in `package.json` is a step no pull request has to pass, which is how
+`npm test` — the pin added *because* the catalogue parser broke twice in
+silence — went a release without CI, and how `check:conventions` sat in
+`check.yml` and not in `deploy.yml` from the day it was added, which is a gate
+`main` could be published past.
 
 `check:samples` needs an `abap2UI5/samples` checkout — set `SAMPLES_HOME`, or
 clone it as a sibling. Without one it *skips* rather than fails, so verify the
@@ -219,7 +228,7 @@ pages with no router in front of them.
 
 | | |
 |---|---|
-| the theme | The key is the playground's (`abap2ui5-playground:theme`). A head script in `config.mjs` reads it before the first paint and hands it to VitePress's own appearance handling; `SiteBar.vue` writes it back when the button is pressed. A reader crossing from a dark playground gets a dark page, with no flash |
+| the theme | The key is the playground's (`abap2ui5-playground:theme`). A head script in `config.mjs` reads it before the first paint and hands it to VitePress's own appearance handling; `SiteMenu.vue` writes it back when the button is pressed. A reader crossing from a dark playground gets a dark page, with no flash |
 | where you were | `theme/site-memory.js`. Every page writes its own path down; the Samples item is lifted to whatever the catalogue last wrote. A stored value is **checked, not followed** — resolved against this origin and kept only if it is still inside the section the markup declares: the href it carries, or a wider `scope` the caller names for a link written deeper than what it restores (the other three bars point Documentation at the first page of the manual and still come back to wherever the reader was in it). A poisoned or stale key costs a restored position and nothing else. The cases are `test/site-memory.test.mjs` |
 
 The playground is consulted by both and remembered by neither: its URL carries
@@ -283,7 +292,7 @@ the bar, not for the links between the sites; those are one attribute.
   another host needs nothing.
 
 - **`themeConfig.nav` is empty, and it stays empty.** The bar carries the four
-  sections of the project (`theme/SiteBar.vue`), the search, and everything
+  sections of the project (`theme/SiteNav.vue`), the search, and everything
   else behind the menu at its right-hand end. An entry added back to `nav`
   lands between the sections and the search box and the row stops reading left
   to right. What used to be there — Guide, Links, the version number — is

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -87,7 +87,7 @@ export default defineConfig({
     // script and still before the first paint, so a reader arriving from a
     // dark playground gets a dark page rather than a white flash.
     //
-    // theme/SiteBar.vue writes the playground key back when the button here
+    // theme/SiteMenu.vue writes the playground key back when the button here
     // is pressed. Its two lines and these are one mechanism.
     [
       "script",
@@ -164,7 +164,7 @@ export default defineConfig({
     // EMPTY, AND THAT IS THE BAR'S SHAPE NOW. There were three dropdowns here
     // - Guide, Links and the version number - and the bar they sat in has been
     // rebuilt around the four sections of the project (Home, Documentation,
-    // Samples, Playground, in theme/SiteBar.vue), with the search in the
+    // Samples, Playground, in theme/SiteNav.vue), with the search in the
     // middle and everything else behind the menu at the right-hand end. All
     // three were duplicates of something the reader already had:
     //
@@ -178,7 +178,7 @@ export default defineConfig({
     //   1.144.0    four entries - release notes, support, contribute, sponsor
     //              - all four already in that same menu. What was NOT
     //              elsewhere is the NUMBER, which moved into the menu as its
-    //              first heading (`VERSION` in SiteBar.vue; check:version
+    //              first heading (`VERSION` in SiteMenu.vue; check:version
     //              follows it there).
     //
     // So nothing was taken off the site, only out of the row. Keep it empty:

--- a/docs/.vitepress/theme/SearchBox.vue
+++ b/docs/.vitepress/theme/SearchBox.vue
@@ -18,7 +18,7 @@
  * wire), which is not a price to charge a reader who came to read one page.
  */
 import { computed, nextTick, ref, shallowRef, watch, onMounted, onUnmounted } from 'vue';
-import { search, grouped, loadIndex, highlight } from './search-engine.js';
+import { search, grouped, loadIndex, highlight, rememberQuery, recallQuery } from './search-engine.js';
 
 const open = ref(false);
 const query = ref('');
@@ -50,7 +50,15 @@ async function fetchIndex() {
 function show() {
   open.value = true;
   fetchIndex();
-  nextTick(() => input.value?.focus());
+  /* The last thing that was searched for, if a hit was opened recently
+   * (search-engine.js). Selected, not merely filled in: the reader who wants
+   * it presses Enter or arrows, and the reader who wants something else types
+   * over it without reaching for Backspace. */
+  if (!query.value) query.value = recallQuery();
+  nextTick(() => {
+    input.value?.focus();
+    if (query.value) input.value?.select();
+  });
 }
 
 function hide() {
@@ -83,10 +91,17 @@ function hrefOf(hit) {
   }
 }
 
+/* A hit was opened - by Enter, by a click, or by a middle click that opened it
+ * in a tab of its own. Written down BEFORE hide(), which clears the field. */
+function leave() {
+  rememberQuery(query.value);
+  hide();
+}
+
 function go(hit) {
   if (!hit) return;
   const { href } = hrefOf(hit);
-  hide();
+  leave();
   location.assign(href);
 }
 
@@ -170,7 +185,7 @@ const parts = (text) => highlight(text, query.value);
               :href="hrefOf(hit).href"
               :target="hrefOf(hit).target"
               @mouseenter="active = indexOf(hit)"
-              @click="hide"
+              @click="leave"
             >
               <span class="a2ui5-search-hit-title">
                 <span v-for="([text, on], i) in parts(hit.entry.title)" :key="i" :class="{ hl: on }">{{ text }}</span>

--- a/docs/.vitepress/theme/SiteNav.vue
+++ b/docs/.vitepress/theme/SiteNav.vue
@@ -13,7 +13,7 @@
  */
 import { computed, onMounted, ref } from "vue";
 import { useData } from "vitepress";
-import { lastVisited } from "./site-memory.js";
+import { handOff, lastVisited, rememberScroll } from "./site-memory.js";
 
 const { page } = useData();
 
@@ -67,12 +67,29 @@ const lift = () => {
   docsHref.value = lastVisited("docs", DOCS, HOME);
 };
 /* The lift that cannot be missed: on the click itself, on the element, because
- * a ref set in the handler reaches the DOM a tick too late. */
-const liftNow = (e) => {
+ * a ref set in the handler reaches the DOM a tick too late.
+ *
+ * And then the record that says where the reader is being sent, which is what
+ * lets the page that arrives put them back where they were IN it rather than
+ * at the top of it (site-memory.js). It is written after the lift, so it names
+ * the href that is actually followed and not the one in the markup.
+ *
+ * The Playground item writes none: its URL carries the code in the editor, so
+ * there is no position of it to come back to - the same reason it is consulted
+ * by the memory and remembered by neither.
+ */
+const leave = (e) => {
   const el = e.currentTarget;
-  el.href = el.dataset.site === "docs"
-    ? lastVisited("docs", DOCS, HOME)
-    : lastVisited("samples", SAMPLES);
+  /* Where the reader is on THIS page, now rather than in 300ms: the listener
+   * in theme/index.js is throttled, and a click that lands inside its window
+   * would otherwise store an offset from before the last scroll. */
+  rememberScroll();
+  if (el.dataset.site) {
+    el.href = el.dataset.site === "docs"
+      ? lastVisited("docs", DOCS, HOME)
+      : lastVisited("samples", SAMPLES);
+  }
+  handOff(el.href);
 };
 
 /* Lifted on mount, and again whenever the stored position can have moved while
@@ -94,9 +111,9 @@ onMounted(() => {
          two sections of THIS deployment now - the section that used to be one
          non-clickable word ("Documentation") is two places a reader can move
          between, which is what the brand alone could not offer. -->
-    <a :href="HOME" data-text="Home" :class="{ here: onHome }" :aria-current="onHome ? 'page' : undefined" title="abap2UI5 in one page">Home</a>
-    <a :href="docsHref" data-text="Documentation" data-site="docs" :class="{ here: !onHome }" :aria-current="!onHome ? 'page' : undefined" title="The manual, where you left it" @click="liftNow">Documentation</a>
-    <a :href="samplesHref" data-text="Samples" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="liftNow">Samples</a>
-    <a :href="PLAYGROUND" data-text="Playground" :target="SAME_TAB" title="Write ABAP and run it in the browser">Playground</a>
+    <a :href="HOME" :class="{ here: onHome }" :aria-current="onHome ? 'page' : undefined" title="abap2UI5 in one page" @click="leave"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><path d="M3.6 10.9 12 4.2l8.4 6.7v8.3a1 1 0 0 1-1 1h-4.3v-6.1H8.9v6.1H4.6a1 1 0 0 1-1-1z"/></svg><span data-text="Home">Home</span></a>
+    <a :href="docsHref" data-site="docs" :class="{ here: !onHome }" :aria-current="!onHome ? 'page' : undefined" title="The manual, where you left it" @click="leave"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><path d="M12 7.2C10.5 5.9 8.5 5.2 6 5.2H3.3v11.9H6c2.5 0 4.5.7 6 1.9 1.5-1.2 3.5-1.9 6-1.9h2.7V5.2H18c-2.5 0-4.5.7-6 1.9z"/><path d="M12 7.2v11.8"/></svg><span data-text="Documentation">Documentation</span></a>
+    <a :href="samplesHref" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="leave"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><rect x="3.2" y="4.8" width="17.6" height="14.4" rx="2"/><path d="M3.2 9.4h17.6M8.5 9.4v9.8"/></svg><span data-text="Samples">Samples</span></a>
+    <a :href="PLAYGROUND" :target="SAME_TAB" title="Write ABAP and run it in the browser"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><circle cx="12" cy="12" r="8.6"/><path d="M10.2 8.4v7.2a.5.5 0 0 0 .76.43l5.8-3.6a.5.5 0 0 0 0-.86l-5.8-3.6a.5.5 0 0 0-.76.43z" fill="currentColor" stroke="none"/></svg><span data-text="Playground">Playground</span></a>
   </nav>
 </template>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -5,7 +5,7 @@ import './style.css'
 import { setUpPlayground } from './playground.js'
 import TheBar from './TheBar.vue'
 import SiteNav from './SiteNav.vue'
-import { rememberHere } from './site-memory.js'
+import { rememberHere, rememberScroll, takeHandoff } from './site-memory.js'
 
 /** @type {import('vitepress').Theme} */
 export default {
@@ -13,7 +13,7 @@ export default {
   // The bar's right-hand end - the three sites, and the menu behind the bar's
   // last button with the light/dark switch in it - injected into the nav bar
   // and, without the menu, into the screen a phone opens instead of it. See
-  // SiteBar.vue for what the group is and style.css for where in the row it
+  // SiteNav.vue for what the group is and style.css for where in the row it
   // lands: the slot renders after VitePress's own appearance switch and
   // social links, and CSS orders the sites back in front of the marks and the
   // menu after them.
@@ -48,11 +48,48 @@ export default {
     const rememberUnlessHome = () => {
       if (!location.pathname.replace(/index\.html$/, '').match(/\/docs\/?$/)) rememberHere('docs')
     }
+
+    // How far DOWN the page, which is the other half of coming back to it.
+    // The offset is written for every page including the home page: what the
+    // rule above is about is which page the Documentation item opens, and
+    // that is a different question from where in a page the reader was.
+    //
+    // Throttled, because scroll fires per frame and this writes to storage.
+    // `pagehide` as well, for a reader who leaves inside the window - and
+    // SiteNav.vue writes it on the click itself, which is the case that has
+    // to be exact.
+    let pending = 0
+    const noteScroll = () => {
+      if (pending) return
+      pending = setTimeout(() => { pending = 0; rememberScroll() }, 300)
+    }
+
+    // ...and back to it, but ONLY when the bar said so (site-memory.js). The
+    // router draws the new page and scrolls it to the top itself, not always
+    // in the same frame, so the offset is re-applied for a few frames until
+    // it holds. About a tenth of a second, and it stops the moment it works.
+    const restore = () => {
+      const y = takeHandoff()
+      if (y === null) return
+      let tries = 0
+      const put = () => {
+        scrollTo(0, y)
+        if (++tries < 6 && Math.abs(scrollY - y) > 2) requestAnimationFrame(put)
+      }
+      requestAnimationFrame(put)
+    }
+
     if (!import.meta.env.SSR) {
       rememberUnlessHome()
+      restore()
+      addEventListener('scroll', noteScroll, { passive: true })
+      addEventListener('pagehide', () => rememberScroll())
       const onAfter = router.onAfterRouteChange
       router.onAfterRouteChange = (to) => {
         rememberUnlessHome()
+        // Home -> Documentation is a route change, not a load: this site is
+        // one application and two of the bar's four items are pages of it.
+        restore()
         onAfter?.(to)
       }
     }

--- a/docs/.vitepress/theme/search-engine.js
+++ b/docs/.vitepress/theme/search-engine.js
@@ -168,3 +168,57 @@ export function highlight(text, query) {
   if (at < hay.length) out.push([hay.slice(at), false]);
   return out;
 }
+
+/* ── THE LAST THING YOU SEARCHED FOR ────────────────────────────────────────
+ *
+ * A search that finds something ends on another page — often on another
+ * deployment — and the box that opens there is a new one, empty. A reader
+ * comparing three samples of the same control typed the same word three times,
+ * which is the search asking them to remember what they had just told it.
+ *
+ * So the query is written down when a hit is opened, and the next box on this
+ * origin opens with it, SELECTED, so the first keystroke replaces it rather
+ * than appending to it: the field is a suggestion, not a state to clear.
+ *
+ * It is the one-origin-one-localStorage the theme and the position memory
+ * already use, and it is CHECKED rather than followed — anything on this
+ * origin can write anything into that key. A string, short enough to have been
+ * typed, and recent: after half an hour a prefilled field is a question the
+ * reader has stopped asking.
+ */
+
+const QUERY_KEY = 'abap2ui5-playground:search';
+const QUERY_TTL = 30 * 60 * 1000;
+const QUERY_MAX = 120;
+
+/** Write down what was typed, as a hit is opened. An empty or absurd query
+ *  clears the memory rather than storing itself. */
+export function rememberQuery(query) {
+  if (typeof localStorage === 'undefined') return;
+  const q = (query || '').trim();
+  try {
+    if (!q || q.length > QUERY_MAX) localStorage.removeItem(QUERY_KEY);
+    else localStorage.setItem(QUERY_KEY, JSON.stringify({ q, at: Date.now() }));
+  } catch {
+    /* A refused or full storage. The reader types it again, as before. */
+  }
+}
+
+/** What to open the box with, or `''` — which is every case that is not a
+ *  recent query written by this box. */
+export function recallQuery() {
+  if (typeof localStorage === 'undefined') return '';
+  let record = null;
+  try {
+    record = JSON.parse(localStorage.getItem(QUERY_KEY) || 'null');
+  } catch {
+    return ''; /* not JSON: not something this wrote */
+  }
+  if (!record || typeof record.q !== 'string' || typeof record.at !== 'number') return '';
+  const age = Date.now() - record.at;
+  /* Backwards too. A clock that moved, or a timestamp somebody put in the
+   * future, is not an age this trusts. */
+  if (!(age >= 0 && age < QUERY_TTL)) return '';
+  const q = record.q.trim();
+  return q && q.length <= QUERY_MAX ? q : '';
+}

--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -87,3 +87,128 @@ export function lastVisited(site, fallback, scope = fallback) {
     return fallback;
   }
 }
+
+/* ── WHERE ON THE PAGE, not only which page ─────────────────────────────────
+ *
+ * The item above comes back to the page you left. It came back to the TOP of
+ * it, which on the two pages a reader actually leaves half-read - the manual's
+ * long chapters, and a catalogue of 770 rows - is most of the way to not
+ * having been remembered at all: the reader who was at sample 400, looked
+ * something up in the manual and pressed Samples, arrived at sample 1.
+ *
+ * So the offset is written down per path, and restored on ARRIVAL BY THE BAR
+ * and nowhere else. That last part is the whole design. A page that restored
+ * its offset on every load would fight the browser (which already restores it
+ * for back and forward) and would surprise a reader who followed a link to a
+ * page they happen to have read before - landing them mid-chapter with no
+ * scrollbar movement to explain it. The bar says, in one record, "I am sending
+ * you back to X"; the page that IS X, and arrives within seconds, honours it.
+ * Anything else ignores it.
+ *
+ * A hash in the URL wins: `#section` is a destination the reader named, and an
+ * offset is only ever a memory of one.
+ */
+
+const SCROLL_KEY = "abap2ui5-playground:scroll";
+const HANDOFF_KEY = "abap2ui5-playground:returning";
+/* Enough paths for moving between the four sections without losing any of
+ * them, and small enough that the value stays a few hundred bytes. */
+const SCROLL_MAX = 12;
+/* The bar's click and the page that arrives are one navigation. Half a minute
+ * is a slow connection; a record older than that belongs to a journey that
+ * ended some other way. */
+const HANDOFF_TTL = 30_000;
+
+/** This document, as the scroll map keys it. The hash is deliberately not part
+ *  of it: it is one page, wherever in it the reader entered. */
+const here = () => location.pathname + location.search;
+
+const readMap = () => {
+  try {
+    const raw = JSON.parse(localStorage.getItem(SCROLL_KEY) || "{}");
+    return raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+  } catch {
+    return {};
+  }
+};
+
+/** Write down how far down this page the reader is. Cheap enough to call from
+ *  a scroll handler, which is where it is called from - `pagehide` alone loses
+ *  the offset whenever a browser decides not to fire it. */
+export function rememberScroll(y = window.scrollY, path = here()) {
+  if (typeof localStorage === "undefined") return;
+  if (!Number.isFinite(y) || y < 0) return;
+  try {
+    const map = readMap();
+    /* Re-inserted, so the key order is least-recently-written first and the
+     * oldest is the one that falls off. */
+    delete map[path];
+    map[path] = Math.round(y);
+    for (const old of Object.keys(map).slice(0, -SCROLL_MAX)) delete map[old];
+    localStorage.setItem(SCROLL_KEY, JSON.stringify(map));
+  } catch {
+    /* A refused or full storage. The reader lands at the top, as before. */
+  }
+}
+
+/** The offset stored for `path`, or 0. Checked, not followed: anything on this
+ *  origin can write anything here, and `scrollTo` will take whatever it is
+ *  given. */
+export function scrollOf(path = here()) {
+  if (typeof localStorage === "undefined") return 0;
+  try {
+    const y = readMap()[path];
+    return Number.isFinite(y) && y >= 0 && y < 1e7 ? y : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * "I am sending the reader back to `href`" — written by a bar item as it is
+ * clicked, read by the page that arrives.
+ *
+ * The href is resolved against this origin and stored as a path, so a link to
+ * another host (which shares no storage) writes nothing.
+ */
+export function handOff(href) {
+  if (typeof localStorage === "undefined" || !href) return;
+  try {
+    const to = new URL(href, location.href);
+    if (to.origin !== location.origin) return;
+    localStorage.setItem(HANDOFF_KEY, JSON.stringify({ to: to.pathname + to.search, at: Date.now() }));
+  } catch {
+    /* Not a URL, or no storage. Nothing is restored, which is the old
+     * behaviour and not a broken one. */
+  }
+}
+
+/**
+ * The offset this page should be restored to, if the bar just sent the reader
+ * here — and `null` in every other case, which is most of them.
+ *
+ * Reading it CONSUMES it: the record describes one arrival, and a second read
+ * would be a later navigation inheriting somebody else's destination.
+ */
+export function takeHandoff() {
+  if (typeof localStorage === "undefined") return null;
+  let record = null;
+  try {
+    record = JSON.parse(localStorage.getItem(HANDOFF_KEY) || "null");
+    localStorage.removeItem(HANDOFF_KEY);
+  } catch {
+    return null;
+  }
+  if (!record || typeof record.to !== "string" || typeof record.at !== "number") return null;
+  const age = Date.now() - record.at;
+  if (!(age >= 0 && age < HANDOFF_TTL)) return null;
+  /* The record has to name THIS page. It is written before a navigation that
+   * may not happen (a middle click, a refused link, a reader who went
+   * somewhere else instead), so arriving anywhere but at `to` means it was
+   * not this journey. */
+  if (record.to !== here()) return null;
+  /* A destination the reader named beats one this remembered. */
+  if (location.hash) return null;
+  const y = scrollOf(record.to);
+  return y > 0 ? y : null;
+}

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1531,19 +1531,42 @@
  * back. */
 .Layout .VPNav .bar-nav a,
 .Layout .VPNav .bar-nav .here {
+  /* A row now, because each item is a mark and a word: the reservation moved
+     one level in, onto the word, which is the part that goes bold. */
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.Layout .VPNav .bar-nav a > span,
+.Layout .VPNav .bar-nav .here > span {
   display: inline-flex;
   flex-direction: column;
   align-items: center;
 }
 
-.Layout .VPNav .bar-nav a::after,
-.Layout .VPNav .bar-nav .here::after {
+.Layout .VPNav .bar-nav a > span::after,
+.Layout .VPNav .bar-nav .here > span::after {
   content: attr(data-text);
   height: 0;
   overflow: hidden;
   visibility: hidden;
   font-weight: 600;
   pointer-events: none;
+}
+
+/* THE MARK IN FRONT OF THE WORD. The same four this site's home page draws on
+ * its cards - a house, a book, a window, a play button - in the link's own
+ * colour, so they dim and brighten with it and the section you are on is
+ * marked twice. 15px, which is the search box's glyph and the two marks at the
+ * other end: two icon sizes in one bar is something a reader sees without
+ * being able to name it. The same rule is on the other three bars
+ * (src/catalogue/catalogue.css and src/shell/shell.css in abap2UI5/playground),
+ * kept in step by hand like everything else in this row. */
+.Layout .VPNav .bar-nav svg {
+  width: 15px;
+  height: 15px;
+  flex: none;
 }
 
 .Layout .VPNav .bar-nav a:hover {
@@ -1561,7 +1584,7 @@
  * The button after the marks and what opens under it: the switch for light and
  * dark, the project's tools and its repositories - the other three bars' menu
  * in their numbers (a 30px box for the button, a 220px sheet, rows of 5px
- * pills). A <details>, so it opens and closes with no script; SiteBar.vue
+ * pills). A <details>, so it opens and closes with no script; SiteMenu.vue
  * closes it on a click anywhere else and on Escape. The switch swaps its whole
  * label with the theme: over there the swap keys off `[data-theme]` and a
  * media query, here VitePress has already resolved both into a single class

--- a/scripts/lib/release.mjs
+++ b/scripts/lib/release.mjs
@@ -20,7 +20,7 @@ import path from 'path';
 /** Where the version is written, and how to find it in each file. */
 const SITES = [
   {
-    /* The bar, which is theme/SiteBar.vue and not config.mjs any more. The
+    /* The bar's menu, which is theme/SiteMenu.vue and not config.mjs any more. The
      * number used to be a nav dropdown's label - `text: "1.144.0"` - and the
      * dropdown is gone: its four entries were already in the menu behind the
      * bar's last button, so the rebuilt bar kept the number and dropped the

--- a/test/gates.test.mjs
+++ b/test/gates.test.mjs
@@ -1,0 +1,100 @@
+/*
+ * The eleven gates are written out in three places. Do all three name the
+ * same set?
+ *
+ * `package.json`'s `check` script is what a contributor runs; check.yml is
+ * what a pull request has to pass; deploy.yml is what stands in front of the
+ * published site. Nothing compared them, and they had already drifted twice
+ * in the same direction - a gate in one list and not in another, which is a
+ * gate that can be walked past:
+ *
+ *   - `npm test` was in the script and in neither workflow, and went a
+ *     release without CI - the pin added BECAUSE the catalogue parser broke
+ *     twice in silence;
+ *   - `check:conventions` was in the script and in check.yml but not in
+ *     deploy.yml, from the day it was added, so main could be published past
+ *     the one gate that reads the house style.
+ *
+ * Both were found by eye, weeks apart. This is the same reading done by a
+ * machine, in `npm test`, so a twelfth gate added to one list and forgotten
+ * in the other two is red before it is merged rather than after.
+ *
+ * The ORDER is deliberately not compared: deploy.yml has to build the site it
+ * publishes, so `docs:build` and `check:cross-site` - which judges the built
+ * HTML - necessarily come last there. What has to match is the set.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (f) => readFileSync(join(ROOT, f), 'utf8');
+
+/** Every gate the `check` script chains, as the npm script names it. */
+function scriptGates() {
+  const pkg = JSON.parse(read('package.json'));
+  const chain = pkg.scripts.check;
+  assert.ok(chain, 'package.json has a `check` script');
+  return chain
+    .split('&&')
+    .map((part) => part.trim().replace(/^npm run /, ''))
+    .filter(Boolean);
+}
+
+/** Every gate a workflow runs, by the npm script behind the step. */
+function workflowGates(file) {
+  const yml = read(file);
+  const out = [];
+  for (const m of yml.matchAll(/^\s*run:\s*(npm (?:run [\w:-]+|test|ci))\s*$/gm)) {
+    const cmd = m[1].replace(/^npm run /, '').replace(/^npm /, '');
+    if (cmd === 'ci') continue; // installing is not a gate
+    out.push(cmd);
+  }
+  return out;
+}
+
+/* The floor. A pattern that matched nothing would compare three empty sets
+ * and report that they agree - which is the exact failure this file exists to
+ * catch, one level up. */
+test('all three lists are actually read', () => {
+  assert.ok(scriptGates().length >= 5, 'the check script chains gates');
+  for (const f of ['.github/workflows/check.yml', '.github/workflows/deploy.yml']) {
+    assert.ok(workflowGates(f).length >= 5, `${f} runs gates`);
+  }
+});
+
+test('check.yml runs every gate the check script does, and no other', () => {
+  assert.deepEqual(new Set(workflowGates('.github/workflows/check.yml')), new Set(scriptGates()));
+});
+
+test('deploy.yml runs every gate the check script does, and no other', () => {
+  /* The one that had drifted. A gate missing here is a gate main can be
+   * published past, and nothing about the deploy would look wrong. */
+  assert.deepEqual(new Set(workflowGates('.github/workflows/deploy.yml')), new Set(scriptGates()));
+});
+
+test('no gate is run twice in one workflow', () => {
+  for (const f of ['.github/workflows/check.yml', '.github/workflows/deploy.yml']) {
+    const gates = workflowGates(f);
+    assert.equal(gates.length, new Set(gates).size, `${f} lists a gate twice`);
+  }
+});
+
+test('check.yml keeps the script order, so a green run locally is a green run there', () => {
+  assert.deepEqual(workflowGates('.github/workflows/check.yml'), scriptGates());
+});
+
+test('the documents say eleven, and there are eleven', () => {
+  /* AGENTS.md, README.md, CONTRIBUTING.md and CLAUDE.md all count them in
+   * prose. A twelfth gate that left the four documents saying "eleven" is the
+   * same drift as a gate missing from a workflow, one document over. */
+  const gates = scriptGates();
+  assert.equal(gates.length, 11, `the count in the four documents is 11, the lists have ${gates.length}`);
+  for (const doc of ['AGENTS.md', 'README.md', 'CONTRIBUTING.md', 'CLAUDE.md']) {
+    assert.match(read(doc), /eleven/, `${doc} counts the gates`);
+  }
+});

--- a/test/scroll-memory.test.mjs
+++ b/test/scroll-memory.test.mjs
@@ -1,0 +1,164 @@
+/*
+ * Coming back to a page means coming back to WHERE ON IT you were.
+ *
+ * The bar's Documentation and Samples items already restored the page. They
+ * restored the top of it, which on the manual's long chapters and on a
+ * catalogue of 770 rows is most of the way to not having remembered anything:
+ * the reader who was at sample 400, looked something up and pressed Samples,
+ * arrived at sample 1.
+ *
+ * The offset is now written per path, and restored ON ARRIVAL BY THE BAR AND
+ * NOWHERE ELSE — that is the whole design, and it is what these cases are
+ * about. A page that restored on every load would fight the browser's own
+ * back-and-forward restoration and would drop a reader who followed an
+ * ordinary link into the middle of a page with nothing to explain it. So the
+ * bar writes one record naming where it is sending them; the page that IS
+ * that, arriving within seconds, honours it; everything else ignores it.
+ *
+ * A browser test on this repository cannot reach any of it: `vitepress
+ * preview` serves this site on localhost while the neighbouring deployments
+ * are on abap2ui5.github.io, so every case would take the different-origin
+ * branch. Here `location` and `localStorage` are stubs.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const SITE = 'https://abap2ui5.github.io';
+
+/** The globals the module reads, with a real (in-memory) store behind them. */
+function at(path, store = {}, run = () => {}) {
+  const before = { location: globalThis.location, localStorage: globalThis.localStorage };
+  const [pathname, search] = path.split(/(?=\?)/);
+  globalThis.location = {
+    href: SITE + path,
+    origin: SITE,
+    pathname,
+    search: search || '',
+    hash: '',
+  };
+  globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+  };
+  try {
+    return run(store);
+  } finally {
+    globalThis.location = before.location;
+    globalThis.localStorage = before.localStorage;
+  }
+}
+
+const { rememberScroll, scrollOf, handOff, takeHandoff } =
+  await import('../docs/.vitepress/theme/site-memory.js');
+
+const SCROLL = 'abap2ui5-playground:scroll';
+const BACK = 'abap2ui5-playground:returning';
+
+test('an offset is written for the page it was taken on, and read back', () => {
+  const store = {};
+  at('/docs/cookbook/tables', store, () => rememberScroll(1200));
+  at('/docs/cookbook/tables', store, () => {
+    assert.equal(scrollOf(), 1200);
+  });
+  /* Another page of the same site is another entry, not the same one. */
+  at('/docs/get_started/about', store, () => {
+    assert.equal(scrollOf(), 0);
+  });
+});
+
+test('the catalogue keeps one offset per filtered list, because the URL is the list', () => {
+  const store = {};
+  at('/playground/samples/?q=table', store, () => rememberScroll(900));
+  at('/playground/samples/', store, () => assert.equal(scrollOf(), 0));
+  at('/playground/samples/?q=table', store, () => assert.equal(scrollOf(), 900));
+});
+
+test('the map does not grow without bound', () => {
+  const store = {};
+  for (let i = 0; i < 30; i++) at(`/docs/p${i}`, store, () => rememberScroll(i + 1));
+  const kept = Object.keys(JSON.parse(store[SCROLL]));
+  assert.equal(kept.length, 12);
+  /* The twelve most recent, and the oldest is what fell off. */
+  assert.ok(kept.includes('/docs/p29'));
+  assert.ok(!kept.includes('/docs/p0'));
+});
+
+test('the bar hands off, and the page it names restores', () => {
+  const store = {};
+  at('/playground/samples/', store, () => rememberScroll(4000));
+  at('/docs/cookbook/tables', store, () => handOff('https://abap2ui5.github.io/playground/samples/'));
+  at('/playground/samples/', store, () => {
+    assert.equal(takeHandoff(), 4000);
+  });
+});
+
+test('arriving anywhere else ignores the record', () => {
+  /* It is written before a navigation that may never happen - a middle click,
+   * a reader who went somewhere else instead. */
+  const store = {};
+  at('/playground/samples/', store, () => rememberScroll(4000));
+  at('/docs/cookbook/tables', store, () => handOff('/playground/samples/'));
+  at('/docs/resources/api', store, () => assert.equal(takeHandoff(), null));
+});
+
+test('reading it consumes it, so the next page does not inherit the journey', () => {
+  const store = {};
+  at('/playground/samples/', store, () => rememberScroll(4000));
+  at('/docs/', store, () => handOff('/playground/samples/'));
+  at('/playground/samples/', store, () => {
+    assert.equal(takeHandoff(), 4000);
+    assert.equal(takeHandoff(), null, 'the second read');
+  });
+});
+
+test('a stale record is not a journey', () => {
+  const store = {};
+  at('/playground/samples/', store, () => rememberScroll(4000));
+  store[BACK] = JSON.stringify({ to: '/playground/samples/', at: Date.now() - 120_000 });
+  at('/playground/samples/', store, () => assert.equal(takeHandoff(), null));
+});
+
+test('a hash the reader named beats an offset this remembered', () => {
+  const store = {};
+  at('/docs/cookbook/tables', store, () => rememberScroll(1200));
+  at('/docs/cookbook/tables', store, () => handOff('/docs/cookbook/tables'));
+  const before = globalThis.location;
+  at('/docs/cookbook/tables', store, () => {
+    globalThis.location.hash = '#popups';
+    assert.equal(takeHandoff(), null);
+  });
+  globalThis.location = before;
+});
+
+test('a link to another host writes no record: it shares no storage', () => {
+  const store = {};
+  at('/docs/', store, () => handOff('https://github.com/abap2UI5/abap2UI5'));
+  assert.equal(store[BACK], undefined);
+});
+
+test('what comes out of storage is checked, not followed', () => {
+  /* Anything on this origin can write there, and scrollTo takes whatever it is
+   * given. Every one of these is a value that is not an offset. */
+  for (const junk of ['"top"', '{"/docs/":"1e9"}', '{"/docs/":-40}', '{"/docs/":99999999}', 'null', '[1,2]', 'not json at all']) {
+    const store = { [SCROLL]: junk };
+    at('/docs/', store, () => assert.equal(scrollOf(), 0, junk));
+  }
+});
+
+test('a record that is not a record restores nothing', () => {
+  for (const junk of ['null', '{}', '{"to":"/docs/"}', '{"to":5,"at":1}', 'nonsense']) {
+    const store = { [BACK]: junk, [SCROLL]: JSON.stringify({ '/docs/': 500 }) };
+    at('/docs/', store, () => assert.equal(takeHandoff(), null, junk));
+  }
+});
+
+test('a page with no stored offset restores nothing rather than the top', () => {
+  /* `null`, not 0: the caller scrolls only when there is somewhere to scroll
+   * to, and "back to the top" is what happens anyway. */
+  const store = {};
+  at('/docs/', store, () => handOff('/docs/'));
+  at('/docs/', store, () => assert.equal(takeHandoff(), null));
+});

--- a/test/search.test.mjs
+++ b/test/search.test.mjs
@@ -199,3 +199,79 @@ test('the search box in the bar carries the cross-site attribute on a sample hit
   const fn = box.slice(box.indexOf('function hrefOf'), box.indexOf('function go'));
   assert.match(fn, /target:\s*'_self'/);
 });
+
+/* ── THE LAST THING YOU SEARCHED FOR ────────────────────────────────────────
+ *
+ * A hit opens another page, often on another deployment, and the box that
+ * opens there used to be empty: a reader comparing three samples of the same
+ * control typed the same word three times. So the query is written down as a
+ * hit is opened and the next box starts with it - and, because it comes back
+ * out of a localStorage anything on this origin can write to, what comes back
+ * is checked rather than used. */
+const { rememberQuery, recallQuery } = await import('../docs/.vitepress/theme/search-engine.js');
+
+const QUERY_KEY = 'abap2ui5-playground:search';
+
+/** The one global these two touch, as a store this test can look inside. */
+function stored(store, run) {
+  const before = globalThis.localStorage;
+  globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+  };
+  try {
+    return run();
+  } finally {
+    globalThis.localStorage = before;
+  }
+}
+
+test('a query survives the hit that was opened on it', () => {
+  const store = {};
+  stored(store, () => rememberQuery('table select dialog'));
+  assert.equal(stored(store, () => recallQuery()), 'table select dialog');
+});
+
+test('an empty query clears the memory rather than storing itself', () => {
+  const store = {};
+  stored(store, () => rememberQuery('carousel'));
+  stored(store, () => rememberQuery('   '));
+  assert.equal(store[QUERY_KEY], undefined);
+  assert.equal(stored(store, () => recallQuery()), '');
+});
+
+test('a query the reader has stopped asking is not offered back', () => {
+  /* Half an hour. A field prefilled with yesterday's question is a worse
+   * starting point than an empty one. */
+  const store = { [QUERY_KEY]: JSON.stringify({ q: 'carousel', at: Date.now() - 31 * 60 * 1000 }) };
+  assert.equal(stored(store, () => recallQuery()), '');
+});
+
+test('what comes back out of storage is checked, not used', () => {
+  for (const junk of [
+    'not json',
+    'null',
+    '"carousel"',
+    JSON.stringify({ q: 'carousel' }),
+    JSON.stringify({ q: 42, at: Date.now() }),
+    JSON.stringify({ q: 'carousel', at: 'now' }),
+    /* A timestamp in the future is not an age, and a query longer than
+     * anything anybody typed into a 320px field is not one either. */
+    JSON.stringify({ q: 'carousel', at: Date.now() + 60_000 }),
+    JSON.stringify({ q: 'x'.repeat(500), at: Date.now() }),
+  ]) {
+    assert.equal(stored({ [QUERY_KEY]: junk }, () => recallQuery()), '', junk.slice(0, 40));
+  }
+});
+
+test('no storage at all is an empty box, not a broken one', () => {
+  const before = globalThis.localStorage;
+  globalThis.localStorage = undefined;
+  try {
+    assert.equal(recallQuery(), '');
+    rememberQuery('carousel'); /* must not throw */
+  } finally {
+    globalThis.localStorage = before;
+  }
+});


### PR DESCRIPTION
Three things, two of them reported from the site itself.

## The deploy was missing a gate

`deploy.yml` did not run `check:conventions`. `check.yml` did, `npm run check` did, and AGENTS.md said all of them ran the same list in the same order — so the one gate that reads the house style of the fenced examples was a gate `main` could be published past, from the day it was added.

The step is added, where check.yml has it. The claim about the ORDER was wrong and stays wrong if it is only reworded: the publishing job has to build the site it publishes, so `docs:build` and `check:cross-site` — which judges the built HTML — necessarily come last there. What has to match is the SET, and that is now what the documents say and what `test/gates.test.mjs` reads: three lists (the `check` script, check.yml, deploy.yml) compared as sets, with check.yml additionally held to the script's order, a floor so a pattern matching nothing cannot report agreement, and the gate count in the four documents pinned to the number of gates.

This drift had happened twice, both times found by eye and weeks late. It is decided in `npm test` now, before a merge.

## Coming back to a page means coming back to where on it you were

The Documentation and Samples items came back to the page you left — and to the top of it, which on the manual's long chapters and on a catalogue of 770 rows is most of the way to not having remembered anything.

The offset is written per path now, and restored **on arrival by the bar and nowhere else**. That last part is the design: a page that restored on every load would fight the browser, which already does this for back and forward, and would drop a reader who followed an ordinary link into the middle of a page with nothing to explain it. So a bar item writes one record naming where it is sending the reader; the page that *is* that, arriving within half a minute and with no hash of its own, honours it; everything else ignores it. What comes out of storage is checked rather than used — `scrollTo` takes whatever it is given.

**The search remembers what you asked.** A hit opens another page, often another deployment, and the box that opened there was empty: a reader comparing three samples of one control typed the same word three times. The query is written down as a hit is opened and the next box starts with it, selected, so the first keystroke replaces it. Recent, short and a string, or it is not offered back.

## The four sections carry their marks

Home, Documentation, Samples and Playground each carry the mark this site's home page already draws on its cards — a house, a book, a window, a play button — in the link's own colour, so the section you are on is marked twice. The bold-width reservation moved one level in, onto the word, which is the part that goes bold.

## Checked

`npm run check`: all eleven gates green, 99 unit tests (12 of them new for the scroll memory, 5 for the query memory).

The other three bars, and the other copies of both memories, are in the matching abap2UI5/playground pull request; the two have to land together to keep `check:design` and the four bars in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_