### PR TITLE
Add "Copy link to selection" feature for documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `docs/.vitepress/theme/style.css` | Everything this site looks like. Its palette is the playground's, copied — see *One site in three places* below |
 | `docs/.vitepress/theme/SiteBar.vue` | The right-hand end of the bar: the three sites, and the menu behind the bar's last button — the light/dark switch, the project's tools and its repositories. Rendered into `nav-bar-content-after` by `theme/index.js`; the marks between them are VitePress's own `socialLinks`, ordered by `style.css` |
 | `docs/.vitepress/theme/site-memory.js` | Where the reader was, on each site, so the bar comes back to it; pinned by `test/site-memory.test.mjs` |
+| `docs/.vitepress/theme/link-to-selection.js` | **Copy link to selection** — the button under a selection inside the article, and the fallback for a browser too old for `:~:`. `theme/text-fragment.js` is the half with no DOM in it (what to quote, how to spell it), pinned by `test/text-fragment.test.mjs` |
 | `docs/.vitepress/theme/TheBar.vue` | The bar, as one element this repository owns: the brand, `SiteNav.vue` (the four sections), `SearchBox.vue`, the two marks, `SiteMenu.vue` (the menu behind the last button, and the version number `check:version` reads). It used to be the theme's bar with our parts in its slots and 85 override lines arguing its own parts out of the way; the theme now keeps two things, the hamburger and the screen it opens on a phone |
 | `docs/.vitepress/theme/SearchBox.vue` | The box in the middle of the bar and what it opens. `theme/search-engine.js` is the matching, framework-free because the other three bars carry a copy of it; both are pinned by `test/search.test.mjs` |
 | `scripts/check-design.mjs` | The palette, the type and the radii the four bars share, against `abap2UI5/playground`'s copy of them — needs a checkout (`PLAYGROUND_HOME`, `.playground`, `../playground`) or the network, and fails rather than passing without one. The table of what is shared, and both spellings of each value, is `scripts/lib/design.mjs` |
@@ -46,7 +47,7 @@ it are decidable, and all eleven are decided before a merge:
 
 | | |
 |---|---|
-| `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate — and the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow |
+| `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate; the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow; and the text fragment behind *Copy link to selection* — what it quotes, and how it escapes it |
 | `check:version` | the release number in the bar's menu (`VERSION` in `theme/SiteBar.vue` — it was a nav dropdown's label in `config.mjs` until the bar was rebuilt), the deprecations page and the changelog, against the newest release tag of the framework — this one goes stale without anybody touching this repository |
 | `docs:build` | a page that does not build is a page nobody can read |
 | `check:examples` | the ABAP in the fenced blocks, against the real framework: does it compile, and does the view it builds name controls and properties that exist on the UI5 floor this documentation targets. **It ran no abaplint rules at all until 2026-09-04** — the generated config had no `rules` block, so abaplint walked 139 files, ran nothing, and printed `0 issue(s) found` for years. Ten examples with an unbalanced parenthesis were sitting behind that. The three compile rules it runs now (`parser_error`, `check_syntax`, `unknown_types`) are the sample repositories' own; the reasoning for stopping there, measured against the full 188-rule set, is in the file |
@@ -454,6 +455,79 @@ class in it (before that, `data-code` only worked for a class called
 error), the app-only layout fix for a column narrower than 820px, and
 `frameOptions="allow"` on the app frame. **Merge and deploy
 [abap2UI5/playground](https://github.com/abap2UI5/playground) first**, then this.
+
+## A link to what you selected
+
+Select anything inside a page of the manual — a sentence, a chain out of a
+fence, one method of an example — and a small **Copy link to selection** button
+appears under it. What it copies is this page's URL with the words quoted in it,
+as the browser's own [text fragment](https://developer.mozilla.org/en-US/docs/Web/URI/Fragment/Text_fragments):
+
+```
+.../development/lifecycle.html#:~:text=client-%3Eview_display
+```
+
+The browser finds those words and highlights them.
+
+**Why the words and not the line.** The per-sample pages in
+[abap2UI5/playground](https://github.com/abap2UI5/playground) answer "look at
+line 40 to 55" with `#L40-L55`, and that is right over there: one class per
+page, printed whole, so a line number is an address. A page here is a dozen
+fences and the prose around them — and, the part that decides it, nothing here
+has a commit behind it. GitHub's line links are permalinks because they name a
+SHA; a line number on a documentation page names whatever is on that line
+*today*, and the next correction to the example above it moves the line
+silently. A link somebody pasted into an issue would then point at the wrong
+line and nothing would be red. A quote of the words survives every edit that
+does not delete the words themselves, and when it does not survive it lands at
+the top of the page rather than on something else.
+
+**What it costs the pages: nothing.** No ids on a fence, no numbers in a
+gutter, no markup on any of the 838 examples — a text fragment is a property of
+the URL, not of the document, which is the whole reason this is a hundred lines
+of theme and no change to a single page.
+
+The parts worth knowing about `theme/text-fragment.js`, which is where the
+decisions are and what `test/text-fragment.test.mjs` pins:
+
+- A **short** selection is quoted whole; anything longer is quoted as its first
+  and last few words (`text=start,end`), because a directive carrying two
+  paragraphs is a URL nobody pastes into a chat window.
+- A selection that **crosses lines** is always quoted as start and end, however
+  short. An exact quote has to be found inside ONE block, and every line of a
+  highlighted fence is an element of its own — a two-line exact quote matches
+  nothing at all.
+- The **whitespace is collapsed**, because that is how the browser compares it:
+  an indented chain selected out of a fence is the same text as the one line
+  the directive spells.
+- A quote the page carries **twice** is an address for the wrong one, so the
+  words in front of the selection are added as a prefix (and the words after it
+  as a suffix if the page repeats those too). Only when it is actually
+  ambiguous: context is length in a URL and one more thing that can go stale.
+- The **hyphen is escaped by hand**. `encodeURIComponent` leaves `-` alone
+  because it is unreserved, and `-` is exactly what marks a part of the
+  directive as the prefix or the suffix: `client->view_display` written out
+  unescaped is a valid directive for something else entirely. That one is a
+  silent wrong answer, not an error, which is why it has a test of its own.
+
+**What a browser too old for `:~:` gets.** Text fragments are Chrome 80,
+Safari 16.1 and Firefox 131 and later; an older one ignores the directive and
+lands at the top of the page, which reads as a broken link. So
+`markDirective( )` in `link-to-selection.js` scrolls to the block the words are
+in and marks it for a few seconds instead — and it only ever runs where it is
+needed, because a browser that supports fragments takes the directive OUT of
+`location.href` (and has `document.fragmentDirective`, which is what is
+actually tested).
+
+**What could not be verified here, and has to be checked by hand once.**
+Headless Chromium under Playwright *parses* the directive — it strips it from
+`location.href` — and never acts on it: no scroll, no highlight, for a plain
+static page, cross-origin, same-origin, followed by a real click or opened
+directly. So everything up to the clipboard is checked (the button appears on a
+selection inside the article and on nothing else, the directive is the selected
+words, the URL is this page, the old-browser fallback marks the right element)
+and the last step — the browser actually jumping to the words — is not. Open
+one of these links in a real browser after changing anything here.
 
 ## Toolchain
 

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -3,6 +3,7 @@ import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
 import { setUpPlayground } from './playground.js'
+import { markDirective, setUpLinkToSelection } from './link-to-selection.js'
 import TheBar from './TheBar.vue'
 import SiteNav from './SiteNav.vue'
 import { rememberHere } from './site-memory.js'
@@ -32,6 +33,18 @@ export default {
     // The Run button under a runnable ABAP example. One delegated listener for
     // the whole site — the browser half of docs/.vitepress/playground.mjs.
     if (!import.meta.env.SSR) setUpPlayground()
+
+    // "Copy link to selection" — a link to the words a reader marked, as a
+    // text fragment (link-to-selection.js, and text-fragment.js for why the
+    // link names the words rather than the line they are on). One delegated
+    // listener for the whole site, like the Run button above it; the second
+    // call is only ever reached by a browser too old for `:~:`, and lands it
+    // where the words are instead of at the top of the page.
+    if (!import.meta.env.SSR) {
+      setUpLinkToSelection()
+      if (document.readyState === 'complete') markDirective()
+      else window.addEventListener('load', markDirective, { once: true })
+    }
 
     // Where the reader is, for the Docs item on the other three bars to come
     // back to (site-memory.js). On every route change, because this site is a

--- a/docs/.vitepress/theme/link-to-selection.js
+++ b/docs/.vitepress/theme/link-to-selection.js
@@ -1,0 +1,194 @@
+/*
+ * "Copy link to selection", once it is in a browser — the DOM half of
+ * theme/text-fragment.js, which is where the reasoning for quoting the words
+ * rather than numbering the lines is written down.
+ *
+ * Select anything inside a page of the manual — a sentence, a chain out of a
+ * fence, one method of an example — and a small button appears under it. Press
+ * it and the clipboard holds this page's URL with the selection quoted in it:
+ *
+ *   .../development/lifecycle.html#:~:text=client-%3Eview_display
+ *
+ * Three things are deliberate:
+ *
+ * **The whole page is the surface.** It is not a button on a code block: a
+ * reader quoting a sentence of prose to a colleague has exactly the problem a
+ * reader quoting a chain has, and one affordance for both is one thing to
+ * learn. What it is scoped to is the ARTICLE (.vp-doc) — a selection in the
+ * sidebar or the bar is somebody dragging, not somebody quoting.
+ *
+ * **Nothing is added to the page until somebody selects something.** No markup
+ * on a fence, no ids, no numbers in the gutter: a text fragment is a property
+ * of the URL, not of the document, which is what makes this a hundred lines
+ * here and no change at all to the 838 examples.
+ *
+ * **The page it lands on is this page, not a copy of it.** The link is built
+ * from `location`, so a link made on a `docs:dev` server names localhost and a
+ * link made on the site names the site.
+ *
+ * The fallback at the bottom is for a browser too old to know what `:~:` means
+ * — it would land at the top of the page and look like a broken link. There it
+ * scrolls to the block the words are in and marks it for a moment. Browsers
+ * that support fragments (`document.fragmentDirective`) do their own, better
+ * job and this stays out of their way.
+ */
+import { fragmentFor, normalise, parseDirective } from './text-fragment.js'
+
+/** The article, and nothing else on the page. */
+const ARTICLE = '.vp-doc'
+/* The elements a selection's context is taken from: what is quoted has to be
+ * disambiguated by the words AROUND it, and a block is where "around" ends. */
+const BLOCK = 'p, li, dd, dt, td, th, pre, blockquote, h1, h2, h3, h4, h5, h6'
+
+const LABEL = 'Copy link to selection'
+const DONE = 'Link copied'
+const FAILED = 'Copy it from the address bar'
+
+/** The selection, if it is a real one inside the article. */
+function quoted() {
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return undefined
+  const range = selection.getRangeAt(0)
+  const node = range.commonAncestorContainer
+  const element = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement
+  if (!element?.closest(ARTICLE)) return undefined
+  return normalise(range.toString()) === '' ? undefined : range
+}
+
+/** The text before and after the selection, within the block it starts in. */
+function around(range) {
+  const start = range.startContainer
+  const element = start.nodeType === Node.ELEMENT_NODE ? start : start.parentElement
+  const block = element?.closest(BLOCK) ?? element?.closest(ARTICLE)
+  if (!block) return { prefix: '', suffix: '' }
+
+  const read = (from, to) => {
+    try {
+      const part = document.createRange()
+      from(part)
+      to(part)
+      return part.toString()
+    } catch {
+      /* A selection that started in one block and ended in another: the
+       * context is a nicety, and the directive is written without it. */
+      return ''
+    }
+  }
+  return {
+    prefix: read(
+      (part) => part.setStart(block, 0),
+      (part) => part.setEnd(range.startContainer, range.startOffset),
+    ),
+    suffix: read(
+      (part) => part.setStart(range.endContainer, range.endOffset),
+      (part) => part.setEnd(block, block.childNodes.length),
+    ),
+  }
+}
+
+/** The one button, made when it is first needed and moved about after that. */
+let button
+
+function show(range) {
+  if (!button) {
+    button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'a2ui5-quote'
+    button.textContent = LABEL
+    button.addEventListener('mousedown', (event) => event.preventDefault()) // keep the selection
+    button.addEventListener('click', copy)
+    document.body.append(button)
+  }
+  button.textContent = LABEL
+  button.hidden = false
+
+  /* Under the end of the selection, and never off the right-hand edge. */
+  const box = range.getBoundingClientRect()
+  const width = button.offsetWidth
+  const left = Math.min(box.left + window.scrollX, window.scrollX + document.documentElement.clientWidth - width - 8)
+  button.style.left = `${Math.max(window.scrollX + 8, left)}px`
+  button.style.top = `${box.bottom + window.scrollY + 8}px`
+}
+
+const hide = () => {
+  if (button) button.hidden = true
+}
+
+function copy() {
+  const range = quoted()
+  if (!range) return hide()
+
+  const { prefix, suffix } = around(range)
+  const directive = fragmentFor({
+    text: range.toString(),
+    prefix,
+    suffix,
+    /* Read here rather than on every selection change: this is the whole
+     * article as text, and it is only needed to answer whether the quote is
+     * ambiguous. */
+    pageText: document.querySelector(ARTICLE)?.innerText ?? '',
+  })
+  if (!directive) return hide()
+
+  const url = `${location.origin}${location.pathname}${location.search}#:~:${directive}`
+  const said = (text) => {
+    button.textContent = text
+    setTimeout(hide, 1600)
+  }
+  try {
+    navigator.clipboard.writeText(url).then(() => said(DONE), () => said(FAILED))
+  } catch {
+    said(FAILED)
+  }
+}
+
+/** The button, wired to the selection. Called once, from the theme. */
+export function setUpLinkToSelection() {
+  let pending
+  document.addEventListener('selectionchange', () => {
+    clearTimeout(pending)
+    /* After the drag, not during it: a selection changes on every pixel of a
+     * mouse-down, and a button that moved with it would be impossible to aim
+     * at. */
+    pending = setTimeout(() => {
+      const range = quoted()
+      if (range) show(range)
+      else hide()
+    }, 200)
+  })
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') hide()
+  })
+}
+
+/**
+ * What a browser that does not know `:~:` gets instead of a link that appears
+ * to do nothing: the block the words are in, scrolled to and marked. Every
+ * browser that supports text fragments has `document.fragmentDirective` and is
+ * left alone here — it highlights the words themselves, which is better than
+ * this can be.
+ */
+export function markDirective(url = location.href) {
+  /* A browser that supports fragments also takes the directive OUT of the
+   * URL - `location.href` no longer carries it - so this reads the directive
+   * only where it is still there to read, which is exactly where it is
+   * needed. The url is a parameter so that this can be exercised at all:
+   * nothing else about it can be reached from a browser that strips it. */
+  if ('fragmentDirective' in document) return
+  const directive = parseDirective(url)
+  const article = document.querySelector(ARTICLE)
+  if (!directive || !article || directive.start === '') return
+
+  const wanted = normalise(directive.start)
+  /* The DEEPEST element carrying the words: every ancestor up to <body>
+   * carries them too, and scrolling to the article is not an answer. */
+  const carrying = [...article.querySelectorAll('*')].filter(
+    (element) => normalise(element.textContent).includes(wanted),
+  )
+  const target = carrying.find((element) => !carrying.some((other) => other !== element && element.contains(other)))
+  if (!target) return
+
+  target.scrollIntoView({ block: 'center' })
+  target.classList.add('a2ui5-quoted')
+  setTimeout(() => target.classList.remove('a2ui5-quoted'), 4000)
+}

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2038,3 +2038,49 @@
   outline-offset: 2px;
   border-radius: var(--radius-control);
 }
+
+/* =========================================== copy link to selection ===
+ *
+ * The button that appears under a selection inside the article, and the mark
+ * a browser too old for text fragments gets instead of the browser's own.
+ * theme/text-fragment.js says why the link quotes the words rather than
+ * numbering the lines; theme/link-to-selection.js is what puts this on screen.
+ *
+ * Positioned in DOCUMENT coordinates rather than the viewport, so it stays on
+ * the words it belongs to while the page scrolls under it - a floating button
+ * that drifts away from its own selection reads as a bug in the page. */
+.a2ui5-quote {
+  position: absolute;
+  z-index: 20;
+  padding: 5px 11px;
+  border: 1px solid var(--a2ui5-c-hairline);
+  border-radius: var(--radius-control);
+  background-color: var(--bg);
+  color: var(--a2ui5-c-link);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  white-space: nowrap;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.12);
+}
+
+.a2ui5-quote:hover {
+  background-color: var(--bg-sunken);
+}
+
+/* The fallback's mark. The same tint the sample pages colour a linked line
+ * with (sample.css in abap2UI5/playground), because it is the same promise:
+ * this is the part of the page the link was about. It is removed after a few
+ * seconds - it says "here", it is not a state the page is in. */
+.vp-doc .a2ui5-quoted {
+  background-color: var(--a2ui5-c-out-tint);
+  border-radius: var(--radius-control);
+  transition: background-color 0.4s;
+}
+
+/* Printing a page prints its text, and a button is not text. */
+@media print {
+  .a2ui5-quote { display: none; }
+}

--- a/docs/.vitepress/theme/text-fragment.js
+++ b/docs/.vitepress/theme/text-fragment.js
@@ -1,0 +1,144 @@
+/*
+ * A link to the WORDS a reader selected, rather than to the lines they are on.
+ *
+ * The per-sample pages in abap2UI5/playground answer "look at line 40 to 55"
+ * with #L40-L55: one class per page, printed whole, so a line number is an
+ * address. A page of this manual is not that. It carries a dozen fences and a
+ * page of prose around them, and — this is the part that decides it — nothing
+ * here has a commit behind it. GitHub's line links are permalinks because they
+ * name a SHA; a line number on a documentation page names whatever is on that
+ * line today, and the next correction to the example silently moves it. A link
+ * somebody pasted into an issue would then point at the wrong line, and
+ * nothing would be red.
+ *
+ * So the link names the text instead, using the browser's own text fragments:
+ *
+ *   .../get_started/quickstart.html#:~:text=INTERFACES%20z2ui5_if_app
+ *
+ * The browser finds those words and highlights them. Correct an example above
+ * it and the link still lands; delete the words themselves and it lands at the
+ * top of the page, which is the one failure mode of a link that has no id to
+ * miss. Nothing is stored, nothing is generated, and no markup is added to a
+ * single fence.
+ *
+ * This file is the part with no DOM in it — what to quote, and how to spell
+ * it — so it can be checked as a unit (test/text-fragment.test.mjs).
+ * theme/link-to-selection.js is the browser half.
+ *
+ * The directive it writes is the standard one:
+ *
+ *   text=[prefix-,]textStart[,textEnd][,-suffix]
+ *
+ * and the four decisions in it are:
+ *
+ *  - A SHORT selection is quoted whole. Anything longer is quoted as its first
+ *    and last few words, because a directive carrying two paragraphs is a URL
+ *    nobody can paste into a chat window.
+ *  - A selection that CROSSES LINES is always quoted as start and end, however
+ *    short it is. An exact match has to be found inside one block, and every
+ *    line of a highlighted code fence is its own element — a two-line quote
+ *    would match nothing at all. start,end is the form that spans blocks; that
+ *    is what it is for.
+ *  - The words are compared with their whitespace collapsed, which is how the
+ *    fragment itself is matched: an indented chain selected out of a fence is
+ *    the same text as the one line the directive spells.
+ *  - The match begins at the first place textStart occurs, so a textStart the
+ *    page carries twice is an address for the wrong one. When that happens the
+ *    words in front of the selection are added as a prefix, and if the page
+ *    repeats those too, the words after it as a suffix.
+ */
+
+/** Whitespace as a text fragment matches it: one space, and none at the ends. */
+export const normalise = (text) => String(text ?? "").replace(/\s+/g, " ").trim();
+
+/* What has to be escaped inside a part of the directive. encodeURIComponent
+ * already takes "," and "&"; "-" it leaves alone, because "-" is unreserved in
+ * a URL — and it is exactly the character that marks a part as the prefix or
+ * the suffix, so a hyphen inside the quoted words has to go by hand. */
+const enc = (part) => encodeURIComponent(part).replace(/-/g, "%2D");
+
+const words = (text) => (text === "" ? [] : text.split(" "));
+
+/** Words of the text before and after the selection, when one is needed. */
+const CONTEXT = 5;
+/** Words quoted at each end of a selection too long to quote whole. */
+const EDGE = 5;
+/** A selection of at most this many words is quoted whole. */
+const EXACT = 12;
+
+/** How many places in the page this run of words occurs. */
+const count = (page, needle) => (needle === "" ? 0 : page.split(needle).length - 1);
+
+/**
+ * The `text=` directive for a selection, or null when there is nothing to
+ * quote. `prefix` and `suffix` are the text around the selection inside the
+ * same block, and `pageText` the page it was made on — both are only read to
+ * decide whether the quote is ambiguous, and a caller that passes neither gets
+ * the shortest directive that describes the selection.
+ */
+export function fragmentFor({ text, prefix = "", suffix = "", pageText = "" } = {}) {
+  const selection = normalise(text);
+  if (selection === "") return null;
+
+  const page = normalise(pageText);
+  const all = words(selection);
+  /* Across lines, or simply long: quoted as its two ends. The halves never
+   * overlap - a textEnd is looked for AFTER textStart, so a short selection is
+   * split down the middle rather than quoted twice. */
+  const spans = /\n/.test(String(text)) || all.length > EXACT;
+  const half = Math.min(EDGE, Math.floor(all.length / 2));
+
+  const start = spans && half > 0 ? all.slice(0, half).join(" ") : selection;
+  const end = spans && half > 0 ? all.slice(all.length - half).join(" ") : "";
+
+  /* Where the match BEGINS is what a repeated quote gets wrong, so it is the
+   * start that has to be made unique: first with the words in front of it,
+   * then - for a quote whose end is its own end - with the words after. */
+  let before = "";
+  let after = "";
+  if (page !== "" && count(page, start) > 1) {
+    before = words(normalise(prefix)).slice(-CONTEXT).join(" ");
+    if (before === "" || count(page, `${before} ${start}`) > 1) {
+      after = words(normalise(suffix)).slice(0, CONTEXT).join(" ");
+    }
+  }
+
+  return [
+    "text=",
+    before === "" ? "" : `${enc(before)}-,`,
+    enc(start),
+    end === "" ? "" : `,${enc(end)}`,
+    after === "" ? "" : `,-${enc(after)}`,
+  ].join("");
+}
+
+/**
+ * The parts of a `:~:text=` directive in a URL, or null when it carries none.
+ * The browsers that support text fragments never need this — they find the
+ * words themselves; it is read by the fallback in link-to-selection.js, which
+ * is what a browser too old for them gets instead of a link that does nothing.
+ */
+export function parseDirective(url) {
+  const at = String(url ?? "").indexOf(":~:");
+  if (at === -1) return null;
+  const directive = String(url).slice(at + 3).split("&").find((part) => part.startsWith("text="));
+  if (directive === undefined) return null;
+
+  const parts = directive.slice("text=".length).split(",").filter((part) => part !== "");
+  if (parts.length === 0) return null;
+  const decode = (part) => {
+    try {
+      return decodeURIComponent(part);
+    } catch {
+      /* Somebody else's URL, hand-edited or truncated in a chat window. */
+      return part;
+    }
+  };
+
+  let prefix = "";
+  let suffix = "";
+  if (parts.length > 1 && parts[0].endsWith("-")) prefix = decode(parts.shift().slice(0, -1));
+  if (parts.length > 1 && parts[parts.length - 1].startsWith("-")) suffix = decode(parts.pop().slice(1));
+
+  return { prefix, start: decode(parts[0] ?? ""), end: parts.length > 1 ? decode(parts[1]) : "", suffix };
+}

--- a/test/text-fragment.test.mjs
+++ b/test/text-fragment.test.mjs
@@ -1,0 +1,117 @@
+/*
+ * The link a reader copies for the words they selected — specifically the half
+ * that decides WHAT to quote and how to spell it (theme/text-fragment.js).
+ *
+ * Why this is a unit test and not a browser one: what can go wrong here is not
+ * visible on a page. A directive that quotes two words the page carries three
+ * times looks exactly like one that quotes two words it carries once — both
+ * highlight something, and only one of them highlights the right thing. The
+ * same goes for the escaping: a hyphen left unescaped inside the quote is a
+ * valid directive that means something else entirely (everything before it
+ * becomes a prefix), so the link works, silently, on the wrong words.
+ *
+ * The browser half (theme/link-to-selection.js) is a button, a rectangle and
+ * the clipboard, and is left to the browser.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { fragmentFor, normalise, parseDirective } = await import('../docs/.vitepress/theme/text-fragment.js');
+
+test('a short selection is quoted whole', () => {
+  assert.equal(fragmentFor({ text: 'the app class', pageText: 'a page with the app class in it' }),
+    'text=the%20app%20class');
+});
+
+test('whitespace is collapsed, because that is how the fragment is matched', () => {
+  // A chain selected out of a fence arrives with its indentation and its line
+  // breaks; the directive has to spell it the way the browser compares it.
+  assert.equal(normalise('  page->input(\n     value = lv_x )  '), 'page->input( value = lv_x )');
+  assert.equal(fragmentFor({ text: '  two   words  ' }), 'text=two%20words');
+});
+
+test('nothing to quote is no link at all', () => {
+  assert.equal(fragmentFor({ text: '   \n  ' }), null);
+  assert.equal(fragmentFor({}), null);
+});
+
+test('a long selection is quoted as its two ends', () => {
+  // Twenty words in a URL is a URL nobody pastes into a chat window, so a
+  // selection past the limit is quoted as where it starts and where it stops.
+  const text = 'one two three four five six seven eight nine ten eleven twelve thirteen fourteen';
+  assert.equal(fragmentFor({ text }), 'text=one%20two%20three%20four%20five,ten%20eleven%20twelve%20thirteen%20fourteen');
+});
+
+test('a selection that crosses lines is quoted as two ends however short it is', () => {
+  // The reason it must be: an exact quote has to be found inside ONE block,
+  // and every line of a highlighted code fence is an element of its own. Five
+  // words over two lines are quoted as two words and two words - the halves
+  // may not overlap, because textEnd is looked for after textStart, so the one
+  // in the middle is spanned rather than spelled.
+  assert.equal(fragmentFor({ text: 'METHOD z2ui5_if_app~main.\n  DATA lv_x TYPE' }),
+    'text=METHOD%20z2ui5_if_app~main.,lv_x%20TYPE');
+});
+
+test('a quote the page repeats is given the words in front of it', () => {
+  const page = 'the app calls client->view_display twice; the app calls client->view_display again';
+  assert.equal(
+    fragmentFor({ text: 'client->view_display', prefix: 'somewhere else the reader will', pageText: page }),
+    'text=somewhere%20else%20the%20reader%20will-,client%2D%3Eview_display',
+  );
+});
+
+test('...and the words after it when the page repeats those too', () => {
+  const page = 'the app calls client->view_display twice; the app calls client->view_display again';
+  assert.equal(
+    fragmentFor({ text: 'client->view_display', prefix: 'the app calls', suffix: 'twice;', pageText: page }),
+    'text=the%20app%20calls-,client%2D%3Eview_display,-twice%3B',
+  );
+});
+
+test('a quote the page carries once is left alone', () => {
+  // Context is not free - it is length in a URL and one more thing that can go
+  // stale - so it is only added when the quote is actually ambiguous.
+  const page = 'the app calls client->view_display once';
+  assert.equal(fragmentFor({ text: 'client->view_display', prefix: 'the app calls', pageText: page }),
+    'text=client%2D%3Eview_display');
+});
+
+test('a hyphen inside the quote is escaped, because a hyphen is punctuation here', () => {
+  // "prefix-,start" and "end,-suffix": an unescaped hyphen in the words does
+  // not break the link, it silently makes it mean something else.
+  assert.equal(fragmentFor({ text: 'z2ui5_cl_ui5_view_builder=>factory( )' }),
+    'text=z2ui5_cl_ui5_view_builder%3D%3Efactory(%20)');
+  assert.equal(fragmentFor({ text: 'client->nav_app_leave( )' }), 'text=client%2D%3Enav_app_leave(%20)');
+  assert.equal(fragmentFor({ text: 'one, two & three' }), 'text=one%2C%20two%20%26%20three');
+});
+
+test('a directive reads back as the words it was written from', () => {
+  // The fallback for a browser too old for `:~:` has to find the words again.
+  const written = fragmentFor({
+    text: 'client->view_display',
+    prefix: 'the app calls',
+    suffix: 'twice;',
+    pageText: 'the app calls client->view_display twice; the app calls client->view_display again',
+  });
+  assert.deepEqual(parseDirective(`https://abap2ui5.github.io/docs/x.html#:~:${written}`), {
+    prefix: 'the app calls',
+    start: 'client->view_display',
+    end: '',
+    suffix: 'twice;',
+  });
+});
+
+test('a two-ended directive reads back as both ends', () => {
+  assert.deepEqual(parseDirective('/docs/x.html#:~:text=CLASS%20zcl_x,ENDCLASS.'),
+    { prefix: '', start: 'CLASS zcl_x', end: 'ENDCLASS.', suffix: '' });
+});
+
+test('a URL with no directive in it is not one', () => {
+  assert.equal(parseDirective('https://abap2ui5.github.io/docs/x.html'), null);
+  assert.equal(parseDirective('https://abap2ui5.github.io/docs/x.html#a-heading'), null);
+  assert.equal(parseDirective(undefined), null);
+  // Somebody else's fragment directive, for something that is not text.
+  assert.equal(parseDirective('/docs/x.html#:~:unknown=1'), null);
+});


### PR DESCRIPTION
Adds a "Copy link to selection" button that appears when readers select text inside documentation pages. The button copies a URL with the selected words quoted as a [text fragment](https://developer.mozilla.org/en-US/docs/Web/URI/Fragment/Text_fragments), allowing readers to share links to specific passages rather than line numbers.

## Key Changes

- **`docs/.vitepress/theme/link-to-selection.js`** — Browser half of the feature. Displays a button under selections within the article, handles clipboard operations, and provides a fallback for older browsers that don't support text fragments (scrolls to the block containing the words and highlights it temporarily).

- **`docs/.vitepress/theme/text-fragment.js`** — Logic for generating text fragment directives. Decides what to quote (short selections whole, long selections as start/end), handles whitespace normalization, escapes special characters, and disambiguates repeated phrases with context. Includes parsing logic for the fallback.

- **`test/text-fragment.test.mjs`** — Comprehensive unit tests covering quote generation, whitespace handling, ambiguity resolution, escaping, and directive parsing.

- **`docs/.vitepress/theme/style.css`** — Styling for the button (`.a2ui5-quote`) and the fallback highlight mark (`.a2ui5-quoted`). Button is positioned absolutely to stay with the selection, hidden during printing.

- **`docs/.vitepress/theme/index.js`** — Wires up the feature on page load, calling `setUpLinkToSelection()` for the button and `markDirective()` for the fallback.

- **`AGENTS.md`** — Documents the new feature and its test coverage.

## Implementation Details

The feature requires no changes to documentation pages themselves — no ids, no markup, no line numbers. Text fragments are a URL property, not a document property. The directive format follows the browser standard: `text=[prefix-,]textStart[,textEnd][,-suffix]`.

Short selections (≤12 words) are quoted exactly; longer selections use their first and last 5 words. Selections crossing lines always use start/end form. When a phrase appears multiple times on the page, context words are added as prefix/suffix to disambiguate. Hyphens and special characters are properly escaped since `-` marks prefix/suffix boundaries in the directive syntax.

Browsers supporting text fragments (with `document.fragmentDirective`) highlight the words themselves. Older browsers get a fallback that finds the deepest element containing the words, scrolls it into view, and marks it with a highlight class for 4 seconds.

https://claude.ai/code/session_011NvguZ4JHinUZKoVHe999H