### PR TITLE
The restore holds the position, and the search invites you to look around

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,9 +233,14 @@ pages with no router in front of them.
 | where **on** the page you were | `theme/site-memory.js` again, keys `:scroll` (a small map of path → offset, the twelve most recent) and `:returning`. Restored **on arrival by the bar and nowhere else**: a bar item writes one record saying where it is sending the reader, and the page that *is* that, arriving within half a minute and with no hash of its own, honours it. Restoring on every load would fight the browser's own back-and-forward restoration and would drop a reader who followed an ordinary link into the middle of a page with nothing to explain it. A stored offset is checked the same way a stored path is — `scrollTo` takes whatever it is given. `test/scroll-memory.test.mjs` |
 | the last thing you searched for | `theme/search-engine.js`, key `:search`. A hit opens another page, often another deployment, and the box that opens there was empty; the query is written down as a hit is opened and the next box starts with it, selected, so the first keystroke replaces it. Checked (a string, short, and less than half an hour old) rather than used. `test/search.test.mjs` |
 
-The playground is consulted by both and remembered by neither: its URL carries
-the code in the editor, so an item that reopened yesterday's sample would be a
-different promise from the one the word makes.
+**The playground is remembered too** (`:last-playground`), and it did not use
+to be. The argument against was that its URL carries the code in the editor
+rather than a place. What that missed is the case it creates: a reader with a
+SAMPLE open over there has code that is not a draft, and a sample that was
+picked and read is deliberately not stored, so pressing Documentation and then
+Playground threw it away. The URL is what carries it, so the URL is what comes
+back. This site only READS that key; the playground writes it, and never from
+an embedded or app-only view.
 
 **What a browser test in this repository cannot reach.** `vitepress preview`
 serves this site on localhost while the catalogue link points at

--- a/docs/.vitepress/theme/SearchBox.vue
+++ b/docs/.vitepress/theme/SearchBox.vue
@@ -67,8 +67,33 @@ function hide() {
   active.value = 0;
 }
 
-const hits = computed(() => (entries.value.length ? search(entries.value, query.value) : []));
+/* A high limit, and the grouping does the capping. `search` slices to thirty
+ * by default, and a group's count would then be "eight of twenty-nine" for a
+ * word with two hundred and thirty-one answers - a number that is worse than
+ * no number. Scoring is over ~940 short entries; the cost of asking for all of
+ * them is not measurable. */
+const hits = computed(() => (entries.value.length ? search(entries.value, query.value, { limit: 500 }) : []));
 const groups = computed(() => grouped(hits.value));
+
+/* What is in the box, in the two numbers a reader recognises. Only once the
+ * index has arrived - before that the box says what it is, not how much. */
+const counts = computed(() => {
+  if (!entries.value.length) return null;
+  let docs = 0;
+  for (const e of entries.value) if (e.area === 'docs') docs++;
+  return { docs, samples: entries.value.length - docs };
+});
+
+/* SOMETHING TO PRESS WHEN YOU DO NOT KNOW WHAT TO ASK. An empty search box is
+ * a question put to somebody who came to browse, and these are the answers
+ * worth having: eight words that each open a shelf rather than a page. They
+ * are checked against the real index - the smallest of them, `chart`, returns
+ * sixteen hits across three of the four areas. */
+const SUGGESTIONS = ['table', 'dialog', 'value help', 'upload', 'chart', 'navigation', 'binding', 'launchpad'];
+function suggest(word) {
+  query.value = word;
+  input.value?.focus();
+}
 /* The rows in the order the arrow keys walk them, which is the order they are
  * drawn in - grouped, not scored. */
 const rows = computed(() => groups.value.flatMap((g) => g.hits));
@@ -167,16 +192,43 @@ const parts = (text) => highlight(text, query.value);
             <a href="https://abap2ui5.github.io/playground/samples/" target="_self">sample catalogue</a>
             are both browsable without it.
           </p>
-          <p v-else-if="!query" class="a2ui5-search-note">
-            Every page of the documentation and every sample in the three catalogues.
-            <kbd>↑</kbd><kbd>↓</kbd> to move, <kbd>↵</kbd> to open.
-          </p>
+          <div v-else-if="!query" class="a2ui5-search-empty">
+            <p class="a2ui5-search-note">
+              <template v-if="counts">
+                <strong>{{ counts.docs }}</strong> pages of the manual and
+                <strong>{{ counts.samples }}</strong> working samples, in one box —
+                search by control, by class name, or by what you are trying to do.
+              </template>
+              <template v-else>
+                Every page of the documentation and every sample in the three catalogues.
+              </template>
+            </p>
+            <div class="a2ui5-search-try">
+              <span class="a2ui5-search-try-head">Have a look at</span>
+              <button
+                v-for="word in SUGGESTIONS"
+                :key="word"
+                class="a2ui5-search-chip"
+                type="button"
+                @click="suggest(word)"
+              >{{ word }}</button>
+            </div>
+          </div>
           <p v-else-if="!rows.length" class="a2ui5-search-note">
             Nothing matches <strong>{{ query }}</strong>.
           </p>
 
           <div v-for="group in groups" :key="group.label" class="a2ui5-search-group">
-            <div class="a2ui5-search-group-head">{{ group.label }}</div>
+            <div class="a2ui5-search-group-head">
+              {{ group.label }}
+              <!-- Eight of two hundred and thirty-one is a different answer
+                   from eight, and the difference is whether there is more to
+                   look at. -->
+              <span v-if="group.total > group.hits.length" class="a2ui5-search-count">
+                &nbsp;{{ group.hits.length }} of {{ group.total }}
+              </span>
+              <span v-else class="a2ui5-search-count">&nbsp;{{ group.total }}</span>
+            </div>
             <a
               v-for="hit in group.hits"
               :key="hit.entry.url"
@@ -199,6 +251,19 @@ const parts = (text) => highlight(text, query.value);
               </span>
             </a>
           </div>
+        </div>
+
+        <!-- THE KEYS, ALWAYS. They used to be in the line the empty state
+             showed, which is the one moment a reader is not using them: the
+             first keystroke replaced that line with results and took the only
+             mention of the arrows and Enter with it. And the shortcut that
+             opens the box was printed on the button and nowhere inside, so
+             once you were in you were told nothing at all. -->
+        <div class="a2ui5-search-keys">
+          <span><kbd>↑</kbd><kbd>↓</kbd> to move</span>
+          <span><kbd>↵</kbd> to open</span>
+          <span><kbd>esc</kbd> to close</span>
+          <span class="a2ui5-search-keys-end"><kbd>/</kbd> or <kbd>⌘</kbd><kbd>K</kbd> from anywhere</span>
         </div>
       </div>
     </div>

--- a/docs/.vitepress/theme/SiteNav.vue
+++ b/docs/.vitepress/theme/SiteNav.vue
@@ -74,9 +74,10 @@ const lift = () => {
  * at the top of it (site-memory.js). It is written after the lift, so it names
  * the href that is actually followed and not the one in the markup.
  *
- * The Playground item writes none: its URL carries the code in the editor, so
- * there is no position of it to come back to - the same reason it is consulted
- * by the memory and remembered by neither.
+ * The Playground item does this too now. It used to write nothing, on the
+ * grounds that its URL carries the code in the editor rather than a place -
+ * but that URL is exactly what a reader with a SAMPLE open over there loses by
+ * pressing Documentation and then Playground, and site-memory.js says the rest.
  */
 const leave = (e) => {
   const el = e.currentTarget;
@@ -114,6 +115,6 @@ onMounted(() => {
     <a :href="HOME" :class="{ here: onHome }" :aria-current="onHome ? 'page' : undefined" title="abap2UI5 in one page" @click="leave"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><path d="M3.6 10.9 12 4.2l8.4 6.7v8.3a1 1 0 0 1-1 1h-4.3v-6.1H8.9v6.1H4.6a1 1 0 0 1-1-1z"/></svg><span data-text="Home">Home</span></a>
     <a :href="docsHref" data-site="docs" :class="{ here: !onHome }" :aria-current="!onHome ? 'page' : undefined" title="The manual, where you left it" @click="leave"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><path d="M12 7.2C10.5 5.9 8.5 5.2 6 5.2H3.3v11.9H6c2.5 0 4.5.7 6 1.9 1.5-1.2 3.5-1.9 6-1.9h2.7V5.2H18c-2.5 0-4.5.7-6 1.9z"/><path d="M12 7.2v11.8"/></svg><span data-text="Documentation">Documentation</span></a>
     <a :href="samplesHref" :target="SAME_TAB" data-site="samples" title="Every abap2UI5 sample, searchable" @click="leave"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><rect x="3.2" y="4.8" width="17.6" height="14.4" rx="2"/><path d="M3.2 9.4h17.6M8.5 9.4v9.8"/></svg><span data-text="Samples">Samples</span></a>
-    <a :href="PLAYGROUND" :target="SAME_TAB" title="Write ABAP and run it in the browser"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><circle cx="12" cy="12" r="8.6"/><path d="M10.2 8.4v7.2a.5.5 0 0 0 .76.43l5.8-3.6a.5.5 0 0 0 0-.86l-5.8-3.6a.5.5 0 0 0-.76.43z" fill="currentColor" stroke="none"/></svg><span data-text="Playground">Playground</span></a>
+    <a :href="playgroundHref" data-site="playground" :target="SAME_TAB" title="Write ABAP and run it in the browser" @click="leave"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><circle cx="12" cy="12" r="8.6"/><path d="M10.2 8.4v7.2a.5.5 0 0 0 .76.43l5.8-3.6a.5.5 0 0 0 0-.86l-5.8-3.6a.5.5 0 0 0-.76.43z" fill="currentColor" stroke="none"/></svg><span data-text="Playground">Playground</span></a>
   </nav>
 </template>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -5,7 +5,7 @@ import './style.css'
 import { setUpPlayground } from './playground.js'
 import TheBar from './TheBar.vue'
 import SiteNav from './SiteNav.vue'
-import { rememberHere, rememberScroll, takeHandoff } from './site-memory.js'
+import { rememberHere, rememberScroll, restoreScroll } from './site-memory.js'
 
 /** @type {import('vitepress').Theme} */
 export default {
@@ -64,24 +64,12 @@ export default {
       pending = setTimeout(() => { pending = 0; rememberScroll() }, 300)
     }
 
-    // ...and back to it, but ONLY when the bar said so (site-memory.js). The
-    // router draws the new page and scrolls it to the top itself, not always
-    // in the same frame, so the offset is re-applied for a few frames until
-    // it holds. About a tenth of a second, and it stops the moment it works.
-    const restore = () => {
-      const y = takeHandoff()
-      if (y === null) return
-      let tries = 0
-      const put = () => {
-        scrollTo(0, y)
-        if (++tries < 6 && Math.abs(scrollY - y) > 2) requestAnimationFrame(put)
-      }
-      requestAnimationFrame(put)
-    }
-
+    // ...and back to it, but ONLY when the bar said so. site-memory.js decides
+    // whether this arrival is the one the bar named, and holds the offset
+    // against the router's own scroll-to-top and a page that is still growing.
     if (!import.meta.env.SSR) {
       rememberUnlessHome()
-      restore()
+      restoreScroll()
       addEventListener('scroll', noteScroll, { passive: true })
       addEventListener('pagehide', () => rememberScroll())
       const onAfter = router.onAfterRouteChange
@@ -89,7 +77,7 @@ export default {
         rememberUnlessHome()
         // Home -> Documentation is a route change, not a load: this site is
         // one application and two of the bar's four items are pages of it.
-        restore()
+        restoreScroll()
         onAfter?.(to)
       }
     }

--- a/docs/.vitepress/theme/search-engine.js
+++ b/docs/.vitepress/theme/search-engine.js
@@ -109,12 +109,18 @@ export function search(entries, query, { limit = 30 } = {}) {
  * first, then each sample corpus — with at most `perGroup` in each, so one
  * corpus of 636 ports cannot bury the four pages that explain them.
  */
-export function grouped(hits, { perGroup = 6 } = {}) {
+export function grouped(hits, { perGroup = 8 } = {}) {
   const order = [];
   const byGroup = new Map();
+  /* How many a group HAS, beside how many it shows. A reader who typed
+   * "table" and sees eight is looking at eight of two hundred and thirty-one,
+   * and the difference between those two numbers is the difference between
+   * "that is all there is" and "there is a whole shelf of this". */
+  const total = new Map();
   for (const hit of hits) {
     const key = hit.entry.area === 'docs' ? 'Documentation' : hit.entry.group;
     if (!byGroup.has(key)) { byGroup.set(key, []); order.push(key); }
+    total.set(key, (total.get(key) ?? 0) + 1);
     const rows = byGroup.get(key);
     if (rows.length < perGroup) rows.push(hit);
   }
@@ -122,7 +128,7 @@ export function grouped(hits, { perGroup = 6 } = {}) {
    * typed a word that is both a chapter and a control wants the explanation
    * before the seven hundred examples of it. */
   order.sort((a, b) => (a === 'Documentation' ? -1 : b === 'Documentation' ? 1 : 0));
-  return order.map((label) => ({ label, hits: byGroup.get(label) }));
+  return order.map((label) => ({ label, hits: byGroup.get(label), total: total.get(label) }));
 }
 
 /** The index, fetched once. Callers await this on the first keystroke, never

--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -212,3 +212,67 @@ export function takeHandoff() {
   const y = scrollOf(record.to);
   return y > 0 ? y : null;
 }
+
+/**
+ * Take the handoff and act on it: scroll to the offset, and keep scrolling to
+ * it until it takes.
+ *
+ * One `scrollTo` is not enough. The router draws the new page and scrolls it
+ * to the top itself, not always in the same frame, and a page whose content is
+ * still arriving is a page too short to reach the offset - which the browser
+ * clamps to the top, the exact thing this is here to stop. So it is re-applied
+ * as the page settles, for up to three seconds.
+ *
+ * It stops the moment the offset takes, and the moment the READER scrolls:
+ * a scroll that was not this one is the reader saying where they want to be,
+ * and it wins. Without that a page shorter than the stored offset would hold
+ * them at the bottom of it.
+ */
+export function restoreScroll() {
+  const y = takeHandoff();
+  if (y === null) return;
+
+  /* WHAT CANCELS THIS IS THE READER, AND NOTHING ELSE.
+   *
+   * It used to stop as soon as `scrollY` was not where the last frame put it,
+   * on the theory that a scroll this did not cause is the reader taking over.
+   * It is not: a page still loading moves its own scroll. The browser's scroll
+   * anchoring shifts the offset to keep the content under your eyes steady as
+   * things arrive above it - and the home page, whose hero image is the
+   * largest thing on the site to arrive late, is where that happens every
+   * time. The offset was applied to a page still a few hundred pixels short,
+   * anchoring nudged it, this read the nudge as a reader and gave up. It went
+   * "a little way down" and stopped, on that page and no other.
+   *
+   * So the reader is asked directly. A wheel, a touch, a key, a pointer:
+   * those are somebody saying where they want to be, and they win. Layout
+   * settling is not one of them. */
+  const until = Date.now() + 2000;
+  const MOVED = ['wheel', 'touchstart', 'keydown', 'pointerdown'];
+  let stopped = false;
+  const stop = () => {
+    stopped = true;
+    for (const e of MOVED) removeEventListener(e, stop, true);
+  };
+  for (const e of MOVED) addEventListener(e, stop, { capture: true, passive: true });
+
+  /* IT HOLDS THE POSITION, it does not merely reach it. Reaching it once is
+   * not enough and stopping there is how this failed: the router draws the
+   * page and scrolls it to the top ITSELF, after this - measured, in that
+   * order, `scrollTo(0, 1600)` and then `scrollTo(0, 0)` - so the offset was
+   * applied, taken away again a frame later, and the loop had already
+   * congratulated itself and gone. Two seconds of holding covers that, and a
+   * page still growing underneath, and costs about a hundred and twenty
+   * frames of one assignment each.
+   *
+   * Holding is only safe BECAUSE the reader can take it back: the four events
+   * above end it on the first wheel, key, touch or pointer - a scrollbar drag
+   * included - so nothing is ever fought with. */
+  const put = () => {
+    if (stopped) return;
+    if (Math.round(scrollY) !== y) scrollTo(0, y);
+    if (Date.now() < until) requestAnimationFrame(put);
+    else stop();
+  };
+  requestAnimationFrame(put);
+}

--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -22,10 +22,19 @@
 // it is what every step below falls back to - nothing here ever returns a link
 // worse than the one it was given.
 //
-// THE PLAYGROUND IS NOT REMEMBERED, only consulted. Its URL carries the code
-// in the editor (?src=...), and a Playground item that reopened yesterday's
-// sample instead of an empty editor would be a different promise from the one
-// the word makes. Samples and docs are places; the playground is a workbench.
+// THE PLAYGROUND IS REMEMBERED TOO, and it did not used to be. The reasoning
+// against it was that its URL carries the code in the editor, so an item that
+// reopened yesterday's sample would be a different promise from the one the
+// word makes: samples and docs are places, the playground is a workbench.
+//
+// What that argument missed is the case it creates. A reader who opens a
+// SAMPLE over there has code that is not a draft - a sample that was picked
+// and read is deliberately not stored - so pressing Documentation and then
+// Playground threw it away and started them on the default sample. Their own
+// edits survived that trip; the sample they were reading did not.
+//
+// This site only ever READS that key. The playground writes it, and never
+// from an embedded or app-only view.
 
 /* The playground's namespace, for keys this site writes too. It is the wrong
  * word for a value shared by three deployments and it is the namespace every
@@ -35,6 +44,7 @@
 const KEY = {
   samples: "abap2ui5-playground:last-samples",
   docs: "abap2ui5-playground:last-docs",
+  playground: "abap2ui5-playground:last-playground",
 };
 
 /** Write down that the reader is on this site's page. */

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1868,7 +1868,9 @@
   z-index: 200;
   display: flex;
   justify-content: center;
-  padding: 12vh 16px 16px;
+  /* Higher up and roomier than it was: this is a place to browse ~940 entries
+     in, and 12vh of dimmed page above it was margin nobody reads. */
+  padding: 8vh 16px 16px;
   background: rgba(0, 0, 0, 0.45);
   backdrop-filter: blur(2px);
 }
@@ -1876,8 +1878,11 @@
 .a2ui5-search-panel {
   display: flex;
   flex-direction: column;
-  width: min(680px, 100%);
-  max-height: 76vh;
+  /* 820, not 680. A sample's row is a title, a class name and a sentence, and
+     at 680 the sentence wrapped to two lines on most of them - a list of
+     two-line rows reads as a wall rather than as something to run an eye down. */
+  width: min(820px, 100%);
+  max-height: 82vh;
   border: 1px solid var(--line);
   border-radius: var(--radius-surface);
   background: var(--bg);
@@ -2054,6 +2059,114 @@
 .Layout button:focus-visible,
 .Layout summary:focus-visible,
 .Layout input:focus-visible,
+/* ---- the empty state, which is the invitation ----
+ *
+ * A box that opens on one grey line is a question asked of somebody who came
+ * to look around. So it says what is in it, in the two numbers that mean
+ * something, and then offers eight words to press. They are not decoration:
+ * each one opens a shelf (the smallest, `chart`, returns sixteen hits across
+ * three areas), and pressing one fills the field, so the next thing the reader
+ * does is edit a real query rather than compose one from nothing. */
+.a2ui5-search-empty {
+  padding: 10px 6px 18px;
+}
+
+.a2ui5-search-empty .a2ui5-search-note {
+  padding-bottom: 6px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.a2ui5-search-empty strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.a2ui5-search-try {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px 0;
+}
+
+.a2ui5-search-try-head {
+  margin-right: 2px;
+  color: var(--fg-dim);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.a2ui5-search-chip {
+  padding: 5px 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--bg-sunken);
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.a2ui5-search-chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* How many the group has, beside how many it is showing. */
+.a2ui5-search-count {
+  margin-left: 6px;
+  color: var(--fg-dim);
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* ---- the keys, on screen the whole time ----
+ *
+ * They used to be one line in the empty state - gone the moment anybody typed,
+ * which is the moment they start mattering - and the shortcut that opens the
+ * box was printed on the button and nowhere inside it. */
+.a2ui5-search-keys {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 16px;
+  padding: 9px 14px;
+  border-top: 1px solid var(--line);
+  background: var(--bg-sunken);
+  color: var(--fg-dim);
+  font-size: 12px;
+}
+
+.a2ui5-search-keys-end {
+  margin-left: auto;
+}
+
+.a2ui5-search-keys kbd {
+  display: inline-block;
+  min-width: 17px;
+  margin-right: 3px;
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg-dim);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+@media (max-width: 620px) {
+  /* On a phone the row keeps the three keys that work there and drops the one
+     that names a keyboard shortcut for opening it. */
+  .a2ui5-search-keys-end { display: none; }
+}
+
 .a2ui5-search-scrim a:focus-visible,
 .a2ui5-search-scrim button:focus-visible,
 .a2ui5-search-scrim input:focus-visible {

--- a/test/search.test.mjs
+++ b/test/search.test.mjs
@@ -170,9 +170,15 @@ test('one corpus cannot bury the others', () => {
     area: 'samples', group: 'Controls', title: `List ${i}`, text: '', code: `z2ui5_cl_smpc_app_${i}`, terms: 'list', url: `/x/${i}/`,
   }));
   many.push({ area: 'docs', group: 'Cookbook', title: 'Lists', text: '', headings: [], terms: 'list', url: '/docs/list.html' });
-  const groups = grouped(search(many, 'list'));
+  const groups = grouped(search(many, 'list', { limit: 500 }));
   assert.equal(groups[0].label, 'Documentation');
-  assert.ok(groups[1].hits.length <= 6);
+  assert.ok(groups[1].hits.length <= 8);
+  /* And it SAYS how many it is holding back, which is the difference between
+   * "that is all there is" and "there is a shelf of this". The count is of the
+   * hits it was GIVEN - which is why the box asks search( ) for a high limit
+   * and lets this do the capping, rather than counting a slice of thirty. */
+  assert.equal(groups[1].total, 40);
+  assert.equal(groups[0].total, 1);
 });
 
 test('an empty query is not a search for everything', () => {

--- a/test/site-memory.test.mjs
+++ b/test/site-memory.test.mjs
@@ -128,3 +128,53 @@ test('a scope wider than the link is what restores a section from a deep href', 
   /* And the scope is a fence, not a door: outside it, the written link stands. */
   assert.equal(on(SITE, '/docs/cookbook/view/definition.html', () => lastVisited('samples', deep, SAMPLES)), deep);
 });
+
+/* ── THE PLAYGROUND IS A PLACE AFTER ALL ────────────────────────────────────
+ *
+ * It used to be consulted and never remembered: its URL carries the code in
+ * the editor, so an item that reopened yesterday's sample was held to be a
+ * different promise from the one the word makes. What that missed is the case
+ * it creates — a reader with a SAMPLE open over there has code that is not a
+ * draft, and is not stored as one, so this round trip threw it away. The URL
+ * is what carries it, so the URL is what comes back.
+ */
+const PLAYGROUND = 'https://abap2ui5.github.io/playground/';
+const PLAYGROUND_KEY = 'abap2ui5-playground:last-playground';
+
+/** The same stub as above, on the playground's key. */
+function withPlayground(stored, run) {
+  const before = { location: globalThis.location, localStorage: globalThis.localStorage };
+  globalThis.location = { href: SITE + '/docs/get_started/about.html', origin: SITE };
+  globalThis.localStorage = {
+    getItem: (k) => (k === PLAYGROUND_KEY && stored !== undefined ? stored : null),
+    setItem: () => {},
+  };
+  try {
+    return run();
+  } finally {
+    globalThis.location = before.location;
+    globalThis.localStorage = before.localStorage;
+  }
+}
+
+test('the playground comes back to the sample that was open in it', () => {
+  const last = '/playground/?src=https%3A%2F%2Fraw.githubusercontent.com%2Fx%2Fy.clas.abap';
+  assert.equal(withPlayground(last, () => lastVisited('playground', PLAYGROUND)), last);
+});
+
+test('a shared link keeps the code it carries in its fragment', () => {
+  const last = '/playground/#code=AAAA';
+  assert.equal(withPlayground(last, () => lastVisited('playground', PLAYGROUND)), last);
+});
+
+test('nothing stored opens the empty editor, as the markup says', () => {
+  assert.equal(withPlayground(undefined, () => lastVisited('playground', PLAYGROUND)), PLAYGROUND);
+});
+
+test("a stored value outside the playground is not the playground", () => {
+  /* The same check every other item gets: resolved against this origin and
+   * kept only if it is still inside the link the markup carries. */
+  for (const junk of ['https://elsewhere.example/x', '/docs/cookbook/tables', '/playground/../docs/x', 'javascript:alert(1)']) {
+    assert.equal(withPlayground(junk, () => lastVisited('playground', PLAYGROUND)), PLAYGROUND, junk);
+  }
+});


### PR DESCRIPTION
Two reports from the site, and the second one turned into a rebuild of the search panel.

## The home page was the one that did not come back

Two mistakes, and each on its own was enough.

It stopped as soon as `scrollY` was not where the last frame put it, on the theory that a scroll it did not cause is the reader taking over. It is not: a page still loading moves its own scroll, and the home page — whose hero image is the largest thing on the site to arrive late — is where that happens every time. The reader is asked directly now: a wheel, a touch, a key, a pointer. Layout settling is not one of those.

And it stopped as soon as it *reached* the offset, which is worse. Measured on the home page, in this order: `scrollTo(0, 1600)` from the restore, then `scrollTo(0, 0)` from the router drawing the page. It won the frame and lost the page. It **holds** the position for two seconds now — measured at 1600 across the whole window, and giving way to 1100 on the reader's first wheel, which is the whole reason holding is safe.

## The search is something to browse in

**The keys are on screen the whole time.** They used to be one line of the empty state — gone the moment anybody typed, which is the moment they start mattering — and the shortcut that *opens* the box was printed on the button outside and nowhere inside it. A row under the results now says all four: `↑↓` move, `↵` open, `esc` close, `/` or `⌘K` from anywhere.

**The empty state says what is in the box and offers a way in.** 165 pages of the manual and 772 working samples, and eight words to press. They are not decoration: each opens a shelf, checked against the real index — the smallest, `chart`, returns sixteen hits across three of the four areas — and pressing one fills the field, so the next thing the reader does is edit a real query rather than compose one from nothing.

**Every group says how many it has beside how many it shows.** Eight of two hundred and thirty-one is a different answer from eight, and the difference is whether there is more to look at. For that count to be a real count the box asks `search` for 500 rather than the default 30 and lets the grouping cap at eight a group — otherwise "eight of twenty-nine" for a word with 231 answers, which is a number worse than no number.

**And it is bigger**: 820px wide rather than 680, 8vh from the top rather than 12. A sample's row is a title, a class name and a sentence, and at 680 the sentence wrapped on most of them — a list of two-line rows reads as a wall rather than as something to run an eye down.

## Checked

`npm run check`: all eleven gates, 99 unit tests. The restore was measured against a `vitepress preview` of this build, on the home page it was failing on.

The other three bars are in the matching abap2UI5/playground pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_