### PR TITLE
The arrow keys bring the list with them, the shortcut is the one you have, and the listing squares up with the text

### DIFF
--- a/docs/.vitepress/theme/SearchBox.vue
+++ b/docs/.vitepress/theme/SearchBox.vue
@@ -90,6 +90,14 @@ const counts = computed(() => {
  * are checked against the real index - the smallest of them, `chart`, returns
  * sixteen hits across three of the four areas. */
 const SUGGESTIONS = ['table', 'dialog', 'value help', 'upload', 'chart', 'navigation', 'binding', 'launchpad'];
+
+/* ⌘ on an Apple keyboard and Ctrl on every other one. The key row said ⌘K to
+ * everybody, which is not a shorter way of writing Ctrl - it is an instruction
+ * that does not work, given to the readers who are not on a Mac. The handler
+ * has always taken either (`metaKey || ctrlKey`); only the label was wrong. */
+const APPLE = typeof navigator !== 'undefined'
+  && /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || '');
+const META = APPLE ? '⌘' : 'Ctrl';
 function suggest(word) {
   query.value = word;
   input.value?.focus();
@@ -130,6 +138,27 @@ function go(hit) {
   location.assign(href);
 }
 
+/**
+ * The arrow keys move the mark AND bring the row into view.
+ *
+ * They moved the mark alone, and the list did not follow: eight rows a group
+ * over four groups is more than a panel holds, so walking down with the
+ * keyboard marked rows nobody could see and the reader was pressing Enter on
+ * something off the bottom of the box.
+ *
+ * `block: 'nearest'` rather than a centring scroll: it moves the list by the
+ * one row that is needed and leaves it alone while the mark is already on
+ * screen, which is what makes a long walk down read as a list scrolling rather
+ * than as a list jumping. Only from HERE - the mouse sets `active` too, and a
+ * list that scrolled under the pointer would move the row out from under it.
+ */
+function move(step) {
+  active.value = Math.min(Math.max(active.value + step, 0), rows.value.length - 1);
+  nextTick(() => {
+    document.querySelector('.a2ui5-search-hit.active')?.scrollIntoView({ block: 'nearest' });
+  });
+}
+
 function onKey(e) {
   if (!open.value) {
     /* Two ways in, both what a reader of technical documentation already has
@@ -141,8 +170,8 @@ function onKey(e) {
     return;
   }
   if (e.key === 'Escape') { e.preventDefault(); hide(); return; }
-  if (e.key === 'ArrowDown') { e.preventDefault(); active.value = Math.min(active.value + 1, rows.value.length - 1); }
-  else if (e.key === 'ArrowUp') { e.preventDefault(); active.value = Math.max(active.value - 1, 0); }
+  if (e.key === 'ArrowDown') { e.preventDefault(); move(1); }
+  else if (e.key === 'ArrowUp') { e.preventDefault(); move(-1); }
   else if (e.key === 'Enter') { e.preventDefault(); go(rows.value[active.value]); }
 }
 
@@ -263,7 +292,7 @@ const parts = (text) => highlight(text, query.value);
           <span><kbd>↑</kbd><kbd>↓</kbd> to move</span>
           <span><kbd>↵</kbd> to open</span>
           <span><kbd>esc</kbd> to close</span>
-          <span class="a2ui5-search-keys-end"><kbd>/</kbd> or <kbd>⌘</kbd><kbd>K</kbd> from anywhere</span>
+          <span class="a2ui5-search-keys-end"><kbd>/</kbd> or <kbd>{{ META }}</kbd><kbd>K</kbd> from anywhere</span>
         </div>
       </div>
     </div>

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -486,8 +486,16 @@
  */
 @media (min-width: 1440px) {
   .Layout .VPDoc.has-aside .vp-doc div[class*='language-'] {
-    margin-left: -56px;
-    margin-right: -56px;
+    /* ALL OF IT ON THE RIGHT. It was 56px each side, which centred the box on
+       the column and put its left edge 56px outside the paragraph above it -
+       two left edges down a page that has one column of text, and the tab
+       strip of a `code-group` sitting inboard of the block it belongs to.
+       A listing reads down its left edge, and that edge is the text's.
+       78 rather than 112: the room on the right is what there is between the
+       column and the outline - 94px measured at 1440 - less a cushion, and
+       the left side is no longer there to borrow from. */
+    margin-left: 0;
+    margin-right: -78px;
   }
 }
 


### PR DESCRIPTION
Four reports, all measured in a rendered browser.

## The arrow keys moved the mark and the list did not follow

Eight rows a group over four groups is more than the panel holds, so walking down with the keyboard marked rows nobody could see — and the reader was pressing Enter on something off the bottom of the box.

`block: "nearest"`, so the list moves by the one row that is needed and stays still while the mark is already on screen. Only from the arrow keys: the mouse sets the mark too, and a list that scrolled under the pointer would take the row out from under it.

## The key row named a shortcut half the readers do not have

It said the Apple modifier to everybody. The handler has always taken either (`metaKey || ctrlKey`) — only the label was wrong, and a label naming a key that does nothing is worse than no label. `Ctrl` on everything that is not an Apple keyboard now.

## The listing squares up with the text

It was 56px out on each side, which centred it on the column and put its left edge outside the paragraph above it — two left edges down a page with one column of text, and a `code-group`'s tab strip sitting inboard of the block it belongs to.

All of it goes on the right now: 78px, the room there is between the column and the outline (94px measured at 1440) less a cushion. Left edges line up at 1280, 1440, 1600 and 1920, and nothing overlaps the outline.

## The two page shapes start at one height

A manual page began its title 94px under the bar and its outline at 94; a sample page began its crumb line at 68 and its outline at 104 — two pages a reader steps between, starting in three different places. All 94 now. The sample pages moved to meet this site's number rather than the other way round: raising a heading to 22px under a sticky bar is not air, it is a collision waiting for a scroll.

## Also answered, with a measurement rather than a guess

*Is the home page in a different font?* No — every page resolves the same family (`system-ui, -apple-system, …`). What differs is the size: 17px on the home page against 14 on a manual page and 15 on a sample's lede, which is VitePress's home layout and deliberate.

## Checked

`npm run check`: all eleven gates, 115 unit tests.

The matching half — the same two search fixes, the page height and the hairline down the outline — is in the abap2UI5/playground pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_