### PR TITLE
Every page of the manual says where in the manual it is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `docs/.vitepress/theme/SiteNav.vue` | The four sections, in the bar and again in the phone screen the theme's hamburger opens. Every item that leaves this deployment carries a `target` (`check:cross-site`), and three of the four are lifted to where the reader last was (`site-memory.js`) |
 | `docs/.vitepress/theme/SiteMenu.vue` | The menu behind the bar's last button: the light/dark switch, the project's tools and its repositories, and the version number `check:version` reads (`VERSION`) |
 | `docs/.vitepress/theme/code-lines.js` | A number beside every line of every listing, and an address for it: `#B2L42` is line 42 of the second listing on a page, `#B2L42-L58` a passage of it. The block is part of the address because a page of this manual is a dozen listings and `#L42` would name a line in each; the catalogue's pages print one class, which is why theirs are `#L42`. The number is a CSS counter drawn from an empty link, so the block still copies as a file you can paste |
+| `docs/.vitepress/theme/Crumbs.vue` | The trail above the title on every page of the manual — "Documentation › Cookbook › Model". Rendered into the default theme's `doc-before` slot, so it is the doc column's first line and lands where the sample catalogue's own crumb line lands, to the pixel. `theme/crumbs.js` is the half with no Vue in it: it walks `themeConfig.sidebar` against the page, so the trail cannot drift from the navigation the way the bar's old Guide dropdown did. Pinned by `test/crumbs.test.mjs`, which walks the real sidebar |
 | `docs/.vitepress/theme/SearchBox.vue` | The box in the middle of the bar and what it opens. `theme/search-engine.js` is the matching, framework-free because the other three bars carry a copy of it; both are pinned by `test/search.test.mjs` |
 | `scripts/check-design.mjs` | The palette, the type and the radii the four bars share, against `abap2UI5/playground`'s copy of them — needs a checkout (`PLAYGROUND_HOME`, `.playground`, `../playground`) or the network, and fails rather than passing without one. The table of what is shared, and both spellings of each value, is `scripts/lib/design.mjs` |
 | `scripts/check-cross-site.mjs` | Every link out of this deployment and into a neighbouring one on the same origin carries a `target`, or VitePress's router swallows it and shows this site's 404 at the other site's URL. Reads the BUILT html, so it runs after `docs:build`; the rule and the reasoning are in `scripts/lib/cross-site.mjs` |
@@ -49,7 +50,7 @@ it are decidable, and all eleven are decided before a merge:
 
 | | |
 |---|---|
-| `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate; the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow; and the text fragment behind *Copy link to selection* — what it quotes, and how it escapes it |
+| `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate; the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow; the text fragment behind *Copy link to selection* — what it quotes, and how it escapes it; and the crumb trail above every title, walked against the real sidebar so a restructured section cannot leave the trail passing against a fiction |
 | `check:version` | the release number in the bar's menu (`VERSION` in `theme/SiteMenu.vue` — it was a nav dropdown's label in `config.mjs` until the bar was rebuilt, and in `SiteBar.vue` until the bar was split), the deprecations page and the changelog, against the newest release tag of the framework — this one goes stale without anybody touching this repository |
 | `docs:build` | a page that does not build is a page nobody can read |
 | `check:examples` | the ABAP in the fenced blocks, against the real framework: does it compile, and does the view it builds name controls and properties that exist on the UI5 floor this documentation targets. **It ran no abaplint rules at all until 2026-09-04** — the generated config had no `rules` block, so abaplint walked 139 files, ran nothing, and printed `0 issue(s) found` for years. Ten examples with an unbalanced parenthesis were sitting behind that. The three compile rules it runs now (`parser_error`, `check_syntax`, `unknown_types`) are the sample repositories' own; the reasoning for stopping there, measured against the full 188-rule set, is in the file |
@@ -162,6 +163,19 @@ the bar's markup, which exists four times by hand for the same reason, and to
 the bar's **measure**: 20px from either edge at every width, 12px on a phone,
 over the whole width and never centred, which is the catalogue's bar and which
 `style.css` (*the measure*) holds the theme's two nav layouts to.
+
+**A page opens the same way on both documents.** 48px under the bar, a crumb
+trail, then the title — and on the right, level with the trail, *On this page*.
+The catalogue's per-sample pages had all of it and the manual had none of it,
+so the two started in three different places; `theme/Crumbs.vue` and *where in
+the manual* in `style.css` are this side of it, and the numbers there are
+`tools/sample-pages.mjs`'s, down to the 1.55 line-height that puts the heading
+underneath on the same pixel. Copied by hand like the palette and the bar, and
+for the same reason. What is NOT copied is the trail itself: the catalogue's
+comes from the row being rendered, and this one is walked out of
+`themeConfig.sidebar` (`theme/crumbs.js`), because a second list of the manual's
+sections is a second list to keep in step — the bar's old Guide dropdown was
+exactly that and it drifted twice.
 
 **The accent is SAP blue, and the mark is still red.** `#0a6ed1` / `#4aa3ff` is
 what a link, a button and the hero name are set in; `#d03c4a` is the circle in

--- a/docs/.vitepress/theme/Crumbs.vue
+++ b/docs/.vitepress/theme/Crumbs.vue
@@ -1,0 +1,49 @@
+<script setup>
+/*
+ * The line above the title that says where in the manual you are:
+ *
+ *     Documentation › Cookbook › Model
+ *
+ * The sample catalogue has had this on every one of its pages since they were
+ * generated (`.crumbs` in tools/sample-pages.mjs, abap2UI5/playground), and a
+ * reader crossing between the two documents met it on one side only. Same
+ * shape, same separator, same size, same place on the page — see *where in the
+ * manual* in style.css for the numbers and where they came from.
+ *
+ * The trail names the SECTIONS the page stands in and stops short of the page
+ * itself, because the page's own name is the heading directly underneath: a
+ * catalogue page reads "Sample catalogue › Learn › Basics" above an h1 that is
+ * the sample's title, and repeating it in the line above would say it twice.
+ *
+ * WHERE THE TRAIL COMES FROM. The sidebar in config.mjs, walked against the
+ * page being rendered — not a second list to keep in step with it. The bar
+ * used to carry a Guide dropdown that was exactly such a copy and it drifted
+ * twice; the comment above `nav: []` in config.mjs is that scar. Whatever the
+ * sidebar says a page's ancestors are is what this line says they are, and a
+ * section renamed there is renamed here in the same commit. The walk itself is
+ * `crumbs.js`, so that it can be tested.
+ */
+import { computed } from 'vue'
+import { useData, withBase } from 'vitepress'
+import { trailFor } from './crumbs.js'
+
+const { page, theme } = useData()
+
+/* `relativePath` rather than the route, because it is what the SERVER knows as
+ * well: the trail is then in the HTML a crawler and a first paint are given,
+ * and not something that appears a tick after hydration. */
+const trail = computed(() => trailFor(theme.value.sidebar, page.value.relativePath))
+</script>
+
+<template>
+  <!-- The separator is `aria-hidden`: a screen reader announcing "Documentation
+       single right pointing angle quotation mark Cookbook" is worse than one
+       announcing two links and a word. -->
+  <p class="a2ui5-crumbs">
+    <template v-for="(crumb, i) in trail" :key="i">
+      <span v-if="i" class="sep" aria-hidden="true">›</span>
+      <a v-if="crumb.link" :href="withBase(crumb.link)">{{ crumb.text }}</a>
+      <span v-else>{{ crumb.text }}</span>
+    </template>
+  </p>
+</template>

--- a/docs/.vitepress/theme/crumbs.js
+++ b/docs/.vitepress/theme/crumbs.js
@@ -1,0 +1,86 @@
+/*
+ * Where in the manual a page stands, worked out from the sidebar.
+ *
+ * The half with no Vue in it, for the same reason `text-fragment.js` and
+ * `search-engine.js` are: this is the part that can be WRONG in a way nobody
+ * sees — a trail that quietly loses a level, or gains one, on a page nobody
+ * opened this week. `Crumbs.vue` is the markup around it, and
+ * `test/crumbs.test.mjs` is what holds this file to the sidebar's actual
+ * shapes.
+ */
+
+/** The manual's first page — what the word Documentation opens on all four
+ *  bars of this project (`DOCS` in SiteNav.vue). The first crumb is always
+ *  this, including on a page the sidebar does not name. */
+export const DOCS = '/get_started/about'
+
+/** One spelling for a page, so a sidebar entry and the page being rendered can
+ *  be compared at all: no extension, no `index`, no trailing slash, and one
+ *  slash at the front. The sidebar writes `/tutorials/walkthrough/` and the
+ *  file is `tutorials/walkthrough/index.md`; both have to end as the same
+ *  string. The leading slash is COLLAPSED rather than assumed, because the
+ *  trail is built by putting one in front of a `relativePath` — and a value
+ *  that already carried one would otherwise match nothing, which reads as a
+ *  page the sidebar does not name rather than as the mistake it is. */
+export function key(path) {
+  return (
+    String(path || '')
+      .split(/[#?]/)[0]
+      .replace(/^\/+/, '/')
+      .replace(/\.(md|html)$/, '')
+      .replace(/(^|\/)index$/, '$1')
+      .replace(/\/+$/, '') || '/'
+  )
+}
+
+/* The DEEPEST entry that opens the page wins, and several do by design: a
+ * section's own `link` is its first chapter's, so /cookbook/view/definition is
+ * named by Cookbook, by View and by Definition. Taking the first match would
+ * file a page three levels down under "Documentation" alone; taking the
+ * longest gives it "Documentation › Cookbook › View".
+ *
+ * Returns the whole chain including the match; the caller drops its last
+ * element, because the page's own name is the heading directly underneath. */
+function deepest(items, path, above) {
+  let best = null
+  for (const item of items || []) {
+    const mine = [...above, item]
+    if (key(item.link) === path && (!best || mine.length > best.length)) best = mine
+    const deeper = deepest(item.items, path, mine)
+    if (deeper && (!best || deeper.length > best.length)) best = deeper
+  }
+  return best
+}
+
+/* A sidebar is an array here and has been since the manual had one sidebar for
+ * all of it; VitePress also allows an object keyed by path prefix, and if this
+ * repository ever grows a second sidebar the entries under the LONGEST
+ * matching prefix are the ones to walk. */
+function sectionsOf(sidebar, path) {
+  if (Array.isArray(sidebar)) return sidebar
+  if (!sidebar || typeof sidebar !== 'object') return []
+  const groups = Object.entries(sidebar)
+    .filter(([prefix]) => path.startsWith(key(prefix)))
+    .sort((a, b) => b[0].length - a[0].length)
+  return (groups[0] || Object.entries(sidebar)[0] || [, []])[1] || []
+}
+
+/**
+ * The trail for one page, outermost first: `[{ text, link }, …]`.
+ *
+ * `link` is absent on a crumb the sidebar gives nowhere to open — "Quickstart"
+ * and "Walkthrough" are labels over a list of steps, not pages — and such a
+ * crumb is drawn as plain text, which is what the catalogue does with its own
+ * last one.
+ *
+ * @param {unknown} sidebar `themeConfig.sidebar`, as an array or as an object
+ * @param {string} page the page's `relativePath`, e.g. `cookbook/model/trees.md`
+ */
+export function trailFor(sidebar, page) {
+  const path = key('/' + String(page || ''))
+  const found = deepest(sectionsOf(sidebar, path), path, []) || []
+  return [
+    { text: 'Documentation', link: DOCS },
+    ...found.slice(0, -1).map(({ text, link }) => (link ? { text, link } : { text })),
+  ]
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -7,6 +7,7 @@ import { setUpCodeLines, watchCodeLines } from './code-lines.js'
 import { markDirective, setUpLinkToSelection } from './link-to-selection.js'
 import TheBar from './TheBar.vue'
 import SiteNav from './SiteNav.vue'
+import Crumbs from './Crumbs.vue'
 import { rememberHere, rememberScroll, restoreScroll } from './site-memory.js'
 
 /** @type {import('vitepress').Theme} */
@@ -27,6 +28,12 @@ export default {
     return h(DefaultTheme.Layout, null, {
       'nav-bar-content-before': () => h(TheBar),
       'nav-screen-content-after': () => h(SiteNav),
+      // Where in the manual you are, above the title, on every page that has
+      // one (Crumbs.vue). `doc-before` is the slot immediately in front of the
+      // article inside the doc column, so the trail is the column's first line
+      // - which is where the catalogue's own is - and the home page, which is
+      // not laid out as a document, does not get one.
+      'doc-before': () => h(Crumbs),
     })
   },
 

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -809,6 +809,62 @@
   padding-bottom: 4px;
 }
 
+/* ------------------------------------------------ where in the manual ---
+ *
+ * The trail above the title — "Documentation › Cookbook › Model" — and the
+ * catalogue's `.crumbs` line written out for this theme (tools/sample-pages.mjs
+ * in abap2UI5/playground). The numbers are that file's: 12px, the dimmed
+ * foreground for the whole line including its links, and 6px down to the
+ * heading. Copied by hand for the same reason the palette and the search box
+ * are, and held to it the same way — see *One site in three places* in
+ * AGENTS.md.
+ *
+ * IT SITS WHERE THE TITLE USED TO. `.VPDoc` already opens 48px under the bar
+ * and the trail is the first thing in the column, so the line lands at exactly
+ * the height the catalogue's does and the outline beside it does not move: a
+ * reader stepping between a manual page and a sample page meets the same two
+ * lines in the same two places. `margin-top: 0` is the whole trick — the 48px
+ * is the theme's padding and adding anything here would push both documents
+ * out of step again.
+ *
+ * The separator is `aria-hidden`: a screen reader announcing "Documentation
+ * single right pointing angle quotation mark Cookbook" is worse than one
+ * announcing two links and a word. */
+.Layout .VPDoc .a2ui5-crumbs {
+  margin: 0 0 6px;
+  font-size: 12px;
+  /* 1.55, which is the catalogue's body line-height and therefore what its
+   * own crumb line inherits. Written out here because this theme's body is a
+   * different number: without it the line is 18px against the catalogue's
+   * 18.6 and the heading underneath starts a pixel higher than the same
+   * heading does over there. It is one pixel, and it is one pixel on the only
+   * two lines a reader sees before they see anything else. */
+  line-height: 1.55;
+  color: var(--fg-dim);
+}
+
+/* Underlined, dimmed, in the trail's own colour — the catalogue's crumb links
+ * exactly, and the underline is the point: it is what separates the sections
+ * you can open from the one you are in, which carries no link and is drawn
+ * as plain text. This theme's links are not underlined until hover, so the
+ * rule has to say it. */
+.Layout .VPDoc .a2ui5-crumbs a {
+  color: var(--fg-dim);
+  text-decoration: underline;
+  font-weight: inherit;
+}
+
+.Layout .VPDoc .a2ui5-crumbs a:hover {
+  color: var(--a2ui5-c-link);
+}
+
+/* Air around the separator, and it is padding rather than a space in the
+ * markup: a wrapped trail then breaks between two crumbs instead of leaving a
+ * `›` stranded at the start of the second line. */
+.Layout .VPDoc .a2ui5-crumbs .sep {
+  padding: 0 6px;
+}
+
 /* ------------------------------------------ the filename over a block ---
  *
  * Drawn as the tab a `::: code-group` draws, because that is what it is: the

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1088,10 +1088,18 @@
   flex-direction: column;
   align-items: flex-start;
   height: 100%;
-  border: 1px solid transparent;
+  /* ONE CARD, DRAWN ONE WAY. Half of these were tinted and half outlined,
+     because the tint used to mean "this leaves the site" - and on a row where
+     two of three cards are pages of this manual, a reader reads that as two
+     kinds of thing rather than as one row of six places to go. The outline is
+     the one that survives: it is what the three feature cards above wear, and
+     what this file's own "edges, not surfaces" section argues for. What tells
+     you whether a card leaves is the arrow on it, which is a thing you can
+     read rather than a shade you have to compare. */
+  border: 1px solid var(--vp-c-divider);
   border-radius: 6px;
   padding: 24px;
-  background-color: var(--a2ui5-c-out-tint);
+  background-color: transparent;
   color: var(--vp-c-text-1);
   text-decoration: none;
   transition: border-color 0.25s, transform 0.25s, box-shadow 0.25s;
@@ -1141,26 +1149,16 @@
   transform: translate(2px, -2px);
 }
 
-/* A CARD THAT STAYS ON THIS SITE SAYS SO BY NOT SAYING THE OPPOSITE.
+/* EVERY CARD CARRIES AN ARROW, AND THE ARROW SAYS WHICH KIND IT IS.
  *
- * The tint and the arrow are this row's whole signal: it is drawn differently
- * from the feature cards above it so that a card which LEAVES is recognisable
- * as one before it is clicked. The home page now has a row mixing both - two
- * of its three "around the framework" cards are pages of this manual - and a
- * card that is tinted and arrowed and then lands on /docs/resources/addons
- * spends that signal on nothing. So a card that stays takes the outline the
- * feature cards have, and drops the arrow. */
-.a2ui5-out .a2ui5-out-card.is-inside {
-  background-color: transparent;
-  border-color: var(--vp-c-divider);
-}
-
-.a2ui5-out .a2ui5-out-card.is-inside:hover {
-  border-color: var(--a2ui5-c-link);
-}
-
+ * A card that stayed on this site used to carry none at all, on the argument
+ * that the arrow means "this leaves". That left half a row with nothing on it
+ * to say it could be pressed - and a card with no affordance at all reads as a
+ * panel rather than as a door. So both kinds are arrowed: `↗` leaves this
+ * deployment, `→` stays on it. The reader who does not know the convention
+ * still sees something that points. */
 .a2ui5-out .a2ui5-out-card.is-inside .a2ui5-out-title::after {
-  content: none;
+  content: "→";
 }
 
 .a2ui5-out .a2ui5-out-details {
@@ -1296,6 +1294,29 @@
    headline above them carries. */
 .Layout .VPHome .VPFeature .icon {
   color: var(--a2ui5-red);
+}
+
+/* ...and the same arrow as the row below them, for the same reason: three
+   cards that are links and look like panels are three doors with no handle.
+   `↗` when the card leaves this deployment - the two that open the playground
+   are absolute URLs, which is what the attribute selector reads - and `→` for
+   the one that stays in the manual. */
+.Layout .VPHome .VPFeature.link .title::after {
+  content: "→";
+  margin-left: 6px;
+  color: var(--a2ui5-red);
+  font-size: 14px;
+  font-weight: 400;
+  display: inline-block;
+  transition: transform 0.25s;
+}
+
+.Layout .VPHome a.VPFeature.link[href^="http"] .title::after {
+  content: "↗";
+}
+
+.Layout .VPHome .VPFeature.link:hover .title::after {
+  transform: translate(2px, -2px);
 }
 
 /* ================================================ the home page, at 90% ===
@@ -2238,9 +2259,13 @@
   left: 0;
   z-index: 1;
   display: inline-block;
+  /* The catalogue's gutter, to the pixel: three characters of number with
+     14px either side. Its own padding rather than a margin, because the
+     column has to be opaque all the way to the edge it sticks to - a gap
+     there is a stripe of code showing through the number as a wide chain
+     scrolls under it. */
   min-width: 3ch;
-  margin-right: 14px;
-  padding-right: 8px;
+  padding: 0 14px;
   text-align: right;
   background: var(--vp-code-block-bg);
   color: var(--vp-c-text-3);
@@ -2261,8 +2286,13 @@
   background: var(--a2ui5-c-mark);
 }
 
-/* The block's own left padding goes: the gutter is the left edge now. */
-.vp-doc div[class*='language-'] pre:has(.ln) {
+/* The block's own left padding goes: the gutter IS the left edge now, and it
+   carries its own. The theme puts 24px on the `code` element rather than on
+   the `pre`, which is what made the numbers sit 24px inboard of the box while
+   sticking to the box - so a chain scrolled sideways moved the number 24px and
+   left a stripe of code down the outside of it. */
+.vp-doc div[class*='language-'] pre:has(.ln),
+.vp-doc div[class*='language-'] code:has(.ln) {
   padding-left: 0;
 }
 

--- a/test/crumbs.test.mjs
+++ b/test/crumbs.test.mjs
@@ -1,0 +1,116 @@
+/*
+ * The line above the title on every page of the manual — "Documentation ›
+ * Cookbook › Model" — and specifically the walk that produces it.
+ *
+ * It is derived from the sidebar rather than written a second time, which is
+ * the whole point of it: the bar used to carry a Guide dropdown restating the
+ * sidebar and it drifted twice. What can still go wrong is the WALK, and it
+ * goes wrong quietly — a trail that loses a level, or stops one short, on a
+ * page nobody opened this week. The shapes below are the shapes config.mjs
+ * actually contains, and the last test walks the real sidebar so that a
+ * section restructured there cannot leave this file passing against a fiction.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { key, trailFor } from '../docs/.vitepress/theme/crumbs.js';
+import config from '../docs/.vitepress/config.mjs';
+
+/** Just the words, which is what a reader sees. */
+const words = (sidebar, page) => trailFor(sidebar, page).map((c) => c.text);
+
+test('one spelling for a page, whatever it was written as', () => {
+  assert.equal(key('/get_started/about'), '/get_started/about');
+  assert.equal(key('/get_started/about.md'), '/get_started/about');
+  assert.equal(key('/get_started/about.html'), '/get_started/about');
+  // The sidebar writes the walkthrough's index with a trailing slash and the
+  // file is `index.md`; both have to arrive at the same string.
+  assert.equal(key('/tutorials/walkthrough/'), '/tutorials/walkthrough');
+  assert.equal(key('/tutorials/walkthrough/index.md'), '/tutorials/walkthrough');
+  assert.equal(key('/cookbook/model/trees#binding'), '/cookbook/model/trees');
+  assert.equal(key('/'), '/');
+  assert.equal(key(''), '/');
+  // The trail is built by putting a slash in front of a `relativePath`; a
+  // value that already had one must not become a path matching nothing.
+  assert.equal(key('//cookbook/model/trees'), '/cookbook/model/trees');
+});
+
+test('the deepest entry that opens the page wins', () => {
+  // Every one of these three names /a/one, and the answer is the deepest.
+  const sidebar = [
+    {
+      text: 'Section',
+      link: '/a/one',
+      items: [
+        { text: 'Group', link: '/a/one', items: [{ text: 'Page', link: '/a/one' }] },
+      ],
+    },
+  ];
+  assert.deepEqual(words(sidebar, 'a/one.md'), ['Documentation', 'Section', 'Group']);
+});
+
+test('a crumb the sidebar gives nowhere to open carries no link', () => {
+  // Quickstart, in config.mjs: a label over two steps, not a page.
+  const sidebar = [
+    {
+      text: 'Getting Started',
+      link: '/get_started/about',
+      items: [{ text: 'Quickstart', items: [{ text: 'Hello World', link: '/get_started/hello_world' }] }],
+    },
+  ];
+  const trail = trailFor(sidebar, 'get_started/hello_world.md');
+  assert.deepEqual(trail.map((c) => c.text), ['Documentation', 'Getting Started', 'Quickstart']);
+  assert.equal(trail[1].link, '/get_started/about');
+  assert.equal(trail[2].link, undefined);
+});
+
+test('a page no sidebar names still says which document it is in', () => {
+  assert.deepEqual(words([{ text: 'Section', link: '/a/one' }], 'somewhere/else.md'), ['Documentation']);
+  assert.deepEqual(words([], 'anything.md'), ['Documentation']);
+  assert.deepEqual(words(undefined, 'anything.md'), ['Documentation']);
+});
+
+test('the first crumb is the manual, and it opens the manual', () => {
+  const [first] = trailFor(config.themeConfig.sidebar, 'cookbook/model/trees.md');
+  assert.equal(first.text, 'Documentation');
+  // The same page SiteNav.vue's Documentation item points at.
+  assert.equal(first.link, '/get_started/about');
+});
+
+test('an object sidebar is walked under the longest matching prefix', () => {
+  // Not the shape this repository uses today; the day it grows a second
+  // sidebar, the trail should not silently come from the first one listed.
+  const sidebar = {
+    '/': [{ text: 'Everything', link: '/a/one' }],
+    '/deep/': [{ text: 'Deep', link: '/deep/one', items: [{ text: 'Inner', link: '/deep/two' }] }],
+  };
+  assert.deepEqual(words(sidebar, 'deep/two.md'), ['Documentation', 'Deep']);
+  assert.deepEqual(words(sidebar, 'a/one.md'), ['Documentation']);
+});
+
+test('the real sidebar files the pages where a reader would look for them', () => {
+  const sidebar = config.themeConfig.sidebar;
+  const cases = [
+    ['get_started/about.md', ['Documentation', 'Getting Started']],
+    ['get_started/hello_world.md', ['Documentation', 'Getting Started', 'Quickstart']],
+    ['tutorials/walkthrough/step-4.md', ['Documentation', 'Tutorial', 'Walkthrough']],
+    ['cookbook/model/trees.md', ['Documentation', 'Cookbook', 'Model']],
+    ['cookbook/model/expression_binding.md', ['Documentation', 'Cookbook', 'Model', 'Binding']],
+    ['cookbook/view/definition.md', ['Documentation', 'Cookbook', 'View']],
+  ];
+  for (const [page, expected] of cases) assert.deepEqual(words(sidebar, page), expected, page);
+});
+
+test('every page the sidebar names gets a trail longer than the word Documentation', () => {
+  // The section headers duplicate their first chapter's link, so a walk that
+  // matched shallowly would leave a whole level of pages with no trail at all.
+  const seen = [];
+  const walk = (items) => (items || []).forEach((i) => { if (i.link) seen.push(i.link); walk(i.items); });
+  walk(config.themeConfig.sidebar);
+  assert.ok(seen.length > 100, `expected the manual's sidebar, got ${seen.length} entries`);
+  for (const link of seen) {
+    assert.ok(trailFor(config.themeConfig.sidebar, link).length > 1, `no trail for ${link}`);
+  }
+});


### PR DESCRIPTION
The sample catalogue has had a crumb line above every title since its pages were generated — *Sample catalogue › Learn › Basics* — and the manual, the larger of the two documents and the one with sections four deep, had nothing.

## Where in the manual (`theme/Crumbs.vue`, `theme/crumbs.js`)

*Documentation › Cookbook › Model*, above the title, on every page that has one. Same shape as the catalogue's, and the same place: the trail is the doc column's first line, rendered into the default theme's `doc-before` slot, at the 48px `.VPDoc` already opens with — which is where the catalogue's own crumb line sits and where *On this page* already was on both sites.

Measured at 1512px, docs against a sample page:

| | crumbs | heading | On this page |
|---|---|---|---|
| manual | y=94, 12px/18.6 | y=119 | y=94 |
| catalogue | y=94, 12px/18.6 | y=119 | y=94 |

The 1.55 line-height is copied out of `tools/sample-pages.mjs` and is what makes the last column of that table agree; this theme's body ratio would have put the heading a pixel high.

**The trail comes from `themeConfig.sidebar`**, walked against the page being rendered, not from a second list of the manual's sections. The bar used to carry a Guide dropdown that was exactly such a copy and it drifted twice — the comment above `nav: []` in `config.mjs` is that scar.

Two details worth the words:

- **The deepest entry that names a page wins.** Section headers duplicate their first chapter's link (`Cookbook`, `View` and `Definition` all point at `/cookbook/view/definition`), so a shallow match would file half the manual under *Documentation* alone.
- **A crumb the sidebar gives nowhere to open is plain text.** *Quickstart* and *Walkthrough* are labels over a list of steps, not pages — which is what the catalogue does with its own last crumb.

The walk is a module with no Vue in it, like `search-engine.js` and `text-fragment.js` and for the same reason: what can go wrong here goes wrong quietly, on a page nobody opened this week. `test/crumbs.test.mjs` walks the real sidebar, so a restructured section cannot leave the tests passing against a fiction.

## Also in here, from before

- **The gutter.** The line numbers this manual gained sat inside the block's own left padding, so the first character of ABAP began 20px further right than the same character on a sample page. The padding moves off the `pre` and onto the number. At 1440: block at x=366, gutter at 367 and 36px wide — the catalogue's 161→197.
- **The cards.** Six cards in the home page's second row, half tinted and half outlined, because the tint used to mean *this one leaves the site* — and two of three cards in that row are pages of this manual. All outlined now; what says whether a card leaves is an arrow you can read rather than a shade you have to compare (`↗` leaves, `→` stays). The three feature cards above them get the same arrow, having been links drawn as panels.

## Verification

`npm run check` — all eleven gates, 123 tests. Light and dark checked in a browser against a live sample page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_