### PR TITLE
One type scale for both documents, one measure for the prose, one arrow on every tile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,19 @@ comes from the row being rendered, and this one is walked out of
 sections is a second list to keep in step — the bar's old Guide dropdown was
 exactly that and it drifted twice.
 
+**The type scale is the catalogue's too, and by hand.** The page title, the
+section heading and the body are the catalogue's numbers written into
+`theme/style.css`: `26px/1.25` bold for h1, `15px/1.55` bold for h2 and
+`14px/1.55` for prose (`.sample h1` and `h2` in `tools/sample-pages.mjs`, and
+the `1.55` on `body` in `src/shell/shell.css`). They were 26/34/600, 16/22/600
+and 14/22 here — close enough to look like the same page and far enough that a
+heading read lighter on one side of the bar than on the other. h3 and h4 have
+no counterpart, because a sample page has two heading levels and the manual
+has four; they keep their step and take the 1.55. **`check:design` does not
+cover these** — it compares custom properties, and neither side declares its
+type scale as one. Changing the catalogue's h1 means changing this file's, and
+nothing will tell you.
+
 **The accent is SAP blue, and the mark is still red.** `#0a6ed1` / `#4aa3ff` is
 what a link, a button and the hero name are set in; `#d03c4a` is the circle in
 the wordmark and belongs to the mark alone. `resources/logo.md` is the page
@@ -239,6 +252,16 @@ router never looks at it, and VitePress gives external links in a page a
 menu ever got this wrong. `check:cross-site` now holds the whole built site to
 it, and the direction back needs nothing: the other three documents are static
 pages with no router in front of them.
+
+**The raw markdown is a copy, not a second site.** `generate-llms.mjs` writes
+one `.md` per page into `docs/public/`, VitePress copies that directory to the
+root of the site, and `llms.txt` points an agent at
+`/docs/cookbook/model/trees.md`. `srcDir` is `docs/`, so those files were ALSO
+globbed as pages: every chapter of the manual was rendered a second time, at
+`/docs/public/cookbook/model/trees.html` — 165 files no sidebar names, no
+search index carries and nothing links to. `srcExclude` in `config.mjs` stops
+it; the raw markdown is unaffected, because publicDir copies a file whether or
+not it is also treated as a page.
 
 **One origin means one localStorage**, which is what four things here rely on:
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -33,6 +33,19 @@ export default defineConfig({
     },
   },
   base: "/docs/", // Set your base URL here
+  /* `docs/public/` is the raw markdown of this manual — one .md per page, for
+   * an agent following llms.txt — and VitePress copies it to the root of the
+   * site, which is where llms.txt points (/docs/cookbook/model/trees.md).
+   *
+   * It was ALSO being globbed as source, because srcDir is `docs/` and nothing
+   * said otherwise. So every page of the manual was rendered a second time, as
+   * a full themed page at /docs/public/cookbook/model/trees.html: 165 files
+   * nothing links to, nothing indexes (generate-search.mjs walks the real
+   * pages) and no sidebar names — which is how they were found, being the only
+   * pages on the site whose crumb line could say nothing but "Documentation".
+   * The raw markdown is unaffected: publicDir copies the files regardless of
+   * whether they are also treated as pages. */
+  srcExclude: ["public/**"],
   head: [
     ["link", { rel: "shortcut icon", href: "/docs/favicon.ico" }],
     [

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -271,11 +271,20 @@
  * prose without cutting the code in half.
  */
 
-/* Section headings. The top rule stays: on a long cookbook page it is what
- * lets the eye find the next section while scrolling. Its padding does not. */
+/* Section headings, at the catalogue's h2: 15px, bold, on the 1.55 that
+ * carries everything else there (`h2 { font-size: 15px }` in
+ * tools/sample-pages.mjs). It was 16px/600 here, and 600 against 700 is the
+ * difference a reader stepping between the two documents actually sees - a
+ * heading that looks lighter on one side of the bar than the other.
+ *
+ * WEIGHT IS WHAT SEPARATES THE LEVELS NOW, and it can be, because the top
+ * rule stays: on a long cookbook page that hairline is what lets the eye find
+ * the next section while scrolling, and an h3 has none. Its padding does not
+ * stay. */
 .vp-doc h2 {
-  font-size: 16px;
-  line-height: 22px;
+  font-size: 15px;
+  line-height: 1.55;
+  font-weight: 700;
   margin: 32px 0 12px;
   padding-top: 12px;
   letter-spacing: -0.01em;
@@ -287,20 +296,29 @@
   top: 12px;
 }
 
+/* The catalogue's pages have two heading levels and this manual has four, so
+ * these two are the ones with no value to copy. They keep the step they had -
+ * h3 at the section heading's size and h4 one below it - and take the 1.55 and
+ * the 600 that now separate them from an h2 which is 700 and ruled. */
 .vp-doc h3 {
   font-size: 15px;
-  line-height: 21px;
+  line-height: 1.55;
+  font-weight: 600;
   margin: 24px 0 0;
 }
 
 .vp-doc h4 {
   font-size: 14px;
-  line-height: 20px;
+  line-height: 1.55;
+  font-weight: 600;
   margin: 20px 0 0;
 }
 
-/* The page title, at the size a sample's own page sets its title in over in
- * the catalogue (26px/1.25, tools/sample-pages.mjs). It went the other way
+/* The page title, exactly as a sample's own page sets its title over in the
+ * catalogue: `26px, line-height 1.25` and the browser's own bold for a
+ * heading, which is 700 (`.sample h1` in tools/sample-pages.mjs). Both of the
+ * other two were off by a hair and the hair showed - VitePress puts every
+ * heading at 600, and 34px is not 32.5. It went the other way
  * from everything else in this pass — 22px up to 26px — and that is the shape
  * of the catalogue's scale rather than an exception to it: the body is tight
  * and the one heading that says WHICH PAGE THIS IS is generous, because those
@@ -313,14 +331,15 @@
  * that quietly stops being true after a dependency bump. */
 .vp-doc h1 {
   font-size: 26px;
-  line-height: 34px;
+  line-height: 1.25;
+  font-weight: 700;
   margin-bottom: 16px;
 }
 
 @media (min-width: 768px) {
   .vp-doc h1 {
     font-size: 26px;
-    line-height: 34px;
+    line-height: 1.25;
   }
 }
 
@@ -395,7 +414,11 @@
 .vp-doc blockquote,
 .vp-doc dd {
   font-size: 14px;
-  line-height: 22px;
+  /* 1.55, the catalogue's body line-height, rather than the 22px this had.
+   * The two are 0.3px apart on one line and a line and a half apart down a
+   * long page, and the whole point of the shared measure is that a paragraph
+   * moved between the two documents occupies the same space. */
+  line-height: 1.55;
 }
 
 /* The chrome around the page — sidebar, outline, nav, the prev/next footer —
@@ -1120,6 +1143,27 @@
  * The selectors carry the block class twice because this sits inside
  * `.vp-doc` — VPHomeContent wraps the markdown that follows the frontmatter —
  * and `.vp-doc a` outranks a single class. */
+/* ------------------------------------------- prose on the front page ---
+ *
+ * The markdown under the hero sits in a 1152px block, and until now its
+ * PARAGRAPHS did too: 1152px of 14px type is about 160 characters a line, and
+ * a reader who reached the end of one had to hunt for the start of the next.
+ * The catalogue never had this - every run of prose over there is capped, at
+ * `74ch` on the masthead and the sample lede and `78ch` on a section's
+ * standfirst - so the two front doors of one site wrapped their text at
+ * completely different points.
+ *
+ * 74ch, which is the catalogue's number and lands at about 640px here: the
+ * same measure the manual's own column is set to, from the other direction.
+ * Only the prose. The card grids, the code blocks and the tables keep the
+ * full 1152px, because a card row IS the width of the page and a listing is
+ * not read a line at a time. */
+.Layout .VPHome .vp-doc p,
+.Layout .VPHome .vp-doc li,
+.Layout .VPHome .vp-doc blockquote {
+  max-width: 74ch;
+}
+
 .a2ui5-out {
   display: grid;
   grid-template-columns: 1fr;
@@ -1205,17 +1249,20 @@
   transform: translate(2px, -2px);
 }
 
-/* EVERY CARD CARRIES AN ARROW, AND THE ARROW SAYS WHICH KIND IT IS.
+/* EVERY CARD CARRIES THE SAME ARROW, AND IT IS `↗`.
  *
- * A card that stayed on this site used to carry none at all, on the argument
- * that the arrow means "this leaves". That left half a row with nothing on it
- * to say it could be pressed - and a card with no affordance at all reads as a
- * panel rather than as a door. So both kinds are arrowed: `↗` leaves this
- * deployment, `→` stays on it. The reader who does not know the convention
- * still sees something that points. */
-.a2ui5-out .a2ui5-out-card.is-inside .a2ui5-out-title::after {
-  content: "→";
-}
+ * Two rounds got here. First a card that stayed on this site carried no arrow
+ * at all, on the argument that an arrow means "this leaves" - which left half
+ * a row with nothing on it to say it could be pressed, and a card with no
+ * affordance reads as a panel rather than as a door. Then both kinds were
+ * arrowed and the arrow was made to say WHICH kind: `↗` out, `→` in.
+ *
+ * That is one distinction too many for a row of nine tiles. The arrow's job on
+ * a signpost is "press me", and a reader comparing two glyph shapes across a
+ * grid to work out which link leaves the deployment is a reader doing the
+ * page's work. One arrow, on everything. Where a card goes is what the card
+ * SAYS - and all nine are one site anyway, which is the whole argument of
+ * *One site in three places*. */
 
 .a2ui5-out .a2ui5-out-details {
   display: block;
@@ -1354,21 +1401,15 @@
 
 /* ...and the same arrow as the row below them, for the same reason: three
    cards that are links and look like panels are three doors with no handle.
-   `↗` when the card leaves this deployment - the two that open the playground
-   are absolute URLs, which is what the attribute selector reads - and `→` for
-   the one that stays in the manual. */
+   One glyph on all of them - see the row below for why it stopped being two. */
 .Layout .VPHome .VPFeature.link .title::after {
-  content: "→";
+  content: "↗";
   margin-left: 6px;
   color: var(--a2ui5-red);
   font-size: 14px;
   font-weight: 400;
   display: inline-block;
   transition: transform 0.25s;
-}
-
-.Layout .VPHome a.VPFeature.link[href^="http"] .title::after {
-  content: "↗";
 }
 
 .Layout .VPHome .VPFeature.link:hover .title::after {

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,12 @@ hero:
   # before - the two lines are a welcome and an answer, in that order.
   name: Welcome to abap2UI5
   text: Build UI5 Apps Purely in ABAP
-  tagline: "One ABAP class is one UI5 app. No JavaScript, no OData service, no RAP, no frontend project.\nInstall it with abapGit and run it on anything from NetWeaver 7.02 to ABAP Cloud."
+  # ONE PARAGRAPH, NO HARD BREAK. The `\n` that used to stand after "no
+  # frontend project." broke the tagline at a point the line length had nothing
+  # to do with, so the first line stopped two words short of the measure and
+  # the second started under a ragged edge. Two sentences that belong together
+  # wrap where the column says they wrap.
+  tagline: "One ABAP class is one UI5 app. No JavaScript, no OData service, no RAP, no frontend project. Install it with abapGit and run it on anything from NetWeaver 7.02 to ABAP Cloud."
   image:
     src: /logo.png
     alt: abap2UI5 Logo


### PR DESCRIPTION
Four things a reader sees when they cross between the manual and the sample catalogue, all with the same answer: take the catalogue's number.

## The type was not the same

…and it looked like it was, which is worse than looking different. Measured at 1512px, a manual page against a sample page:

| | manual (before) | catalogue | manual (now) |
|---|---|---|---|
| page title | 26px / 34px / **600** | 26px / 32.5px / **700** | 26px / 32.5px / 700 |
| section heading | **16px** / 22px / **600** | **15px** / 23.25px / **700** | 15px / 23.25px / 700 |
| prose | 14px / **22px** | 14px / **21.7px** (1.55) | 14px / 21.7px |

The sources are `.sample h1` and `h2` in `tools/sample-pages.mjs` and the `1.55` on `body` in `src/shell/shell.css`. `h3` and `h4` have no counterpart — a sample page has two heading levels and this manual has four — so they keep their step and take the 1.55, with a 600 that separates them from an h2 which is now 700 and still ruled.

**`check:design` cannot hold this.** It compares custom properties, and neither side declares its type scale as one. AGENTS.md now says so explicitly rather than leaving it implied.

## The prose on the front page ran to 1152px

About 160 characters a line, while every run of prose in the catalogue is capped (74ch on the masthead and the sample lede). It is `74ch` here now, which lands at **659px** — the width the catalogue's masthead measures. Only the prose: card grids, code blocks and tables keep the full 1152px, because a card row *is* the width of the page.

The hero tagline also loses the hard break after "no frontend project." — it broke the line at a point the measure had nothing to do with.

## One arrow, and it is the diagonal one

Every tile on the home page carried an arrow saying which *kind* of link it was (`↗` out of the deployment, `→` for a page of this manual). That is one distinction too many for a row of nine tiles: the arrow's job on a signpost is "press me", and all nine are one site anyway.

## The manual stopped publishing itself twice

Checking the new crumb line on every built page turned up 165 pages with nothing to say. `docs/public/` holds the raw markdown of each page, VitePress copies that directory to the root of the site, and `llms.txt` points an agent at `/docs/cookbook/model/trees.md` — but `srcDir` is `docs/`, so those files were **also** globbed as pages: every chapter rendered a second time at `/docs/public/cookbook/model/trees.html`. Nothing links to them, no sidebar names them, the search index does not carry them. `srcExclude` ends it; the raw markdown is untouched, because publicDir copies a file whether or not it is also treated as a page.

## Verification

`npm run check` — all eleven gates, 123 tests. The type and the measure were confirmed by measuring both sites in a browser side by side, not by eye; the crumb trail was enumerated across all 165 manual pages (every one gets a real trail, none falls back to a lone "Documentation").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_