### PR TITLE
"On this page" is level with the crumb line, not six pixels under it

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -436,6 +436,29 @@
   font-size: 13px;
 }
 
+/* "On this page", level with the crumb line beside it.
+ *
+ * THE BOX WAS ALREADY RIGHT AND THE LETTERS WERE NOT, which is why this was
+ * called done once already. Both columns open at 94px - the rule above sets
+ * the size and `.VPDoc`\'s padding sets the top - but VitePress gives this
+ * heading `line-height: 32px` on what is now 13px text, and a line box is
+ * taller than its glyphs by half the difference at each end. Measured with a
+ * Range around the text node rather than the element:
+ *
+ *              box top   GLYPH top
+ *   crumbs        94        96
+ *   On this page  94       102      <- six pixels, and the eye sees glyphs
+ *
+ * The catalogue never had it: its `.outline-head` inherits the 1.55 that
+ * carries the whole page, so its letters land at 96 beside a crumb line at 96.
+ * Same ratio here, and the 8px of air the 32px was doing double duty as is
+ * stated instead - a line-height that is also a margin is a number that cannot
+ * be changed for one job without moving the other. */
+.VPDocAside .outline-title {
+  line-height: 1.55;
+  margin-bottom: 8px;
+}
+
 /* …and the group headings in the sidebar back ABOVE the pages under them.
  *
  * The previous version of this rule put them at 12px muted, one step BELOW


### PR DESCRIPTION
The two columns of a page both open at 94px, and this was called aligned once already — on a measurement of the **element**. What a reader sees is the letters, and they were not level.

Measured with a `Range` around the text node rather than `getBoundingClientRect` on the element:

| | box top | glyph top |
|---|---|---|
| crumb line | 94 | 96 |
| On this page | 94 | **102** |

## The cause

VitePress sets `line-height: 32px` on `.outline-title`, and this file had only overridden its `font-size`, down to 13px. A line box is taller than its glyphs by half the difference at each end — so 32px of line around 13px of text pushes the words 6px down inside a box that starts in exactly the right place.

The catalogue never had it: its `.outline-head` inherits the 1.55 that carries the whole page, so its letters land at 96 beside a crumb line at 96. Same ratio here now, and the 8px of air the 32px was doing double duty as is stated as a `margin-bottom` instead — a line-height that is also a gap cannot be changed for one job without moving the other.

## After

| | docs | catalogue |
|---|---|---|
| crumb line, glyph top | 96 | 96 |
| On this page, glyph top | 96 | 96 |
| first outline entry, box top | 122.1 | 122.1 |

## One difference left, deliberately

The first outline entry's **glyphs** are still 3px apart (docs 130.1, catalogue 127.1): the manual's outline links carry `line-height: 24px` against the catalogue's 1.4. That is not drift — the comment on that rule records an earlier attempt at tightening it, which made single-line entries "read as a cramped block" across the 627 entries this manual's outline holds, ~4% of which wrap to two lines. Taking the catalogue's value here would redo a rejected experiment, so it stays and is worth a decision rather than a silent change.

## Verification

`npm run check` — all eleven gates, 123 tests. The alignment was measured on both running sites, glyphs not boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_