### PR TITLE
The outline column is the catalogue's, row for row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,15 @@ comes from the row being rendered, and this one is walked out of
 sections is a second list to keep in step — the bar's old Guide dropdown was
 exactly that and it drifted twice.
 
+**So is the outline column.** *On this page* is the catalogue's row for row:
+13px on `1.4` with `4px 0` of padding and 2px between rows, and its heading
+level with the crumb line beside it. Two of those were wrong for a while in a
+way a measurement of the ELEMENT could not see - VitePress sets
+`line-height: 32px` on `.outline-title`, and a line box is taller than its
+glyphs, so the words sat 6px low in a box that started in the right place.
+**Measure the glyphs** (a `Range` over the text node), not the element, when
+checking that two documents line up.
+
 **The type scale is the catalogue's too, and by hand.** The page title, the
 section heading and the body are the catalogue's numbers written into
 `theme/style.css`: `26px/1.25` bold for h1, `15px/1.55` bold for h2 and

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -830,29 +830,46 @@
   }
 }
 
-/* An outline entry that is too long now wraps rather than being cut. The
+/* An outline entry that is too long wraps rather than being cut. The theme's
  * default is `white-space: nowrap` + `text-overflow: ellipsis`, which keeps
- * every entry one line tall at the price of not saying what it points at.
+ * every entry one line tall at the price of not saying what it points at -
+ * and at 627 entries, about 4% of this manual's are long enough to lose their
+ * last word that way.
  *
- * The spacing needs care, and the obvious version was wrong. The default is
- * `line-height: 32px` on a 14px font - generous, because it doubles as the gap
- * BETWEEN entries. The first attempt here dropped it to 20px so the two lines
- * of a wrapped entry would read as one item, which they did - and every
- * single-line entry lost a third of its breathing room, so the list read as a
- * cramped block.
+ * THE REST OF IT IS THE CATALOGUE'S ROW, VALUE FOR VALUE: `1.4` on the line
+ * and `4px 0` of padding, with the 2px between rows that its `.outline nav`
+ * sets as a flex gap (`.outline nav a` in src/catalogue/catalogue.css). An
+ * entry is 26.2px tall and the next one starts 28.2px below it, on both
+ * documents.
  *
- * Splitting the two jobs fixes both: 24px carries the line, 4px of padding
- * above and below carries the gap. A single-line entry still occupies 32px,
- * exactly as before; a wrapped one keeps its two lines close together and
- * still stands apart from its neighbours. Padding is set per side rather than
- * as a shorthand - `.outline-link.nested` sets `padding-left: 13px` for the
- * indent, and a shorthand would quietly flatten it. */
+ * The history is worth keeping, because it argues the other way. The theme
+ * ships `line-height: 32px` on 14px - generous, and doubling as the gap
+ * BETWEEN entries. A first attempt here dropped it to 20px and left the gap to
+ * it, which pulled a wrapped entry's two lines together and took a third of
+ * the air off every single-line one, so the list read as a cramped block.
+ * Splitting the jobs - 24px for the line, 4px of padding for the gap - fixed
+ * both and stood until now. What it did NOT do is match the catalogue: 32px a
+ * row against 28.2 is a rhythm a reader crossing between the two documents
+ * meets in the outline they were just reading. The two jobs stay split; the
+ * numbers are the catalogue's.
+ *
+ * Padding is set per side rather than as a shorthand - `.outline-link.nested`
+ * sets `padding-left: 13px` for the indent, and a shorthand would quietly
+ * flatten it. The indent has no counterpart to copy: a sample page's outline
+ * is one level, because its headings are. */
 .VPDocOutlineItem a.outline-link {
   white-space: normal;
   text-overflow: clip;
-  line-height: 24px;
+  line-height: 1.4;
   padding-top: 4px;
   padding-bottom: 4px;
+}
+
+/* The 2px between rows, which over there is a flex gap on the column. The
+ * theme's outline is a nested `<ul>`, so it is stated on the item. */
+.VPDocOutlineItem > li + li,
+.VPDocOutlineItem > li > ul > li {
+  margin-top: 2px;
 }
 
 /* ------------------------------------------------ where in the manual ---


### PR DESCRIPTION
Following #238, which levelled the outline's heading with the crumb line: the rows under it now carry the catalogue's numbers as well — 13px on `1.4` with `4px 0` of padding, and the 2px between rows its `.outline nav` sets as a flex gap.

Measured on both running sites:

| | docs | catalogue |
|---|---|---|
| crumb line, glyph top | 96 | 96 |
| On this page, glyph top | 96 | 96 |
| row height | 26.2 | 26.2 |
| row to row | 28.2 | 28.2 |
| first four entries, glyph tops | 127.1 155.3 183.5 211.7 | 127.1 155.3 183.5 211.7 |

## The history argues the other way, and it stays in the comment

The theme ships `line-height: 32px` on 14px — generous, and doubling as the gap *between* entries. A first attempt here cut it to 20px and left the gap to it, which pulled a wrapped entry's two lines together and took a third of the air off every single-line one: the list read as a cramped block. Splitting the jobs — 24px for the line, 4px of padding for the gap — fixed that, and stood until now.

What it did not do is match the catalogue: 32px a row against 28.2 is a rhythm a reader meets in the outline they were just reading on the other site.

**The rejected version does not come back with the smaller number**, because the two jobs stay split: the padding still carries the gap, only the line is the catalogue's. Checked on a page that actually wraps — `configuration/authorization`, three entries over two lines each — the two lines of one entry still sit visibly closer together than two entries do, and the single-line rows keep their air.

The nested indent has no counterpart to copy and keeps its 13px: a sample page's outline is one level deep, because its headings are.

## Verification

`npm run check` — all eleven gates, 123 tests. Measured with a `Range` over the text node, not `getBoundingClientRect` on the element — AGENTS.md now records that distinction, since it is what hid the 6px in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_