### PR TITLE
The ABAP is set at the catalogue's size

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,8 +194,9 @@ the `1.55` on `body` in `src/shell/shell.css`). They were 26/34/600, 16/22/600
 and 14/22 here — close enough to look like the same page and far enough that a
 heading read lighter on one side of the bar than on the other. h3 and h4 have
 no counterpart, because a sample page has two heading levels and the manual
-has four; they keep their step and take the 1.55. **`check:design` does not
-cover these** — it compares custom properties, and neither side declares its
+has four; they keep their step and take the 1.55. The ABAP is the catalogue's
+too - `12.5px` on the same 1.55 (`.source-body`), because the same class often
+appears on both documents. **`check:design` does not cover these** — it compares custom properties, and neither side declares its
 type scale as one. Changing the catalogue's h1 means changing this file's, and
 nothing will tell you.
 

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -348,10 +348,20 @@
  * screen. */
 :root {
   --vp-code-line-height: 1.55;
-  /* 13px flat, not the theme's `.875em`. The relative unit made a listing
-   * inside a callout or a list item shrink with its container, so the same
-   * ABAP was set at three different sizes on one page. */
-  --vp-code-font-size: 13px;
+  /* 12.5px flat, not the theme's `.875em`. Two decisions in one line, and
+   * they are independent.
+   *
+   * FLAT, because the relative unit made a listing inside a callout or a list
+   * item shrink with its container, so the same ABAP was set at three
+   * different sizes on one page.
+   *
+   * 12.5, because that is what the catalogue prints a class at
+   * (`.source-body` in tools/sample-pages.mjs) - and the same ABAP appears on
+   * both documents, often the same class. It was 13 here, half a pixel that
+   * nobody sees on one screen and that shows the moment a reader has the
+   * sample page and the chapter explaining it open in two tabs. The 1.55
+   * above is already the catalogue's, so the whole listing now matches. */
+  --vp-code-font-size: 12.5px;
 }
 
 .vp-doc div[class*='language-'] pre {


### PR DESCRIPTION
Found by auditing **all 38 measurable properties the two documents share** — glyph positions, sizes, line-heights, weights, colours, palette tokens, the outline rhythm, the code gutter, the bar — rather than by eye. Six looked different; four were the audit's own measurement being wrong, two were real. This is one of the two.

## Half a pixel on the thing that is most often literally the same text

A sample page prints a class at **12.5px**; the chapter explaining that class printed it at **13px**. Nobody sees that on one screen — a reader with the sample page and the chapter open in two tabs does.

The line-height was already the catalogue's 1.55, so the whole listing matches now:

| | docs | catalogue |
|---|---|---|
| code size | 12.5px | 12.5px |
| code line-height | 19.375px | 19.375px |
| family | ui-monospace | ui-monospace |
| gutter width | 35.5 | 35.5 |

The other half of that declaration is unchanged and unrelated: the size stays **flat** rather than the theme's `.875em`, because the relative unit made a listing inside a callout or a list item shrink with its container — the same ABAP set at three sizes on one page.

## The audit, for the record

After this and its sibling in `abap2UI5/playground`, all 38 match. The four false alarms are worth naming, because each is a way to measure wrong:

- **h1 off by 1px** — the manual's `h1` carries a `¶` anchor inside it, and a `Range` over the whole subtree includes it. Measured on the text node alone: 119.6 on both.
- **prose 14px vs 15px** — the audit compared `.vp-doc p` against `.sample .lede`, which is a standfirst, not a paragraph. A sample page's ordinary body text is 14px/21.7px, the same as the manual's.
- **outline row colour** — the catalogue's first row was marked and the manual's was not; that was real, and it is fixed on the other side (the playground PR).
- **gutter 36 vs 853** — a selector that fell through to the whole line. Both gutters are 35.5px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_