### PR TITLE
The sidebar starts where the page it navigates starts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,14 @@ comes from the row being rendered, and this one is walked out of
 sections is a second list to keep in step — the bar's old Guide dropdown was
 exactly that and it drifted twice.
 
+**A page is THREE columns and all three start at 96px.** The sidebar, the
+article and the outline all begin under the same 46px bar; the article and the
+outline open 48px below it (the theme's `.VPDoc` padding) and the sidebar
+opened 10px below it, so the manual's own navigation started a line and a half
+above the page it navigates. The 32px that closes it is on `.VPSidebar .nav`,
+never on `.group` — `.group` also spaces the sections from each other. Check
+all three when changing any of them; two of them agreeing is what hid this.
+
 **So is the outline column.** *On this page* is the catalogue's row for row:
 13px on `1.4` with `4px 0` of padding and 2px between rows, and its heading
 level with the crumb line beside it. Two of those were wrong for a while in a

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -446,6 +446,35 @@
   font-size: 13px;
 }
 
+/* THE THIRD COLUMN. The sidebar opened 32px above the other two.
+ *
+ * A page is three columns and they all begin under the same 46px bar, but
+ * only two of them had been checked against each other. The arithmetic, all
+ * of it the theme's:
+ *
+ *   sidebar   46 (bar) + 10 (`.group` padding-top)  = 56  -> glyphs at 64
+ *   article   46 (bar) + 48 (`.VPDoc` padding-top)  = 94  -> glyphs at 96
+ *   outline   the same 94                            = 96
+ *
+ * So the manual's own navigation started a line and a half above the page it
+ * navigates, and that is the step a reader sees when they look across. 48px
+ * is the number to keep - it is the theme's for the article, it is what the
+ * sample catalogue was aligned to, and 10px under a sticky bar is not air,
+ * it is a collision waiting for a scroll.
+ *
+ * The 32px goes on `.nav` rather than on `.group`, because `.group` also
+ * spaces the sections FROM EACH OTHER: adding it there would open 42px
+ * between Cookbook and Configuration as well. On the nav it moves the whole
+ * list once and leaves every gap inside it alone.
+ *
+ * From 960px up only, which is where both of the numbers above are set; below
+ * it the sidebar is a drawer over the page and has no column to line up with. */
+@media (min-width: 960px) {
+  .VPSidebar .nav {
+    padding-top: 32px;
+  }
+}
+
 /* "On this page", level with the crumb line beside it.
  *
  * THE BOX WAS ALREADY RIGHT AND THE LETTERS WERE NOT, which is why this was


### PR DESCRIPTION
A page is **three** columns and only two of them had ever been checked against each other. All three begin under the same 46px bar; the arithmetic under it was the theme's, and it did not agree.

| column | opens at | first glyphs |
|---|---|---|
| sidebar | 46 (bar) + 10 (`.group` padding-top) = 56 | **64** |
| article | 46 (bar) + 48 (`.VPDoc` padding-top) = 94 | 96 |
| outline | the same 94 | 96 |

So the manual's own navigation started a line and a half above the page it navigates — and that step is what a reader sees looking across the three. **All three read 96 now.**

## Why 48 and not 10

It is the theme's number for the article, it is what the sample catalogue was aligned to in #236–#240, and 10px under a sticky bar is not air — it is a collision waiting for a scroll.

## Why on `.nav` and not on `.group`

`.group` also spaces the sections **from each other**; adding 32px there would have opened 42px between *Cookbook* and *Configuration* as well. On `.nav` it moves the whole list once and leaves every gap inside it alone.

From 960px up only, which is where both of the numbers above are set. Below that the sidebar is a drawer over the page and has no column to line up with — measured 0px at 420px wide.

## Checked

- a page with an aside, and one without → sidebar / crumbs / outline all 96
- the home page (no sidebar) → unaffected
- a sidebar long enough to scroll — 2377px with *Technical Insights* open — the last entry is still reachable and the first still reads 96 at the top
- `npm run check`: all eleven gates, 123 tests

This is the defect behind "es springt": the earlier passes measured the article against the catalogue and the outline against the article, and both of those agreed — which is exactly what hid the third column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_