### PR TITLE
The search box states the type it would otherwise inherit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,17 @@ sample catalogues with the titles, summaries and keywords those repositories
 maintain. Results are grouped by area, documentation first, and a sample hit
 opens that sample's own page in the catalogue.
 
+**The box states the type it would otherwise inherit.** Every rule inside the
+panel is identical to `.search-panel`'s in `catalogue.css` — and the two still
+rendered differently, because what a rule does not state is inherited, and the
+two documents have different bodies (16px on 24px here, 14px on 1.55 there). A
+result row came out 67px tall on one side and 59 on the other. So
+`.a2ui5-search-panel` carries `font-size: 14px; line-height: 1.55` itself, the
+input and the Esc button carry `font: inherit` (a form control inherits
+nothing, and the query was set in Arial), and the ring on `:focus-visible` is
+drawn for what you TAB to and not for the field, which is focused on every
+open. One box on four documents cannot depend on which document it opened over.
+
 The index is generated, gitignored and fetched lazily — nothing is loaded until
 somebody types. The matching is `theme/search-engine.js`, deliberately
 framework-free: the other three bars are static HTML and carry a copy of it,

--- a/docs/.vitepress/theme/SearchBox.vue
+++ b/docs/.vitepress/theme/SearchBox.vue
@@ -97,7 +97,13 @@ const SUGGESTIONS = ['table', 'dialog', 'value help', 'upload', 'chart', 'naviga
  * has always taken either (`metaKey || ctrlKey`); only the label was wrong. */
 const APPLE = typeof navigator !== 'undefined'
   && /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || '');
-const META = APPLE ? '⌘' : 'Ctrl';
+/* ONE KEY CAP, NOT TWO PUSHED TOGETHER. This was `⌘`/`Ctrl` and `K` as two
+ * adjacent <kbd>s with nothing between them, which renders as "CtrlK" - a key
+ * nobody has. The catalogue's row has been one cap reading "Ctrl K" since it
+ * was written (`hint(" from anywhere", ["/", apple ? "⌘K" : "Ctrl K"], true)`
+ * in src/shell/search-box.mjs); this is that, and the " or " before it is
+ * already in the markup. */
+const META = APPLE ? '⌘K' : 'Ctrl K';
 function suggest(word) {
   query.value = word;
   input.value?.focus();
@@ -292,7 +298,7 @@ const parts = (text) => highlight(text, query.value);
           <span><kbd>↑</kbd><kbd>↓</kbd> to move</span>
           <span><kbd>↵</kbd> to open</span>
           <span><kbd>esc</kbd> to close</span>
-          <span class="a2ui5-search-keys-end"><kbd>/</kbd> or <kbd>{{ META }}</kbd><kbd>K</kbd> from anywhere</span>
+          <span class="a2ui5-search-keys-end"><kbd>/</kbd> or <kbd>{{ META }}</kbd> from anywhere</span>
         </div>
       </div>
     </div>

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2230,6 +2230,21 @@
   background: var(--bg);
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.25);
   overflow: hidden;
+  /* THE BOX CARRIES ITS OWN TYPE, and it is the catalogue's.
+   *
+   * Every rule inside this panel is identical to `.search-panel`'s in
+   * src/catalogue/catalogue.css - the padding, the sizes, the radii, all of
+   * it - and the two still rendered differently, because what a rule does not
+   * state is INHERITED, and the two documents have different bodies: 16px on
+   * 24px here (VitePress's), 14px on 1.55 there. Measured with the same index
+   * behind both: a result row came out 67px tall here and 59 there, and a hit
+   * summary took a 24px line here against 19.375 there - the same 12.5px
+   * text.
+   *
+   * So the panel states what it inherits. One box on four documents means the
+   * box cannot depend on which document it opened over. */
+  font-size: 14px;
+  line-height: 1.55;
 }
 
 .a2ui5-search-field {
@@ -2252,7 +2267,17 @@
   border: 0;
   background: transparent;
   color: var(--fg);
+  /* A form control does not inherit type - it starts from the browser's own,
+     which is Arial. The query was set in a different face from every result
+     under it, and from the same box on the catalogue, which has carried
+     `font: inherit` all along. */
+  font: inherit;
   font-size: 16px;
+  /* The browser's own padding for a text field, which is what the catalogue's
+     box keeps - this theme resets form controls to 0 and the field came out
+     2px shorter than the same field over there. Not a designed number on
+     either side; it is simply the one the two have to agree on. */
+  padding: 1px 2px;
   outline: none;
 }
 
@@ -2266,6 +2291,7 @@
   border-radius: 4px;
   background: var(--bg-sunken);
   color: var(--fg-dim);
+  font: inherit; /* a button does not inherit type either */
   font-size: 11px;
   cursor: pointer;
 }
@@ -2580,9 +2606,21 @@
   .a2ui5-search-keys-end { display: none; }
 }
 
+/* A ring on what you TAB to, and not on the field.
+ *
+ * The input is focused the moment the box opens, and `/` is a keyboard
+ * action, so `:focus-visible` fired every single time - a blue rectangle
+ * around the field on every open, saying what the caret blinking inside it
+ * already said. The catalogue's box never drew it; this one did, and that was
+ * the last thing that made the two look different.
+ *
+ * The links and the Esc button keep theirs: those are reached by tabbing, and
+ * there a ring is the only thing that says where you are. The catalogue now
+ * draws the same one (`.search-scrim` in src/catalogue/catalogue.css) - this
+ * pair was made identical by ADDING it there rather than by dropping it
+ * here. */
 .a2ui5-search-scrim a:focus-visible,
-.a2ui5-search-scrim button:focus-visible,
-.a2ui5-search-scrim input:focus-visible {
+.a2ui5-search-scrim button:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: var(--radius-control);


### PR DESCRIPTION
Every rule inside the panel is already identical to the catalogue's, line for line — the padding, the sizes, the radii, the shadow — and the two still rendered differently. **What a rule does not state is inherited**, and the two documents have different bodies: 16px on 24px here, 14px on 1.55 there.

Measured with the same index served to both (the sample pages fetch it from the shared origin, so a local comparison has to route it), searching for `table`:

| | before | after |
|---|---|---|
| result row | 67px vs 59px | 59 / 59 |
| hit summary line | 24px vs 19.375px — the same 12.5px text | 19.375 / 19.375 |
| field row | 55px vs 52px | 52 / 52 |
| input face | **Arial** vs the site face | the site face on both |

So `.a2ui5-search-panel` carries `font-size: 14px; line-height: 1.55` itself, and the input and the Esc button carry `font: inherit` — a form control inherits nothing and starts from the browser's own face, so the query was set in Arial while every result under it was not. The input also takes the browser's `1px 2px` padding, which this theme resets to 0 and the catalogue keeps: not a designed number on either side, just the one the two have to agree on.

## Two more, both visible

- The shortcut in the key row was two `<kbd>`s pushed together and rendered **"CtrlK"**, a key nobody has. It is one cap reading "Ctrl K" — which is what the catalogue has said since it was written, comment and all.
- The focus ring fired on the **input** on every single open: `/` is a keyboard action and the field is focused immediately, so a blue rectangle appeared to say what the caret already said. It is now drawn for what you **tab** to — the result links and the Esc button — where a ring is the only thing that says where you are. The catalogue gains the same rule in its own commit, so the pair was made identical by *adding* it there rather than by dropping it here.

## What was already identical

Worth recording, because it is the part that matters most: **the matching**. Same index, same ranking, same grouping — `Documentation 8 of 95`, `Controls 8 of 99`, `Samples 8 of 28`, `Stack 8 of 9`; the same 32 hits in the same order; the same row marked after two arrow keys, scrolled into view. `search-engine.js` and `search-engine.mjs` differ only in comment wording, quote style and one `globalThis.localStorage?.` in place of a `typeof` guard.

## Verification

`npm run check` — all eleven gates, 123 tests. The panel comparison is 15 measured properties, all matching; the sixteenth (`closedByEscape`) reads differently only because the Vue app unmounts the panel while the static page hides it — checked directly: after Escape the catalogue's scrim is `hidden` with `display: none` and the panel has zero height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_