### PR TITLE
The manual is written by a script now, and that is what gets published

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -101,7 +101,20 @@ jobs:
         if: ${{ !cancelled() }}
         run: npm run check:version
 
-      # a page that does not build is a page nobody can read
+      # THE SITE THAT IS PUBLISHED. scripts/build-site.mjs writes all 166 pages
+      # as static HTML - no Vue, no router, no theme - and refuses to finish on
+      # a dead internal link. It takes the bar and the catalogue's two
+      # stylesheets from the published playground when no built checkout is at
+      # hand, which is the case here.
+      - name: build the site
+        if: ${{ !cancelled() }}
+        run: npm run build
+
+      # ...and VitePress's build beside it, which is no longer published. It is
+      # the second opinion the cross-site gate below judges, because that gate
+      # is about VitePress's ROUTER and the published site has none - see the
+      # note on DIST in scripts/check-cross-site.mjs. A page that does not
+      # build is still a page nobody can read.
       - name: vitepress build
         if: ${{ !cancelled() }}
         run: npm run docs:build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,12 @@ on:
   # that mattered was never the one connected to the deploy.
   pull_request:
 
+  # ...and by hand, which there was no way to do. A pull request whose run
+  # never got created - GitHub does not always raise the event when a branch
+  # has just been recreated under an open pull request - left the twelve gates
+  # with no way to be asked again short of pushing something. This is that way.
+  workflow_dispatch:
+
 concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@
 # So the gates run here, in the job that publishes, and the build only follows
 # a green one. check.yml keeps them for pull requests; it no longer runs on
 # main, because this is that run.
-name: Deploy VitePress site to Pages
+name: Deploy the site to Pages
 
 on:
   # Runs on pushes targeting the `main` branch. Change this to `master` if you're
@@ -147,6 +147,18 @@ jobs:
       # …and only then the thing that gets published. `docs:build` is itself
       # one of the gates - a page that does not build is a page nobody can
       # read - so it stays a build step rather than being listed twice.
+      # THE SITE THAT IS PUBLISHED. scripts/build-site.mjs writes all 166 pages
+      # as static HTML - no Vue, no router, no theme - and refuses to finish on
+      # a dead internal link. It takes the bar and the catalogue's two
+      # stylesheets from the published playground when no built checkout is at
+      # hand, which is the case here.
+      - name: Build the site
+        run: npm run build
+
+      # ...and VitePress's build beside it, which is no longer published. It is
+      # the second opinion the cross-site gate below judges, because that gate
+      # is about VitePress's ROUTER and the published site has none - see the
+      # note on DIST in scripts/check-cross-site.mjs.
       - name: Build with VitePress
         run: npm run docs:build
 
@@ -158,10 +170,13 @@ jobs:
       - name: cross-site links
         run: npm run check:cross-site
 
+      # WHAT GOES OUT IS scripts/build-site.mjs's OUTPUT, not VitePress's.
+      # `.site/docs` is the root of this deployment: the artefact's root is
+      # served at /docs/, which is what every absolute path inside it names.
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: docs/.vitepress/dist
+          path: .site/docs
 
   # Deployment job
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ docs/public/**/*.md
 # a search with a page that has moved.
 docs/public/search-index.json
 
-# Where scripts/prototype-site.mjs writes. A prototype's output is not a build
-# and is never committed; the generator rewrites it from scratch each run.
+# Where `npm run build` writes - scripts/build-site.mjs, the site that is
+# published. Rewritten from scratch on every run, so never committed.
+.site/
+# VitePress still builds in CI as a second opinion; its output is not published
+# any more and is not committed either.
 .prototype/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 npm run check          # test + check:version + docs:build + check:cross-site + check:design + check:examples + check:conventions + check:playground + check:api-names + check:api-reference + check:samples
 ```
 
-A documentation repository has no compiler for its prose, but eleven things in
-it are decidable, and all eleven are decided before a merge:
+A documentation repository has no compiler for its prose, but twelve things in
+it are decidable, and all twelve are decided before a merge:
 
 | | |
 |---|---|
@@ -71,7 +71,7 @@ page layout or the builder name is the likely cause. `check:cross-site` carries
 the same floor twice over: no HTML in `dist` at all, and no cross-site link on
 a site whose bar carries three of them on every page.
 
-The eleven are written out in **three** places, and all three have to name the
+The twelve are written out in **three** places, and all three have to name the
 same set: `package.json`'s `check` script, `.github/workflows/check.yml` for a
 pull request, and `.github/workflows/deploy.yml` before the site is published.
 `check.yml` runs them in the script's order; `deploy.yml` cannot, because it
@@ -358,39 +358,43 @@ deliberately paid above for a first paint that fetches nothing across a
 deployment. If that trade is ever re-opened, re-open it for the four copies of
 the bar, not for the links between the sites; those are one attribute.
 
-## The manual without VitePress, as a prototype
+## The site is written by a script, not rendered by a theme
 
-`scripts/prototype-site.mjs` builds this whole site — all 166 pages, the front
-door included — as static HTML in about six seconds, with no Vue, no router and
-no theme. **Nothing depends on it.** It is wired into no gate, no workflow
-publishes it, and `npm run check` neither runs it nor knows it exists. It is
-here to answer one question with a build rather than an argument: what the
-manual looks like, and what it costs, if its pages are generated the way the
-sample catalogue's are.
+`scripts/build-site.mjs` writes all 166 pages as static HTML in about seven
+seconds — no Vue, no router, no theme — and `npm run build` is what the deploy
+publishes. VitePress is still here and still builds in CI, as a second opinion
+and as the thing `check:cross-site` judges (see the note on `DIST` in that
+script); nothing serves it.
 
-The load-bearing finding is that VitePress's markdown renderer is a plain
-library. `createMarkdownRenderer` produces exactly the HTML the site ships —
-the `:::` blocks, the header anchors, Shiki in both themes, links already
-rewritten to `/docs/x.html` — and `md.render(src, env)` hands back the parsed
-frontmatter in `env`, nested keys and all. So this does not reimplement
-markdown; it replaces the FRAME around it.
+The load-bearing finding is that VitePress's markdown renderer works as a plain
+library. `createMarkdownRenderer` produces exactly the HTML the site used to
+ship — the `:::` blocks, the header anchors, Shiki in both themes, links
+already rewritten to `/docs/x.html` — and `md.render(src, env)` hands back the
+parsed frontmatter in `env`, nested keys and all. So this does not reimplement
+markdown; it replaces the FRAME around it. `docs/.vitepress/config.mjs` is
+still the single source of the sidebar and of the markdown transforms, read by
+both builds.
 
-What it borrows, at build time, from a playground checkout (the same three
-places `check:design` looks — `PLAYGROUND_HOME`, `.playground`, `../playground`):
-the bar, lifted out of a BUILT sample page; `catalogue.css` and `sample.css`;
-and `search.mjs`, which is the same file all 772 sample pages load. The search
-box in this bar is therefore not a second implementation of that one — it is
-that one, mounting into the `[data-search]` slot the borrowed bar already
-carries and reading the index this repository publishes. Measured against a
-sample page with the same index: 12 of 12 panel values identical.
+**What it borrows.** The bar, `catalogue.css`, `sample.css` and `search.mjs`
+come from the playground: from a BUILT checkout when there is one
+(`PLAYGROUND_HOME`, `.playground`, `../playground` — the three `check:design`
+looks in), and otherwise over the network from the published site, which is
+what CI uses. `PLAYGROUND_URL` forces the fetched path, which is how it is
+exercised without waiting for CI to be its first run. The search box is
+therefore not a second implementation of the catalogue's — it is the same file,
+mounting into the `[data-search]` slot the borrowed bar already carries.
 
-What it owns: `scripts/prototype-css/docs.css` (the manual's own layer over the
-catalogue's two) and `scripts/prototype-js/site.js`, which calls the four theme
-modules that were already framework-free — the Run button, the line numbers and
+**What it owns.** `scripts/site-css/docs.css` (the manual's own layer over the
+catalogue's two) and `scripts/site-js/site.js`, which calls the four modules in
+`theme/` that were always framework-free: the Run button, the line numbers and
 their addresses, the link to a selection, the position memory. `theme/index.js`
 was the only Vue in front of them.
 
-Two things to know before touching it:
+**The build is itself a gate.** It refuses to finish on a dead internal link —
+33,275 of them are checked on every run — which is what VitePress's own build
+did for us.
+
+Three things to know before touching it:
 
 - **Borrowing a stylesheet takes its class names with it.** `.brand` is the
   catalogue's mark at the left end of the bar and carries a `::after` divider;
@@ -402,9 +406,15 @@ Two things to know before touching it:
   because a third grid track can only exist by taking width out of the article
   — which is what put the manual's prose on a different vertical from the
   catalogue's.
+- **Every page carries its own head.** Title, description, canonical, and the
+  six og/twitter values, all with absolute urls: a relative `og:url` is
+  silently dropped and the preview falls back to a grey card. That is what
+  `transformPageData` used to do and what `meta( )` does now.
 
-Still missing, and the build says so when it finishes: code-group tabs, and
-prev/next under an article.
+Verified against the VitePress build the day it was switched: 168 pages, ten
+content features each — headings, listings, tables, `:::` blocks, list items,
+Run buttons, code groups, external links — and one difference in 1,680
+comparisons, which is the 404 page gaining the bar.
 
 ## Things that will trip you up
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
 All project guidance lives in **[AGENTS.md](AGENTS.md)** — the single source of
-truth for this repository (how the site is built, the eleven gates, the playground rule engine, and what may be written where).
+truth for this repository (how the site is built, the twelve gates, the playground rule engine, and what may be written where).
 
 Read `AGENTS.md` before making any change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,4 @@ Nothing here is a source of truth about the framework: the API reference, the
 sample catalogue and the corpus figures are generated or checked against
 `abap2UI5`, `abap2UI5/samples` and its siblings. If a fact is wrong, it is
 usually wrong there first. [AGENTS.md](AGENTS.md) is the full contract — how
-the site is built, the eleven gates, and what may be written where.
+the site is built, the twelve gates, and what may be written where.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Every contribution makes the documentation better for the community!
 ```sh
 npm ci
 npm run docs:dev     # the site, with hot reload
-npm run check        # what CI runs, all eleven steps
+npm run check        # what CI runs, all twelve steps
 ```
 
 ### What CI checks
 
-A documentation repository has no compiler for its prose, but eleven things in
-it are decidable, and `npm run check` decides all eleven before a merge — the
+A documentation repository has no compiler for its prose, but twelve things in
+it are decidable, and `npm run check` decides all twelve before a merge — the
 prose builds (`docs:build`), the four bars are still made of the same palette,
 type and radii as the playground's (`check:design`), every link into a
 neighbouring site on this origin
@@ -45,7 +45,7 @@ passed. Several of these go stale without anybody touching this repository (a
 release is published elsewhere, a sample class is renamed elsewhere), which is
 why the deploy re-runs them rather than trusting the merge.
 
-**[AGENTS.md](AGENTS.md) describes each of the eleven**, what a failure means and
+**[AGENTS.md](AGENTS.md) describes each of the twelve**, what a failure means and
 which of them need a sibling checkout to say anything at all — read it before
 changing anything beyond prose.
 

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "link:samples": "node scripts/link-samples.mjs",
     "check:samples": "node scripts/link-samples.mjs --check",
     "test": "node --test test/*.test.mjs",
-    "check": "npm run test && npm run check:version && npm run docs:build && npm run check:cross-site && npm run check:design && npm run check:examples && npm run check:conventions && npm run check:playground && npm run check:api-names && npm run check:api-reference && npm run check:samples",
+    "check": "npm run test && npm run check:version && npm run build && npm run docs:build && npm run check:cross-site && npm run check:design && npm run check:examples && npm run check:conventions && npm run check:playground && npm run check:api-names && npm run check:api-reference && npm run check:samples",
     "llms": "node scripts/generate-llms.mjs",
     "search": "node scripts/generate-search.mjs",
-    "check:version": "node scripts/check-version.mjs"
+    "check:version": "node scripts/check-version.mjs",
+    "build": "node scripts/generate-llms.mjs && node scripts/generate-search.mjs && node scripts/build-site.mjs .site"
   },
   "devDependencies": {
     "@abap2ui5/linter": "^0.6.1",

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -18,7 +18,7 @@
  * no Vue, no router and no theme. So this does not reimplement markdown; it
  * replaces the FRAME around it.
  *
- *   node scripts/prototype-site.mjs [out-dir]
+ *   node scripts/build-site.mjs [out-dir]
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -69,28 +69,76 @@ pages.sort();
  * The bar comes from a BUILT sample page rather than from the generator that
  * writes it, because what ships is the thing to copy. */
 const HOMES = ['PLAYGROUND_HOME', '.playground', '../playground'];
-const playground = HOMES
+/* An explicit PLAYGROUND_URL wins over any checkout: it is how the fetched
+   path is exercised without waiting for CI to be the first run of it. */
+const playground = process.env.PLAYGROUND_URL ? null : HOMES
   .map((d) => (d.endsWith('_HOME') ? process.env[d] : path.join(ROOT, d)))
-  .find((at) => at && fs.existsSync(path.join(at, 'src', 'catalogue', 'catalogue.css')));
-if (!playground) {
-  console.error('No playground checkout found (PLAYGROUND_HOME, .playground, ../playground).');
-  console.error('This prototype wears the catalogue\'s frame, so it needs the catalogue.');
-  process.exit(1);
-}
+  .find((at) => at && fs.existsSync(path.join(at, 'dist', 'samples', 'catalogue.css')));
 
-const built = path.join(playground, 'dist', 'samples');
-const anySample = fs.existsSync(built)
-  && fs.readdirSync(built, { withFileTypes: true }).find((e) => e.isDirectory() && e.name.startsWith('z2ui5_'));
-if (!anySample) {
-  console.error(`No built sample pages under ${built} — run \`npm run build\` in the playground first.`);
-  process.exit(1);
-}
+const PUBLISHED = (process.env.PLAYGROUND_URL || 'https://abap2ui5.github.io/playground').replace(/\/$/, '');
+
+/** The four files of the frame, from a built checkout or from the site.
+ *
+ * A checkout is the fast path and the one to use while working: `PLAYGROUND_HOME`,
+ * `.playground`, `../playground`, the same three `check:design` looks in - and
+ * it has to be BUILT, because two of the four (`sample.css`, `search.mjs`) are
+ * build outputs and the bar is lifted from a page the build writes.
+ *
+ * Without one, they come off the published site. That is not a fallback so
+ * much as the arrangement CI uses: cloning and building the playground to
+ * publish a page of this manual would be an hour of UI5 for four files, and
+ * what those four files are is exactly what is deployed. `check:design`
+ * already reaches for the published copy the same way when there is no
+ * checkout, for the same reason.
+ *
+ * The bar comes from a per-sample page rather than the catalogue's index,
+ * because those are written by the build with `../../` in front of every
+ * shared asset - one rewrite turns all of them absolute. Which sample does not
+ * matter and is not hard-coded: the first one the sitemap names.
+ */
+const fetchText = async (url) => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${url}`);
+  return res.text();
+};
+
+const frame = await (async () => {
+  if (playground) {
+    const built = path.join(playground, 'dist', 'samples');
+    const sample = fs.readdirSync(built, { withFileTypes: true })
+      .find((e) => e.isDirectory() && e.name.startsWith('z2ui5_'));
+    if (!sample) throw new Error(`no built sample pages under ${built} — run \`npm run build\` in the playground`);
+    const file = (n) => fs.readFileSync(path.join(built, n), 'utf8');
+    return {
+      from: built,
+      page: fs.readFileSync(path.join(built, sample.name, 'index.html'), 'utf8'),
+      files: { 'catalogue.css': file('catalogue.css'), 'sample.css': file('sample.css'), 'search.mjs': file('search.mjs') },
+    };
+  }
+  const sitemap = await fetchText(`${PUBLISHED}/sitemap.xml`);
+  /* The PATH out of the sitemap, not the url in it: the sitemap names the
+     published origin, and this may be pointed at a local copy of the same
+     tree (PLAYGROUND_URL) to exercise exactly this path. */
+  const one = sitemap.match(/<loc>[^<]*(\/samples\/z2ui5_[a-z0-9_]+\/)<\/loc>/);
+  if (!one) throw new Error(`no per-sample page in ${PUBLISHED}/sitemap.xml to take the bar from`);
+  const [page, ...files] = await Promise.all([
+    fetchText(PUBLISHED + one[1]),
+    fetchText(`${PUBLISHED}/samples/catalogue.css`),
+    fetchText(`${PUBLISHED}/samples/sample.css`),
+    fetchText(`${PUBLISHED}/samples/search.mjs`),
+  ]);
+  return {
+    from: PUBLISHED,
+    page,
+    files: { 'catalogue.css': files[0], 'sample.css': files[1], 'search.mjs': files[2] },
+  };
+})();
+
 const BAR = (() => {
-  const src = fs.readFileSync(path.join(built, anySample.name, 'index.html'), 'utf8');
-  const m = src.match(/<header class="bar">[\s\S]*?<\/header>/);
-  if (!m) throw new Error('no bar in the built sample page');
+  const m = frame.page.match(/<header class="bar">[\s\S]*?<\/header>/);
+  if (!m) throw new Error(`no bar in the sample page from ${frame.from}`);
   return m[0]
-    .replace(/(?:href|src)="\.\.\/\.\.\//g, (t) => t.slice(0, -6) + 'https://abap2ui5.github.io/playground/')
+    .replace(/(?:href|src)="\.\.\/\.\.\//g, (t) => t.slice(0, -6) + `${PUBLISHED}/`)
     .replace(/ aria-current="page"/g, '');
 })();
 
@@ -157,18 +205,58 @@ function crumbsFor(page) {
     .join('');
 }
 
-const shell = ({ title, main, bar }) => `<!doctype html>
+/* ---- the head ---------------------------------------------------------
+ *
+ * The whole of it, per page, because a link to a chapter that previews as the
+ * site's front page is a link nobody clicks. What is here is what the theme
+ * and `transformPageData` used to put there between them: the title, the
+ * description, the canonical url, and the six og/twitter values that decide
+ * what LinkedIn, Slack and WhatsApp draw. Those four take ABSOLUTE urls - a
+ * relative one is silently dropped and the preview falls back to a grey card -
+ * which is what SITE_URL is for. */
+const SITE_URL = 'https://abap2ui5.github.io/docs';
+const OG_IMAGE = `${SITE_URL}/og-image.png`;
+const SITE_DESC = 'Build UI5 Apps Purely in ABAP';
+
+const meta = ({ page, title, description }) => {
+  const url = `${SITE_URL}/${page}`.replace(/index\.md$/, '').replace(/\.md$/, '.html');
+  return [
+    ['link', { rel: 'canonical', href: url }],
+    ['meta', { name: 'description', content: description }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:site_name', content: 'abap2UI5' }],
+    ['meta', { property: 'og:url', content: url }],
+    ['meta', { property: 'og:title', content: title }],
+    ['meta', { property: 'og:description', content: description }],
+    ['meta', { property: 'og:image', content: OG_IMAGE }],
+    ['meta', { property: 'og:image:type', content: 'image/png' }],
+    ['meta', { property: 'og:image:width', content: '1200' }],
+    ['meta', { property: 'og:image:height', content: '630' }],
+    ['meta', { property: 'og:image:alt', content: 'abap2UI5 — Build UI5 Apps Purely in ABAP' }],
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'twitter:image', content: OG_IMAGE }],
+    ['meta', { name: 'twitter:title', content: title }],
+    ['meta', { name: 'twitter:description', content: description }],
+  ].map(([tag, attrs]) => `<${tag} ${Object.entries(attrs)
+    .map(([k, v]) => `${k}="${esc(v)}"`).join(' ')}>`).join('\n');
+};
+
+const shell = ({ title, main, bar, head = '' }) => `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${esc(title)} | abap2UI5</title>
+<title>${esc(title)}</title>
+<link rel="shortcut icon" href="${BASE}favicon.ico">
+<link rel="apple-touch-icon" sizes="180x180" href="${BASE}favicon.ico">
+<link rel="preload" href="${BASE}fonts/inter-roman-latin.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="${BASE}catalogue.css">
 <link rel="stylesheet" href="${BASE}sample.css">
 <link rel="stylesheet" href="${BASE}docs.css">
 <script type="module" src="${BASE}site.js"></script>
 <script type="module" src="${BASE}search.mjs"></script>
 <script>try{var t=localStorage.getItem("abap2ui5-playground:theme");if(t==="dark"||t==="light")document.documentElement.dataset.theme=t}catch(e){}</script>
+${head}
 </head>
 <body>
 ${bar}
@@ -181,6 +269,41 @@ ${main}
 </body>
 </html>
 `;
+
+/* ---- what comes before and after ---------------------------------------
+ *
+ * The sidebar read as one list, in the order it is drawn, with the entries
+ * that only open a section (no link of their own) skipped. A reader working
+ * through the manual front to back has this and the menu; a reader who arrived
+ * from a search has only this. */
+const ORDER = (function flatten(items, out = []) {
+  for (const i of items) {
+    if (i.link) out.push({ text: i.text, link: i.link });
+    if (i.items) flatten(i.items, out);
+  }
+  return out;
+})(config.themeConfig.sidebar)
+  /* A section and its first page name the same link - "Cookbook" and "View"
+     both point at /cookbook/view/definition - and prev/next that walks the
+     same page twice reads as a broken button. First mention wins, which is the
+     section, because that is the name the crumb line uses too. */
+  .filter((row, at, all) => all.findIndex((o) => o.link === row.link) === at);
+
+const linkTo = (link) => BASE.slice(0, -1) + link + (link.endsWith('/') ? 'index.html' : '.html');
+
+function prevNextFor(route) {
+  const at = ORDER.findIndex((r) => r.link.replace(/\/$/, '') === route.replace(/\/$/, ''));
+  if (at < 0) return '';
+  const side = (row, which, arrow) => (row
+    ? `<a class="pn pn-${which}" href="${esc(linkTo(row.link))}">
+         <span class="pn-what">${which === 'prev' ? 'Previous' : 'Next'}</span>
+         <span class="pn-title">${arrow === 'l' ? '← ' : ''}${esc(row.text)}${arrow === 'r' ? ' →' : ''}</span>
+       </a>`
+    : '<span></span>');
+  return `<nav class="prev-next" aria-label="Previous and next page">
+    ${side(ORDER[at - 1], 'prev', 'l')}${side(ORDER[at + 1], 'next', 'r')}
+  </nav>`;
+}
 
 /** A chapter: the menu beside it, the crumb line, the article, the outline. */
 const chapter = ({ body, page, route }) => `<main class="manual">
@@ -196,6 +319,7 @@ const chapter = ({ body, page, route }) => `<main class="manual">
          target="_blank" rel="noopener">${esc(config.themeConfig.editLink?.text || 'Edit this page on GitHub')} ↗</a>
       <span class="updated">Last updated: ${new Date(fs.statSync(path.join(DOCS, page)).mtime).toISOString().slice(0, 10)}</span>
     </div>
+    ${prevNextFor(route)}
   </div>
   ${outlineFor(body)}
 </main>`;
@@ -270,11 +394,19 @@ for (const page of pages) {
     if (at.endsWith('/')) return `href="${at}index.html${rest}"`;
     return last.includes('.') ? all : `href="${at}.html${rest}"`;
   });
-  const title = fm.title || (src.match(/^#\s+(.+)$/m) || [, page])[1];
+  const name = fm.title || (src.match(/^#\s+(.+)$/m) || [, page])[1];
   const route = routeOf(page);
   const isHome = fm.layout === 'home';
+  /* The theme's own title template, and its own rule for the preview: a
+     chapter previews as itself, the front door as the project. */
+  const title = `${name} | abap2UI5`;
   const html = shell({
     title,
+    head: meta({
+      page,
+      title: isHome ? 'abap2UI5 — Build UI5 Apps Purely in ABAP' : title,
+      description: fm.description || SITE_DESC,
+    }),
     bar: isHome ? BAR_HOME : BAR_DOCS,
     main: isHome ? home({ body, fm }) : chapter({ body, page, route }),
   });
@@ -286,6 +418,36 @@ for (const page of pages) {
   headings += (body.match(/<h2 id=/g) || []).length;
   blocks += (body.match(/class="language-/g) || []).length;
 }
+
+/* ---- the page for a url that is not a page -----------------------------
+ *
+ * GitHub Pages answers anything it cannot find under this deployment with the
+ * 404.html at the root of the artefact, which is this. It carries the bar, so
+ * a reader who mistyped a chapter is one click from the four sections rather
+ * than on a white page with a sentence on it. */
+fs.writeFileSync(path.join(OUT, 'docs', '404.html'), shell({
+  title: 'Not found | abap2UI5',
+  head: meta({ page: '404.md', title: 'Not found | abap2UI5', description: SITE_DESC }),
+  bar: BAR_DOCS,
+  main: `<main class="manual">
+  <input class="side-open" type="checkbox" id="side-open">
+  ${sidebarFor('/404')}
+  <label class="side-scrim" for="side-open" aria-hidden="true"></label>
+  <div class="doc-body">
+    <label class="side-button" for="side-open" title="Chapters"><span>Chapters</span></label>
+    <p class="crumbs"><a href="${BASE}get_started/about.html">Documentation</a></p>
+    <div class="vp-doc">
+      <h1>This page is not here</h1>
+      <p>The address does not name a page of this manual. It may have been
+         renamed, or the link that brought you here may be old.</p>
+      <p>The menu beside this lists every chapter, the box in the bar searches
+         the manual and all ~770 samples at once, and
+         <a href="${BASE}get_started/about.html">In a Nutshell</a> is where the
+         manual starts.</p>
+    </div>
+  </div>
+</main>`,
+}));
 
 /* ---- what the pages need beside them --------------------------------- */
 const copyInto = (from, to) => {
@@ -307,7 +469,7 @@ const assets = copyInto(path.join(DOCS, 'public'), path.join(OUT, 'docs'));
    is not a second implementation of that one, it is that one, mounting into
    the `[data-search]` slot the borrowed bar already carries and reading the
    index this repository publishes. */
-for (const f of ['catalogue.css', 'sample.css', 'search.mjs']) fs.copyFileSync(path.join(built, f), path.join(OUT, 'docs', f));
+for (const [name, text] of Object.entries(frame.files)) fs.writeFileSync(path.join(OUT, 'docs', name), text);
 /* One adaptation to the borrowed stylesheet, and it is about DEPTH, not taste.
  * catalogue.css names the type as `../fonts/inter-…woff2`, which is right where
  * it lives: one directory down, in `dist/samples/`, beside `dist/fonts/`. Here
@@ -321,8 +483,8 @@ for (const f of ['catalogue.css', 'sample.css', 'search.mjs']) fs.copyFileSync(p
   if (!css.includes('../fonts/')) throw new Error('catalogue.css no longer names ../fonts/ - check what the type is now');
   fs.writeFileSync(at, css.replace(/\.\.\/fonts\//g, 'fonts/'));
 }
-fs.copyFileSync(path.join(ROOT, 'scripts', 'prototype-css', 'docs.css'), path.join(OUT, 'docs', 'docs.css'));
-fs.copyFileSync(path.join(ROOT, 'scripts', 'prototype-js', 'site.js'), path.join(OUT, 'docs', 'site.js'));
+fs.copyFileSync(path.join(ROOT, 'scripts', 'site-css', 'docs.css'), path.join(OUT, 'docs', 'docs.css'));
+fs.copyFileSync(path.join(ROOT, 'scripts', 'site-js', 'site.js'), path.join(OUT, 'docs', 'site.js'));
 /* The behaviour a page has beyond its markup was already framework-free in
    the theme - the Run button, the line numbers and their addresses, the link
    to a selection, the position memory between the four sites. `index.js` was
@@ -331,9 +493,43 @@ const THEME = path.join(DOCS, '.vitepress', 'theme');
 const modules = ['playground.js', 'code-lines.js', 'link-to-selection.js', 'text-fragment.js', 'site-memory.js'];
 for (const f of modules) fs.copyFileSync(path.join(THEME, f), path.join(OUT, 'docs', f));
 
+/* ---- every internal link, before anything is published -----------------
+ *
+ * The build this replaced had one (VitePress refuses to finish on a dead
+ * link), and a manual whose cross-references rot is a manual nobody trusts
+ * twice. Root-relative only: an external url is somebody else's uptime, and a
+ * relative one does not occur in what this writes.
+ *
+ * `/docs/x` with no extension counts as `/docs/x.html`, which is what GitHub
+ * Pages resolves it to - the pages themselves are rewritten to say so, and
+ * this is the net under that. */
+const dead = [];
+let checked = 0;
+(function sweep(dir) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const at = path.join(dir, e.name);
+    if (e.isDirectory()) { sweep(at); continue; }
+    if (!e.name.endsWith('.html')) continue;
+    const html = fs.readFileSync(at, 'utf8');
+    for (const m of html.matchAll(/(?:href|src)="(\/[^"]*)"/g)) {
+      const to = m[1].split('#')[0].split('?')[0];
+      if (!to) continue;
+      checked++;
+      const target = path.join(OUT, to);
+      if (fs.existsSync(target) || fs.existsSync(path.join(target, 'index.html'))
+        || fs.existsSync(`${target}.html`)) continue;
+      dead.push(`${at.slice(OUT.length)} -> ${m[1]}`);
+    }
+  }
+})(OUT);
+if (dead.length) {
+  console.error(`\n${dead.length} dead link(s) - nothing is published with these:`);
+  for (const d of [...new Set(dead)].slice(0, 25)) console.error(`   ${d}`);
+  process.exit(1);
+}
+
 const seconds = ((Date.now() - started) / 1000).toFixed(1);
-console.log(`${written} pages, ${headings} sections, ${blocks} code blocks, ${assets} files beside them — ${seconds}s`);
+console.log(`${written} pages, ${headings} sections, ${blocks} code blocks, ${assets} files beside them,`);
+console.log(`   ${checked} internal links, none of them dead — ${seconds}s`);
 console.log(`   ${OUT}/docs/`);
-console.log('\nStill missing, on purpose:');
-console.log('   code-group tabs (the renderer emits them, the tabs need a few lines of JS)');
-console.log('   prev/next under an article, and a dead-link check the build does today');
+console.log(`   frame from ${frame.from}`);

--- a/scripts/check-cross-site.mjs
+++ b/scripts/check-cross-site.mjs
@@ -16,7 +16,8 @@
 // what a reader clicks.
 //
 // Usage: node scripts/check-cross-site.mjs [--list]
-//   Needs docs/.vitepress/dist, so run it after `npm run docs:build`.
+//   Needs docs/.vitepress/dist, so run it after `npm run docs:build` - see the
+//   note on DIST below for why it is that build and not the published one.
 //   --list prints every cross-site link it found, by destination.
 
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
@@ -25,7 +26,22 @@ import { fileURLToPath } from 'node:url';
 import { crossSiteLinks, SITE } from './lib/cross-site.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const DIST = join(ROOT, 'docs/.vitepress/dist');
+/* WHICH BUILD THIS JUDGES, and why it is still VitePress's.
+ *
+ * What this gate is about is one specific failure: VitePress's ROUTER taking
+ * over a same-origin link that looks like a page of this site. The published
+ * site is written by scripts/build-site.mjs now and has no router - every link
+ * on it is an ordinary navigation - so the failure cannot happen there, and
+ * pointing this at that build would only have it object to the bar, which is
+ * the catalogue's markup and correct as it stands.
+ *
+ * Both builds render the same markdown, so judging VitePress's output still
+ * judges every link WE write, which is what the gate is for. It stops being
+ * meaningful on the day the VitePress build goes; that is the day to decide
+ * what replaces it, not before. `SITE_OUT` points it at another build. */
+const DIST = process.env.SITE_OUT
+  ? join(ROOT, process.env.SITE_OUT)
+  : join(ROOT, 'docs/.vitepress/dist');
 const LIST = process.argv.includes('--list');
 
 if (!existsSync(DIST)) {

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -485,3 +485,47 @@ details[open] > summary > .side-caret { transform: rotate(90deg); }
   display: inline-block; width: 1.05em; height: 1.05em;
   vertical-align: -.16em; color: var(--fg);
 }
+
+/* ---- what comes before and after --------------------------------------
+ *
+ * Under the article, over the same hairline the edit line uses. Two cells that
+ * keep their sides whether or not both are filled - the first page of the
+ * manual has no previous, and its Next has to stay on the right. */
+.prev-next {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+  margin-top: 14px;
+}
+.prev-next .pn {
+  display: block; padding: 10px 14px;
+  border: 1px solid var(--line); border-radius: var(--radius-surface);
+  color: var(--fg); text-decoration: none;
+}
+.prev-next .pn:hover { border-color: var(--accent); }
+.prev-next .pn-next { text-align: right; }
+.prev-next .pn-what { display: block; font-size: 11px; color: var(--fg-dim); }
+.prev-next .pn-title { display: block; font-size: 13px; font-weight: 600; color: var(--accent); }
+@media (max-width: 620px) { .prev-next { grid-template-columns: minmax(0, 1fr); } }
+
+/* ---- a code group -----------------------------------------------------
+ *
+ * The renderer emits a radio per tab, a label per radio and the blocks after
+ * them, with `active` on the first. The radios do the state; site.js moves the
+ * class, because the blocks are in a different container from the inputs and
+ * the sibling selector cannot reach across it. */
+.vp-code-group .tabs {
+  display: flex; flex-wrap: wrap; gap: 2px;
+  margin: 16px 0 0; padding: 0 4px;
+  border: 1px solid var(--line); border-bottom: 0; border-radius: 8px 8px 0 0;
+  background: var(--bg-sunken);
+}
+.vp-code-group .tabs input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+.vp-code-group .tabs label {
+  padding: 7px 10px 6px;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-dim); font-size: 12.5px; font-weight: 600; cursor: pointer;
+}
+.vp-code-group .tabs label:hover { color: var(--fg); }
+.vp-code-group .tabs input:checked + label { color: var(--accent); border-bottom-color: var(--accent); }
+.vp-code-group .tabs input:focus-visible + label { outline: 2px solid var(--accent); outline-offset: -2px; }
+.vp-code-group .blocks > div[class*="language-"] { display: none; margin: 0; border-radius: 0 0 8px 8px; }
+.vp-code-group .blocks > div[class*="language-"].active { display: block; }

--- a/scripts/site-js/site.js
+++ b/scripts/site-js/site.js
@@ -48,3 +48,16 @@ addEventListener('scroll', () => {
   pending = setTimeout(() => { pending = 0; rememberScroll(); }, 300);
 }, { passive: true });
 addEventListener('pagehide', () => rememberScroll());
+
+/* A code group: the renderer gives every tab a radio and marks the first block
+   `active`. The blocks sit in a container of their own, so no sibling selector
+   reaches from the checked radio to the block it belongs to - this does, once,
+   for every group on the page. */
+for (const group of document.querySelectorAll('.vp-code-group')) {
+  const tabs = [...group.querySelectorAll('.tabs input')];
+  const blocks = [...group.querySelectorAll('.blocks > div')];
+  group.addEventListener('change', () => {
+    const at = tabs.findIndex((t) => t.checked);
+    blocks.forEach((b, i) => b.classList.toggle('active', i === at));
+  });
+}

--- a/test/gates.test.mjs
+++ b/test/gates.test.mjs
@@ -1,5 +1,5 @@
 /*
- * The eleven gates are written out in three places. Do all three name the
+ * The twelve gates are written out in three places. Do all three name the
  * same set?
  *
  * `package.json`'s `check` script is what a contributor runs; check.yml is
@@ -88,13 +88,13 @@ test('check.yml keeps the script order, so a green run locally is a green run th
   assert.deepEqual(workflowGates('.github/workflows/check.yml'), scriptGates());
 });
 
-test('the documents say eleven, and there are eleven', () => {
+test('the documents say twelve, and there are twelve', () => {
   /* AGENTS.md, README.md, CONTRIBUTING.md and CLAUDE.md all count them in
-   * prose. A twelfth gate that left the four documents saying "eleven" is the
+   * prose. A thirteenth gate that left the four documents saying "twelve" is the
    * same drift as a gate missing from a workflow, one document over. */
   const gates = scriptGates();
-  assert.equal(gates.length, 11, `the count in the four documents is 11, the lists have ${gates.length}`);
+  assert.equal(gates.length, 12, `the count in the four documents is 12, the lists have ${gates.length}`);
   for (const doc of ['AGENTS.md', 'README.md', 'CONTRIBUTING.md', 'CLAUDE.md']) {
-    assert.match(read(doc), /eleven/, `${doc} counts the gates`);
+    assert.match(read(doc), /twelve/, `${doc} counts the gates`);
   }
 });


### PR DESCRIPTION
The prototype stops being one. `npm run build` writes all 166 pages as static HTML in about seven seconds — no Vue, no router, no theme — and the deploy uploads that instead of VitePress's output.

**VitePress stays.** It is still the markdown renderer, `config.mjs` is still the single source of the sidebar and of the markdown transforms, and its build still runs in CI as a second opinion. It is simply not what anybody is served.

## What was missing and is not any more

A prototype could leave these out; a site cannot.

| | |
|---|---|
| **every page's own head** | title, description, canonical and the six og/twitter values, all absolute — a relative `og:url` is silently dropped and the preview falls back to a grey card. This is what `transformPageData` did. |
| **prev/next** | the sidebar read as one list, in the order it is drawn, with section entries that name the same link as their first page counted once |
| **a 404** | with the bar on it, so a mistyped address is one click from the four sections rather than a sentence on a white page |
| **code groups** | the renderer emits the radios and the labels; the blocks live in a container of their own, so ten lines move the `active` class |
| **a dead-link check** | the build refuses to finish on one — 33,275 internal links on every run. VitePress's build did this for us. |

## The frame no longer needs a built playground at hand

The bar and the catalogue's `catalogue.css`, `sample.css` and `search.mjs` come from a built checkout when there is one and **over the network from the published site when there is not**, which is what CI has. `check:design` already reaches for the published copy the same way, for the same reason. The fetched path is not left for CI to run first: `PLAYGROUND_URL` points it at a local copy of the same tree, and that is how it was tested here.

## The twelfth gate

`npm run build` joins the eleven, in the script and in both workflows. `test/gates.test.mjs` compares the three lists and the four documents that count them in prose — it was red until all seven agreed.

`check:cross-site` stays on VitePress's build, deliberately. What it is about is VitePress's **router** taking over a same-origin link; the published site has no router, so the failure cannot happen there, and pointing the gate at the new build only had it object to the catalogue's bar. Both builds render the same markdown, so it still judges every link we write. The note on `DIST` says so, and says that the day the VitePress build goes is the day to decide what replaces it.

## Checked against the build it replaces

Page by page: **168 pages, ten content features each** — headings at three levels, listings, tables, `:::` blocks, list items, Run buttons, code groups, external links. **One difference in 1,680 comparisons**, and it is the 404 page gaining the bar.

Twelve gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_