### PR TITLE
Six things the switch had quietly changed, and the listings are the catalogue's now

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -137,9 +137,21 @@ const frame = await (async () => {
 const BAR = (() => {
   const m = frame.page.match(/<header class="bar">[\s\S]*?<\/header>/);
   if (!m) throw new Error(`no bar in the sample page from ${frame.from}`);
-  return m[0]
+  const bar = m[0]
     .replace(/(?:href|src)="\.\.\/\.\.\//g, (t) => t.slice(0, -6) + `${PUBLISHED}/`)
     .replace(/ aria-current="page"/g, '');
+  /* THE SAMPLES ITEM HAS TO SAY WHICH SECTION IT RESTORES.
+   *
+   * The bar is lifted from a per-sample page, where Samples is the section the
+   * reader is already IN - so it carries no `data-site`, because there is
+   * nothing to come back to. Here it is one of the three places you leave for,
+   * and without the attribute site.js has nothing to lift: pressing Samples
+   * opened the front of the catalogue however deep the reader had been. The
+   * `data-scope` is what the stored value is checked against, exactly as the
+   * Documentation item over there declares its own. */
+  const samples = `href="${PUBLISHED}/samples/"`;
+  if (!bar.includes(samples)) throw new Error(`the borrowed bar has no ${samples} to point at the catalogue`);
+  return bar.replace(samples, `${samples} data-site="samples" data-scope="${PUBLISHED}/samples/"`);
 })();
 
 /* WHICH OF THE FOUR THE READER IS ON. The bar names Home, Documentation,
@@ -175,24 +187,51 @@ function sidebarFor(route) {
   const same = (link) => link && link.replace(/\/$/, '') === route.replace(/\/$/, '');
   const holds = (i) => same(i.link) || (i.items || []).some(holds);
   const tree = (items, level) => items.map((i) => {
-    const on = same(i.link) ? ' class="here" aria-current="page"' : '';
+    /* ONE ROW IS MARKED, and it is the deepest one that names this page. A
+       section often points at its own first page - Model and Binding are the
+       same link - and marking both painted two rows in the accent, which is
+       one more than the colour means. */
+    const on = same(i.link) && !(i.items || []).some(holds) ? ' class="here" aria-current="page"' : '';
     const href = i.link ? `${BASE.slice(0, -1)}${i.link}${i.link.endsWith('/') ? 'index.html' : '.html'}` : null;
     const label = href ? `<a href="${esc(href)}"${on}>${esc(i.text)}</a>` : `<span>${esc(i.text)}</span>`;
     if (!i.items) return `<div class="side-item level-${level}">${label}</div>`;
-    return `<details class="side-group level-${level}"${holds(i) ? ' open' : ''}>`
+    return `<details class="side-group level-${level}" data-key="${esc(i.link || i.text)}"${holds(i) ? ' open' : ''}>`
       + `<summary><span class="side-caret" aria-hidden="true"></span>${label}</summary>`
       + `<div class="side-items">${tree(i.items, level + 1)}</div></details>`;
   }).join('');
   return `<nav class="sidebar" aria-label="Documentation">${tree(config.themeConfig.sidebar, 0)}</nav>`;
 }
 
+/* WHICH HEADINGS THE OUTLINE LISTS is the theme's setting, not a number here:
+ * `themeConfig.outline` is [2, 6] on this site, and a page whose sections are
+ * h3 under one h2 - which several chapters of the cookbook are - had an
+ * outline of one row and therefore none at all. A sample page's outline is one
+ * level deep because its headings are; the manual's is not.
+ *
+ * The rows are flat in the markup, as the catalogue's are, and the depth is a
+ * class the stylesheet indents. */
+const LEVELS = (() => {
+  const o = config.themeConfig.outline;
+  if (o === 'deep') return [2, 6];
+  if (typeof o === 'number') return [o, o];
+  if (Array.isArray(o)) return [o[0], o[1]];
+  return [2, 2];
+})();
+
 function outlineFor(html) {
-  const rows = [...html.matchAll(/<h2 id="([^"]+)"[^>]*>([\s\S]*?)<a class="header-anchor"/g)]
-    .map((m) => ({ id: m[1], text: m[2].replace(/<[^>]*>/g, '').trim() }));
+  const rows = [...html.matchAll(/<h([2-6]) id="([^"]+)"[^>]*>([\s\S]*?)<a class="header-anchor"/g)]
+    .map((m) => ({ level: Number(m[1]), id: m[2], text: m[3].replace(/<[^>]*>/g, '').trim() }))
+    .filter((r) => r.level >= LEVELS[0] && r.level <= LEVELS[1]);
   if (rows.length < 2) return '';
+  /* The indent is relative to the SHALLOWEST heading on this page, not to h2.
+     Several chapters put their sections in h3 under a single h2, and measured
+     against h2 every row of those outlines started 13px in - an indent under
+     nothing, which reads as a mistake rather than as a level. Where nothing is
+     nested, the column is flat and identical to a sample page's. */
+  const top = Math.min(...rows.map((r) => r.level));
   return `<aside class="outline" aria-label="On this page">
     <div class="outline-head">On this page</div>
-    <nav>${rows.map((r) => `<a href="#${r.id}">${esc(r.text)}</a>`).join('')}</nav>
+    <nav>${rows.map((r) => `<a href="#${r.id}"${r.level > top ? ` class="lvl-${r.level - top + 2}"` : ''}>${esc(r.text)}</a>`).join('')}</nav>
   </aside>`;
 }
 
@@ -368,6 +407,56 @@ const home = ({ body, fm }) => {
 </main>`;
 };
 
+/* ---- the listings, in the colours a sample page prints ABAP in ---------
+ *
+ * Shiki hands every token an inline `--shiki-light` / `--shiki-dark` pair from
+ * the github themes, which is a scheme of its own: functions purple, types
+ * blue, seven colours in all. A per-sample page over in the catalogue prints
+ * the SAME ABAP in four - keywords red, literals green, numbers purple,
+ * comments grey and italic, everything else the body colour - written into the
+ * markup at build time by tools/abap-highlight.mjs and coloured by
+ * `catalogue.css`, which this site already loads.
+ *
+ * So the pair is swapped for the class the catalogue styles. The colours then
+ * come from ONE place for both documents, light and dark, and this file states
+ * no hex at all.
+ *
+ * Three of the seven are decided by the token TEXT rather than by its colour,
+ * because github gives `constant` to three things the catalogue tells apart:
+ * `42` is a number, `|` and `{` in a string template are part of the string,
+ * and `string` after TYPE is an ordinary word. Verified against the
+ * catalogue's own highlighter, run over the same lines.
+ *
+ * An unknown colour STOPS THE BUILD. A Shiki release that adds one would
+ * otherwise silently print that token in the body colour, and nobody would
+ * look at a listing again to notice. */
+const INK = {
+  '#D73A49': () => 'code-key',      // keywords
+  '#032F62': () => 'code-string',   // string literals
+  '#6A737D': () => 'code-comment',  // comments
+  '#24292E': () => '',              // the body colour: no class at all
+  '#6F42C1': () => '',              // a class or method NAME is plain over there
+  '#22863A': () => '',              // an XML tag name, likewise
+  '#E36209': () => '',              // a parameter, likewise
+  '#005CC5': (text) => {
+    const t = text.trim();
+    if (!t) return '';
+    if (/^[0-9]+(\.[0-9]+)?$/.test(t)) return 'code-number';
+    if (/^[|{}]+$/.test(t)) return 'code-string';   // a string template's own marks
+    return '';
+  },
+};
+
+const recolour = (html) => html.replace(
+  /<span style="--shiki-light:(#[0-9A-F]{6});--shiki-dark:#[0-9A-F]{6}">([^<]*)<\/span>/g,
+  (all, light, text) => {
+    const of = INK[light];
+    if (!of) throw new Error(`the highlighter used ${light}, which no catalogue colour is named for`);
+    const cls = of(text);
+    return cls ? `<span class="${cls}">${text}</span>` : text;
+  },
+);
+
 /* ---- run ------------------------------------------------------------- */
 const md = await createMarkdownRenderer(DOCS, config.markdown || {}, BASE);
 fs.rmSync(OUT, { recursive: true, force: true });
@@ -384,6 +473,7 @@ for (const page of pages) {
      and only for paths that are root-relative and not already based - which
      is what the theme was quietly doing for us. */
   body = body.replace(/(\b(?:src|href)=")\/(?!docs\/)([^"]*)"/g, `$1${BASE}$2"`);
+  body = recolour(body);
   /* And a page written by hand as `/docs/resources/addons` gets its `.html`.
      VitePress resolves that in the router, and GitHub Pages happens to resolve
      it too, by trying `<path>.html` - so it was never broken on the site and

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -172,7 +172,14 @@
 .sidebar > .side-group > summary,
 .sidebar > .side-item > a,
 .sidebar > .side-item > span { color: var(--fg); font-weight: 600; padding-top: 14px; }
-.sidebar > .side-group > summary a { color: inherit; font-weight: inherit; }
+/* A LINK IN THE MENU IS NOT A LINK-COLOURED LINK. Every row here is one, so
+   colouring them the accent paints the whole column blue and the one you are
+   on stops standing out - which is the only thing the accent is for in this
+   list. The rule used to name only the top level (`.sidebar > .side-group`),
+   so `Cookbook` was quiet and `Model`, `Binding` and every other nested
+   section was not. Any depth now; `a.here` above is the exception. */
+.sidebar summary a,
+.sidebar summary a:hover { color: inherit; font-weight: inherit; }
 
 /* The triangle: 90 degrees when shut, pointing down when open, and it is the
    marker the browser would otherwise draw for us. */
@@ -238,11 +245,15 @@ details[open] > summary > .side-caret { transform: rotate(90deg); }
   color: var(--fg-dim); font-size: 11px;
 }
 .vp-doc div[class*="language-"] .copy { display: none; }
-.vp-doc .shiki span { color: var(--shiki-light); }
-:root[data-theme="dark"] .vp-doc .shiki span { color: var(--shiki-dark); }
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .vp-doc .shiki span { color: var(--shiki-dark); }
-}
+/* NOTHING HERE COLOURS A TOKEN. The three rules that used to - reading the
+   `--shiki-light` / `--shiki-dark` pair Shiki writes onto every span - are
+   gone with the pairs themselves: build-site.mjs swaps them for the classes
+   the catalogue styles (`code-key`, `code-string`, `code-number`,
+   `code-comment` in sample.css, over the three values catalogue.css declares).
+   One scheme for the manual and the 772 sample pages, in one place, and this
+   file states no colour at all. They also have to be gone rather than merely
+   unused: `.vp-doc .shiki span` outranks a bare `.code-key`, and with the
+   variable no longer set every listing was drawn in the body colour. */
 
 /* ---- the ::: blocks -------------------------------------------------- */
 .vp-doc .custom-block {
@@ -529,3 +540,29 @@ details[open] > summary > .side-caret { transform: rotate(90deg); }
 .vp-code-group .tabs input:focus-visible + label { outline: 2px solid var(--accent); outline-offset: -2px; }
 .vp-code-group .blocks > div[class*="language-"] { display: none; margin: 0; border-radius: 0 0 8px 8px; }
 .vp-code-group .blocks > div[class*="language-"].active { display: block; }
+
+/* A row of the outline one level deeper than the last. 13px, which is the
+   indent the theme used and which has no counterpart to copy from a sample
+   page: a sample's headings are all h2, so its outline is one level deep and
+   the manual's is not. */
+.manual .outline nav a.lvl-3 { padding-left: 13px; }
+.manual .outline nav a.lvl-4 { padding-left: 26px; }
+.manual .outline nav a.lvl-5 { padding-left: 39px; }
+.manual .outline nav a.lvl-6 { padding-left: 52px; }
+
+/* ---- two things the article's own rules were taking away ---------------
+ *
+ * `code` carries `font-family: monospace` from the browser itself, which
+ * OVERRIDES what it would inherit - so a listing was set in whatever the
+ * browser calls monospace rather than in the stack the four documents share.
+ * `.source-body code { font: inherit }` is how a sample page answers the same
+ * thing, and this is that line.
+ *
+ * And the line numbers: `.vp-doc a` colours every link in the article the
+ * accent, which outranks `.ln > a` in sample.css by nothing at all - the two
+ * are the same weight and this file loads second. A gutter of blue numbers
+ * beside the code is a column of links, which is what they are, but the point
+ * of a line number is to be read past. */
+.vp-doc pre code { font: inherit; background: inherit; }
+.vp-doc .ln > a { color: var(--fg-dim); }
+.vp-doc .ln > a:hover { color: var(--accent); }

--- a/scripts/site-js/site.js
+++ b/scripts/site-js/site.js
@@ -14,7 +14,7 @@
 import { setUpPlayground } from './playground.js';
 import { setUpCodeLines, watchCodeLines } from './code-lines.js';
 import { markDirective, setUpLinkToSelection } from './link-to-selection.js';
-import { rememberHere, rememberScroll, restoreScroll } from './site-memory.js';
+import { handOff, lastVisited, rememberHere, rememberScroll, restoreScroll } from './site-memory.js';
 
 /* The Run button under a runnable ABAP example, and "copy link to selection":
    one delegated listener each, for the whole document. */
@@ -61,3 +61,123 @@ for (const group of document.querySelectorAll('.vp-code-group')) {
     blocks.forEach((b, i) => b.classList.toggle('active', i === at));
   });
 }
+
+/* ---- the bar remembers where you were ---------------------------------
+ *
+ * THIS IS THE HALF THAT WAS MISSING. `rememberHere` above writes down which
+ * page of the manual the reader is on; what makes that worth writing is the
+ * OTHER side - the bar's Samples and Documentation items opening the page you
+ * left rather than the front of the section. The Vue bar did this in
+ * SiteNav.vue and it went with the theme; the borrowed bar carries the
+ * attributes (`data-site`, `data-scope`, `data-back`) and nothing was reading
+ * them.
+ *
+ * The href as it was WRITTEN is kept from the first lift, because after one
+ * the attribute is the page that was restored. `lastVisited` does the
+ * checking: a stored value is whatever anything on this origin put there, so
+ * it is resolved against this origin and kept only if it still falls inside
+ * the section the markup declares. */
+const written = new Map();
+function lift() {
+  for (const a of document.querySelectorAll('a[data-site]')) {
+    if (!written.has(a)) written.set(a, a.getAttribute('href'));
+    const href = written.get(a);
+    if (!href) continue;
+    a.href = lastVisited(a.dataset.site, href, a.dataset.scope || href);
+  }
+}
+lift();
+/* ...and again whenever it can have gone stale while this page stayed open:
+   shown again, looked at again, and on the click itself. */
+addEventListener('pageshow', lift);
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') lift();
+});
+document.addEventListener('click', (e) => {
+  if (e.target.closest?.('a[data-site]')) lift();
+}, true);
+
+/* Where on the page, not only which page. A bar link writes down how far down
+   this page the reader is AND where they are being sent; the page that arrives
+   within seconds, and only that page, puts them back (restoreScroll above). */
+document.addEventListener('click', (e) => {
+  const a = e.target.closest?.('a[data-back]');
+  if (!a) return;
+  rememberScroll();
+  handOff(a.href);
+}, true);
+
+/* ---- the outline says which section you are in ------------------------
+ *
+ * The same walk the per-sample pages do, case for case: the heading whose top
+ * has passed the line under the bar, `-1` above the first one because there is
+ * no section to be in there, and the last row once the page is scrolled to the
+ * end whether or not its heading ever crossed. */
+(function outline() {
+  const nav = document.querySelector('.outline nav');
+  if (!nav) return;
+  const links = [...nav.querySelectorAll('a')];
+  const heads = links.map((a) => document.getElementById(decodeURIComponent(a.getAttribute('href').slice(1))));
+  if (!heads.length || heads.includes(null)) return;
+
+  /* The bar is 46px and sticky, plus the air a heading needs under it before
+     it counts as reached - the number the outline's own `top` uses. */
+  const LINE = 70;
+  let at = -1;
+  const mark = () => {
+    let last = -1;
+    if (window.scrollY >= 1) {
+      for (let i = 0; i < heads.length; i++) {
+        if (heads[i].getBoundingClientRect().top <= LINE) last = i;
+      }
+      if (window.innerHeight + window.scrollY >= document.body.scrollHeight - 2) last = heads.length - 1;
+    }
+    if (last === at) return;
+    if (at > -1) links[at].classList.remove('here');
+    if (last > -1) links[last].classList.add('here');
+    at = last;
+  };
+  let pending = false;
+  const schedule = () => {
+    if (pending) return;
+    pending = true;
+    requestAnimationFrame(() => { pending = false; mark(); });
+  };
+  mark();
+  addEventListener('scroll', schedule, { passive: true });
+  addEventListener('resize', schedule, { passive: true });
+})();
+
+/* ---- the chapter menu keeps the shape you left it in -------------------
+ *
+ * Every page is a fresh document here, so the sections the build opened - the
+ * one holding this page - were the only ones open, and every other section a
+ * reader had unfolded shut itself on the next click. What is written down is
+ * the set of sections that are OPEN, by the key the build gives each one.
+ *
+ * The section holding the current page is opened regardless of what is
+ * stored: it is where the reader is, and a menu that hid it would be worse
+ * than one that forgets. */
+(function tree() {
+  const KEY = 'abap2ui5-playground:docs-tree';
+  const groups = [...document.querySelectorAll('.sidebar details[data-key]')];
+  if (!groups.length) return;
+  const read = () => {
+    try {
+      const v = JSON.parse(localStorage.getItem(KEY) || '[]');
+      return Array.isArray(v) ? new Set(v.filter((k) => typeof k === 'string')) : null;
+    } catch { return null; }
+  };
+  const open = read();
+  if (open) for (const g of groups) g.open = open.has(g.dataset.key);
+  /* ...and the way to where you are, whatever was stored. */
+  const here = document.querySelector('.sidebar a.here');
+  if (here) for (let el = here.closest('details'); el; el = el.parentElement?.closest('details')) el.open = true;
+
+  const write = () => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(groups.filter((g) => g.open).map((g) => g.dataset.key)));
+    } catch { /* a browser that refuses storage keeps the build's own shape */ }
+  };
+  for (const g of groups) g.addEventListener('toggle', write);
+})();


### PR DESCRIPTION
Reported by a reader, one at a time — which is the right way to find them and the wrong way to have shipped them.

## The listings are printed in the catalogue's four colours

Shiki hands every token an inline `--shiki-light`/`--shiki-dark` pair out of the github themes: functions purple, types blue, seven colours in all. A per-sample page sets the same ABAP in four — keywords red, literals green, numbers purple, comments grey and italic, everything else the body colour.

So the pair is swapped for the class `sample.css` already styles, and the colour then comes from **one place** for both documents; this repository states no hex at all. Measured against a sample page:

| | samples | docs |
|---|---|---|
| keyword | `rgb(160, 34, 34)` | identical |
| literal | `rgb(21, 113, 58)` | identical |
| comment | `rgb(106, 109, 118)` | identical |
| the rest | `rgb(28, 29, 33)` | identical |

Three of the seven colours are decided by the token's **text**, because github gives `constant` to three things the catalogue tells apart: `42` is a number, `|` and `{` inside a string template belong to the string, and `string` after `TYPE` is an ordinary word. Checked by running the catalogue's own highlighter over the same lines. An unknown colour now **stops the build** rather than being drawn in the body colour, where nobody would look at a listing again to notice.

## Five more, each its own line

| | |
|---|---|
| **the mono stack** | `code` carries `font-family: monospace` from the **browser**, which overrides what it inherits — so every listing was set in the browser's idea of monospace, not the stack the four documents share. `font: inherit`, the line a sample page already has. |
| **the line numbers** | `.vp-doc a` outranks `.ln > a` by nothing at all and loads second, so the gutter was a column of blue links. |
| **the outline** | listed h2 and nothing else, while `themeConfig.outline` is `[2, 6]`: a chapter whose sections are h3 had an outline of one row, which is none. Every level now — and the indent is relative to the shallowest heading **on the page** rather than to h2, because measured from h2 a page of h3s indented every row under nothing. |
| **the outline, again** | nothing marked where the reader was. The scrollspy is the per-sample pages' walk, case for case. |
| **the menu** | a section that points at its own first page was marked `here` as well as the page, so two rows stood in the accent; and an `a` inside a nested `summary` kept the link colour, which painted most of the column blue. One row is marked now: the deepest that names this page. |
| **the menu, again** | every page is a fresh document here, so the sections a reader had unfolded shut themselves on the next click. The open ones are written down, by the key the build gives each section; the way to the current page is opened whatever is stored. |

## And the bar remembers again

`rememberHere` was being called and nothing was reading it. Lifting the stored page onto the **Samples** and **Documentation** items, and writing the scroll offset down on the way out, was `SiteNav.vue`'s half and went with the theme. Both are back in `site.js`.

The Samples item also had to be told which section it restores: the bar is lifted from a per-sample page, where Samples is the section the reader is already in and therefore carries no `data-site`. Without it, pressing Samples opened the front of the catalogue however deep the reader had been.

## Audited afterwards

Both documents on the origin they share: **240 values** across a chapter and a sample page — the bar, the crumb line, the title, links, listings and their four token colours, the line numbers, the outline and its column, the page itself — at 1280, 1440 and 1920, light and dark. **228 identical.**

The twelve that are not are one thing: the outline's 13px indent, on a page whose sections are h3 under a single h2. A sample page's headings are all h2, so its outline is one level deep and has nothing to indent.

Twelve gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_