### PR TITLE
The listings, the three buttons, the menu's layer, and the item that remembers

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -138,12 +138,45 @@ const frame = await (async () => {
   };
 })();
 
+/* The front of THIS section. The wordmark and the Home item both point at it,
+ * and the marker below finds the Home item by it. */
+const HOME = 'https://abap2ui5.github.io/docs/';
+
+/* EVERY EDIT BELOW IS TO THE NAV, AND CUTS IT OUT TO SAY SO.
+ *
+ * The bar names the catalogue twice: the wordmark on the left goes there as
+ * well, from the sample page this is borrowed from. A plain `replace` takes
+ * the first of the two, which is the wordmark - so `data-site="samples"`
+ * landed on the wordmark and the Samples ITEM, the one a reader presses,
+ * carried nothing for site.js to lift. It opened the front of the catalogue
+ * however deep the reader had been, which is the memory not working at all
+ * for the half of the bar most people use. */
+const NAV = /<nav class="bar-nav">[\s\S]*?<\/nav>/;
+const inNav = (bar, edit) => {
+  const nav = bar.match(NAV);
+  if (!nav) throw new Error(`no <nav class="bar-nav"> in the bar from ${frame.from}`);
+  return bar.replace(NAV, edit(nav[0]));
+};
+/* ...and once means once. A marker that matches twice edits the wrong item and
+ * one that matches nothing edits none, and both are silent. */
+const once = (nav, find, add) => {
+  const n = nav.split(find).length - 1;
+  if (n !== 1) throw new Error(`${find} occurs ${n} times in the borrowed bar's nav, expected exactly one`);
+  return nav.replace(find, find + add);
+};
+
 const BAR = (() => {
   const m = frame.page.match(/<header class="bar">[\s\S]*?<\/header>/);
   if (!m) throw new Error(`no bar in the sample page from ${frame.from}`);
-  const bar = m[0]
+  const brand = /(<a class="brand" href=")[^"]*"/;
+  let bar = m[0]
     .replace(/(?:href|src)="\.\.\/\.\.\//g, (t) => t.slice(0, -6) + `${PUBLISHED}/`)
     .replace(/ aria-current="page"/g, '');
+  /* The wordmark leads to the front of the section the reader is in - the
+     catalogue, on the page this came from, and from here that walked out of
+     the manual. Here the front of the section is the manual's own. */
+  if (!brand.test(bar)) throw new Error(`no wordmark in the bar from ${frame.from}`);
+  bar = bar.replace(brand, `$1${HOME}"`);
   /* THE SAMPLES ITEM HAS TO SAY WHICH SECTION IT RESTORES.
    *
    * The bar is lifted from a per-sample page, where Samples is the section the
@@ -153,9 +186,8 @@ const BAR = (() => {
    * opened the front of the catalogue however deep the reader had been. The
    * `data-scope` is what the stored value is checked against, exactly as the
    * Documentation item over there declares its own. */
-  const samples = `href="${PUBLISHED}/samples/"`;
-  if (!bar.includes(samples)) throw new Error(`the borrowed bar has no ${samples} to point at the catalogue`);
-  return bar.replace(samples, `${samples} data-site="samples" data-scope="${PUBLISHED}/samples/"`);
+  return inNav(bar, (nav) => once(nav, `href="${PUBLISHED}/samples/"`,
+    ` data-site="samples" data-scope="${PUBLISHED}/samples/"`));
 })();
 
 /* WHICH OF THE FOUR THE READER IS ON. The bar names Home, Documentation,
@@ -166,12 +198,21 @@ const BAR = (() => {
  * Both marks are made by finding a string in somebody else's markup, so both
  * throw when it is not there rather than quietly marking nothing: a bar with
  * nothing in bold reads as a bug in whichever site you came from. */
-const marked = (find) => {
-  if (!BAR.includes(find)) throw new Error(`the borrowed bar has no ${find} to mark`);
-  return BAR.replace(find, `${find} aria-current="page"`);
-};
+const marked = (find) => inNav(BAR, (nav) => once(nav, find, ' aria-current="page"'));
 const BAR_DOCS = marked('data-site="docs"');
-const BAR_HOME = marked('href="https://abap2ui5.github.io/docs/"');
+const BAR_HOME = marked(`href="${HOME}"`);
+
+/* THE OTHER HALF OF THE PAIR IS THE BORROWED MARKUP'S, so it is checked rather
+ * than assumed. `data-site` above says which page to come back to; `data-back`,
+ * which the catalogue writes on every bar item that leads to a place, says to
+ * come back to the same POSITION in it. Losing it upstream would take the
+ * scroll memory and leave everything else working - the quietest half of a
+ * failure this file has already shipped once. */
+{
+  const item = BAR.match(/<a [^>]*data-site="samples"[^>]*>/);
+  if (!item) throw new Error('the Samples item did not come out of the bar surgery');
+  if (!item[0].includes('data-back')) throw new Error(`the borrowed bar's Samples item has no data-back: ${item[0]}`);
+}
 
 const urlOf = (page) => BASE + page.replace(/\.md$/, '.html');
 

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -22,6 +22,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { createMarkdownRenderer } from 'vitepress';
 import config from '../docs/.vitepress/config.mjs';
 import { trailFor } from '../docs/.vitepress/theme/crumbs.js';
@@ -113,6 +114,7 @@ const frame = await (async () => {
       from: built,
       page: fs.readFileSync(path.join(built, sample.name, 'index.html'), 'utf8'),
       files: { 'catalogue.css': file('catalogue.css'), 'sample.css': file('sample.css'), 'search.mjs': file('search.mjs') },
+      highlighter: file('abap-highlight.mjs'),
     };
   }
   const sitemap = await fetchText(`${PUBLISHED}/sitemap.xml`);
@@ -126,11 +128,13 @@ const frame = await (async () => {
     fetchText(`${PUBLISHED}/samples/catalogue.css`),
     fetchText(`${PUBLISHED}/samples/sample.css`),
     fetchText(`${PUBLISHED}/samples/search.mjs`),
+    fetchText(`${PUBLISHED}/samples/abap-highlight.mjs`),
   ]);
   return {
     from: PUBLISHED,
     page,
     files: { 'catalogue.css': files[0], 'sample.css': files[1], 'search.mjs': files[2] },
+    highlighter: files[3],
   };
 })();
 
@@ -407,7 +411,39 @@ const home = ({ body, fm }) => {
 </main>`;
 };
 
-/* ---- the listings, in the colours a sample page prints ABAP in ---------
+/* ---- the ABAP, tokenised by the file the catalogue tokenises with -------
+ *
+ * Not "the same colours" - the same PROGRAM. `abap-highlight.mjs` is what
+ * writes the red and the green into all 772 per-sample pages, and it is
+ * published beside them for this; the manual runs it over its own listings and
+ * gets the same answer token for token, which "the same palette applied to
+ * somebody else's tokenising" does not: Shiki's ABAP grammar draws the lines
+ * elsewhere, and `DATA name TYPE` came out with the name inside the keyword.
+ *
+ * It replaces the CONTENT of each line and nothing else. The `<span
+ * class="line">` wrappers stay, because code-lines.js numbers them and every
+ * line of every listing on this site has an address (#B2L42); so does the card,
+ * the language label and the Run button under it.
+ *
+ * The text has to be handed over as it was written, which means undoing the
+ * escaping the renderer did - and `&amp;` last, or `&amp;lt;` becomes a tag. */
+const unescape = (s) => s
+  .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+  .replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+  .replace(/&amp;/g, '&');
+
+const abapify = (html) => html.replace(
+  /(<div class="language-abap[^"]*">[\s\S]*?<code>)([\s\S]*?)(<\/code>)/g,
+  (all, head, code, tail) => {
+    const lines = [...code.matchAll(/<span class="line">([\s\S]*?)<\/span>\s*(?=<span class="line">|$)/g)]
+      .map((m) => unescape(m[1].replace(/<[^>]*>/g, '')));
+    if (!lines.length) return all;
+    return head + highlightAbapLines(lines.join('\n'))
+      .map((line) => `<span class="line">${line}</span>`).join('\n') + tail;
+  },
+);
+
+/* ---- and every other language, in the colours a sample page prints ABAP in -
  *
  * Shiki hands every token an inline `--shiki-light` / `--shiki-dark` pair from
  * the github themes, which is a scheme of its own: functions purple, types
@@ -461,6 +497,18 @@ const recolour = (html) => html.replace(
 const md = await createMarkdownRenderer(DOCS, config.markdown || {}, BASE);
 fs.rmSync(OUT, { recursive: true, force: true });
 
+/* The borrowed highlighter, made importable. It is a module, not data, and the
+ * only way to run somebody else's module is to have it on disk - so it is
+ * written OUTSIDE `docs/`, one level up from the site: this build uses it, and
+ * nothing on the site loads it. */
+fs.mkdirSync(OUT, { recursive: true });
+const highlighterAt = path.join(OUT, 'abap-highlight.mjs');
+fs.writeFileSync(highlighterAt, frame.highlighter);
+const { highlightAbapLines } = await import(pathToFileURL(highlighterAt).href);
+if (typeof highlightAbapLines !== 'function') {
+  throw new Error(`abap-highlight.mjs from ${frame.from} no longer exports highlightAbapLines( )`);
+}
+
 let written = 0, headings = 0, blocks = 0;
 for (const page of pages) {
   const src = fs.readFileSync(path.join(DOCS, page), 'utf8');
@@ -473,7 +521,7 @@ for (const page of pages) {
      and only for paths that are root-relative and not already based - which
      is what the theme was quietly doing for us. */
   body = body.replace(/(\b(?:src|href)=")\/(?!docs\/)([^"]*)"/g, `$1${BASE}$2"`);
-  body = recolour(body);
+  body = recolour(abapify(body));
   /* And a page written by hand as `/docs/resources/addons` gets its `.html`.
      VitePress resolves that in the router, and GitHub Pages happens to resolve
      it too, by trying `<path>.html` - so it was never broken on the site and

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -370,12 +370,28 @@ details[open] > summary > .side-caret { transform: rotate(90deg); }
   margin: 0; padding-top: 12px;
   font-size: 17px; line-height: 26px; font-weight: 500; color: var(--fg-dim);
 }
-.hero-actions { display: flex; flex-wrap: wrap; gap: 12px; padding-top: 29px; }
+/* THREE BUTTONS, ONE SIZE. Laid out as a row of equal tracks rather than as
+   three boxes that each take the width of their own words: `1fr` columns are
+   equalised, and `width: max-content` then sizes the row to three of the
+   widest - so the three match without any of them being told a number, and
+   the row is no wider than it has to be. A fourth action in the frontmatter
+   would join it without a change here, which `repeat(3, …)` would not allow.
+   The padding is 14 rather than 18: with the widths evened out, the shortest
+   label sets how much air the other two carry, and 18 made them roomy. */
+.hero-actions {
+  display: grid; grid-auto-flow: column; grid-auto-columns: 1fr;
+  width: max-content; gap: 12px; padding-top: 29px;
+}
 .hero-action {
-  padding: 0 18px;
+  padding: 0 14px;
   border: 1px solid transparent; border-radius: 6px;
   font-size: 13px; line-height: 34px; font-weight: 600;
-  text-decoration: none; white-space: nowrap;
+  text-align: center; text-decoration: none; white-space: nowrap;
+}
+/* On a phone the row is the width of the column and they stack, because three
+   equal tracks of the longest label do not fit one. */
+@media (max-width: 620px) {
+  .hero-actions { grid-auto-flow: row; width: auto; }
 }
 /* Only the first of the three is the one the page wants; the other two are a
    hairline, not a second filled block.

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -245,15 +245,18 @@ details[open] > summary > .side-caret { transform: rotate(90deg); }
   color: var(--fg-dim); font-size: 11px;
 }
 .vp-doc div[class*="language-"] .copy { display: none; }
-/* NOTHING HERE COLOURS A TOKEN. The three rules that used to - reading the
-   `--shiki-light` / `--shiki-dark` pair Shiki writes onto every span - are
-   gone with the pairs themselves: build-site.mjs swaps them for the classes
-   the catalogue styles (`code-key`, `code-string`, `code-number`,
-   `code-comment` in sample.css, over the three values catalogue.css declares).
-   One scheme for the manual and the 772 sample pages, in one place, and this
-   file states no colour at all. They also have to be gone rather than merely
-   unused: `.vp-doc .shiki span` outranks a bare `.code-key`, and with the
-   variable no longer set every listing was drawn in the body colour. */
+/* NOTHING HERE COLOURS A TOKEN, and nothing here decides which token it is.
+   ABAP is tokenised by the catalogue's own `abap-highlight.mjs`, borrowed at
+   build time - the same program that writes the red and the green into all 772
+   per-sample pages - and every other language keeps Shiki's tokens with its
+   colours mapped onto the same four classes. Either way what arrives here is
+   `code-key`, `code-string`, `code-number`, `code-comment`, which `sample.css`
+   styles over the three values `catalogue.css` declares. One scheme for both
+   documents, in one place, and this file states no colour at all.
+   The three rules that used to read Shiki's `--shiki-light` pair had to GO
+   rather than merely stop matching: `.vp-doc .shiki span` outranks a bare
+   `.code-key`, and with the variable no longer set every listing was drawn in
+   the body colour. */
 
 /* ---- the ::: blocks -------------------------------------------------- */
 .vp-doc .custom-block {

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -134,6 +134,11 @@
     border: 0;
     transform: none;
     transition: none;
+    /* ...AND BACK UNDER THE BAR. The drawer above stands at 40 because it
+       covers the page; standing there while placed in the margin instead put
+       the menu over the bar, which is the catalogue's and sits at 5 - so
+       scrolling drew chapter names across Home and Documentation. */
+    z-index: auto;
   }
 }
 


### PR DESCRIPTION
Four things about the frame this site borrows from the sample catalogue. Three of them are defects a reader reported after the switch; the first is the one this branch was opened for.

## 1. The ABAP is set by the program that sets it on a sample page

Not the same colours — the same **program**. `abap-highlight.mjs` is what writes the red and the green into all 772 per-sample pages; the playground publishes it beside them now ([abap2UI5/playground#74](https://github.com/abap2UI5/playground/pull/74), merged), and this build runs it over the manual's own listings.

The **tokenising** is what that buys over the palette swap it replaces. Shiki's ABAP grammar draws the lines somewhere else, so `DATA name TYPE` arrived with the name inside the keyword and `DEFINITION PUBLIC` as one span; the catalogue splits both and leaves the name in the body colour.

```
before   <span class="code-key"> DEFINITION PUBLIC</span>
after    <span class="code-key">DEFINITION</span> <span class="code-key">PUBLIC</span>
```

It replaces the **content** of each line and nothing else. The `<span class="line">` wrappers stay, so `code-lines.js` still numbers them and every line still has an address (`#B2L42`). The escaping is undone before the text is handed over and redone by the highlighter — `&amp;` last, or `&amp;lt;` becomes a tag. Every other language keeps Shiki's tokens with their colours mapped onto the same four classes.

Over the whole site: 5238 keywords, 4614 literals, 392 comments, 108 numbers, and not one `--shiki-light` left in any page.

## 2. The three buttons on the front door are one size

They were as wide as their words — 155, 129 and 132 — which reads as three buttons rather than a row. A one-column-per-item grid at `1fr` makes them the width of the widest, and the row is 490 instead of 604. Below 620px they stack, as they did.

## 3. The menu stays under the bar when it moves into the margin

At 1680px and wider the chapter menu leaves the flow and is placed absolutely in the left margin. It kept the stacking order it had as a drawer, where 40 is right because a drawer covers the page — and the bar it now scrolled past is the catalogue's, which sits at 5. On a long page the chapter names were drawn across Home and Documentation. Nothing about the placement was wrong, only the layer: `z-index: auto` in that block.

## 4. The Samples item in the bar is the one that remembers

The bar is borrowed from a per-sample page, and there it names the catalogue **twice**: the wordmark on the left goes there as well as the Samples item. The surgery that adds `data-site="samples"` used a plain replace, so it took the first of the two — the wordmark — and the item a reader actually presses carried nothing for `site.js` to lift.

So pressing Samples opened the front of the catalogue however deep the reader had been, and the offset went with it: the wordmark carries no `data-back`, the Samples item does, and only the wordmark was ever restored.

Every edit to the bar now happens inside `<nav class="bar-nav">`, and each marker has to match **exactly once** — a string that matches twice edits the wrong item and one that matches nothing edits none, both in silence. `data-back` is the borrowed markup's half of the pair, so it is checked here rather than assumed.

The wordmark leads to the front of the section the reader is in. On the page this was taken from that is the catalogue, and it was still the catalogue here — clicking **abap2UI5** on a documentation page walked out of the documentation. It is the manual's front door now.

Verified over the whole journey: a sample page at 700, Documentation, three chapters, Samples — back to the same sample at 700 — and Documentation again, back to the third chapter at 1200.

---

Twelve gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW