### PR TITLE
Twenty-eight tables that announced nothing, and a gutter of fifty tab stops

### DIFF
--- a/docs/.vitepress/theme/code-lines.js
+++ b/docs/.vitepress/theme/code-lines.js
@@ -76,6 +76,15 @@ function number(code, bi) {
      * The number itself is the stylesheet's, so that it stays out of what a
      * reader copies. */
     a.setAttribute('aria-label', `Line ${n}`);
+    /* And out of the tab order: a chapter has 55 of these against 69 of
+     * everything else, so a reader on a keyboard pressed Tab two dozen times
+     * to get past ONE listing. The gutter is a pointer affordance - the number
+     * is drawn by the stylesheet and the link under it is how a mouse picks a
+     * line up - and nothing is lost by it: the link still answers a click,
+     * `#B1L42` still opens where it always did, and a screen reader still
+     * meets the link in the page, because a browse cursor is not the tab
+     * order. The listing itself stays a stop, named and scrollable. */
+    a.tabIndex = -1;
     line.prepend(a);
   });
   code.dataset.lines = String(lines.length);

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -163,7 +163,13 @@ const HOME = 'https://abap2ui5.github.io/docs/';
  * carried nothing for site.js to lift. It opened the front of the catalogue
  * however deep the reader had been, which is the memory not working at all
  * for the half of the bar most people use. */
-const NAV = /<nav class="bar-nav">[\s\S]*?<\/nav>/;
+/* `[^>]*` rather than `>`: the nav over there carries `aria-label="Main"`
+ * since the day a landmark with no name was noticed, and a borrow that only
+ * knows the tag as it was on the day it was written breaks on the next
+ * attribute somebody adds to it. What must be exact is the CLASS - that is
+ * what says this is the right nav - and `once()` below is what says the edit
+ * landed where it was meant to. */
+const NAV = /<nav class="bar-nav"[^>]*>[\s\S]*?<\/nav>/;
 const inNav = (bar, edit) => {
   const nav = bar.match(NAV);
   if (!nav) throw new Error(`no <nav class="bar-nav"> in the bar from ${frame.from}`);
@@ -347,7 +353,7 @@ function outlineFor(html) {
   const top = Math.min(...rows.map((r) => r.level));
   return `<aside class="outline" aria-label="On this page">
     <div class="outline-head">On this page</div>
-    <nav>${rows.map((r) => `<a href="#${r.id}"${r.level > top ? ` class="lvl-${r.level - top + 2}"` : ''}>${esc(r.text)}</a>`).join('')}</nav>
+    <nav aria-label="On this page">${rows.map((r) => `<a href="#${r.id}"${r.level > top ? ` class="lvl-${r.level - top + 2}"` : ''}>${esc(r.text)}</a>`).join('')}</nav>
   </aside>`;
 }
 
@@ -716,6 +722,19 @@ const named = (html) => html.replace(
   },
 );
 
+/* AND A TABLE IS A REGION TOO, for the same reason and with the same words.
+ * The renderer wraps every table in `div.vp-doc-table tabindex="0"` so that a
+ * keyboard can scroll one wider than the column - the api reference alone has
+ * 28 of them, 14 of which do scroll on a 390px screen - and every one of them
+ * was a tab stop that announced nothing at all. Numbered, because "table"
+ * twenty-eight times over is twenty-eight things that cannot be told apart,
+ * and the number is the one a reader counts down the page. */
+let seenTables = 0;
+const tabled = (html) => html.replace(
+  /<div class="vp-doc-table"([^>]*)tabindex="0"([^>]*)>/g,
+  (all, before, after) => `<div class="vp-doc-table"${before}tabindex="0"${after} role="region" aria-label="Table ${++seenTables}">`,
+);
+
 const abapify = (html) => html.replace(
   /(<div class="language-abap[^"]*">[\s\S]*?<code>)([\s\S]*?)(<\/code>)/g,
   (all, head, code, tail) => {
@@ -916,7 +935,8 @@ for (const page of pages) {
   body = body.replace(/(\b(?:src|href)=")\/(?!docs\/)([^"]*)"/g, `$1${BASE}$2"`);
   seenImages = 0;
   seenBlocks = 0;
-  body = named(notProse(sized(recolour(abapify(body)))));
+  seenTables = 0;
+  body = tabled(named(notProse(sized(recolour(abapify(body))))));
   /* A link that opens a new tab hands that tab a `window.opener` pointing at
      this one unless it says otherwise. Every current browser implies
      `noopener` for `target="_blank"` and has since 2020 - this is for the ones

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -385,6 +385,10 @@ html { scroll-padding-top: 62px; }
  * needs the four sections more. */
 .bar .release {
   flex: none;
+  /* 86x19 of link, where a target is asked to be 24 in both directions. The
+     three pixels go on as padding, which nothing can see: the group centres
+     what it holds and the number does not move. */
+  padding: 3px 0;
   /* The socials group sets no gap of its own - its marks carry their own
      padding - so the number would sit against the first one. Measured: 0px
      between them. */


### PR DESCRIPTION
The manual's half of a batch found by measuring the published pair; the bar's own three are in [abap2UI5/playground#77](https://github.com/abap2UI5/playground/pull/77) and reach this site by being borrowed.

**Twenty-eight focusable regions with no name.** The renderer wraps every table in `div.vp-doc-table tabindex="0"` so a keyboard can scroll one wider than the column — the api reference alone has 28, and **14 of them do scroll on a 390px screen** — and not one said what it was. It is the case this build already fixed for listings, in the same words: *a focusable region with no accessible name is announced as nothing at all.* `role="region"` and a name now, numbered down the page for the reason the listings are. Checked: 28 of 28, `Table 1` to `Table 28`, in reading order.

**The gutter was 55 of a chapter's 124 tab stops.** Every line of every listing is a link, so a reader on a keyboard pressed Tab two dozen times to get past one listing. It is a pointer affordance — the number is drawn by the stylesheet, the link under it is how a mouse picks a line up — and nothing is lost by taking it out of the tab order:

- the link still answers a click (checked: `#B1L5`)
- a shift-click still composes a range (checked: `#B1L5-L8`, four lines marked)
- a screen reader still meets it, because a browse cursor is not the tab order
- the listing itself stays a stop, named and scrollable

124 stops became **75**.

**The outline is "On this page" to a machine too.** Five landmarks are called navigation on a chapter — the bar, the chapter menu, the trail, prev/next and the outline — and four of them said which. This was the fifth.

**And the version is a 24px target.** 86×19 of link, where a target is asked to be 24 in both directions. Three pixels of padding, which nothing can see: the chapter at 1440×900 comes out **pixel for pixel identical** to the page it replaces.

**The borrow survives an attribute.** `NAV` matched `<nav class="bar-nav">` exactly, and the bar over there carries `aria-label="Main"` as of today — so the next attribute anybody adds to that nav would have stopped this build dead. The class is what identifies the nav and `once()` is what proves the edit landed; the rest of the tag is not this build's business. With `[^>]*` the build works against the published bar as it is now and as it will be after the playground deploys.

Twelve gates green, 126 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_