### PR TITLE
"On this page" was two landmarks with one name

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -351,10 +351,17 @@ function outlineFor(html) {
      nothing, which reads as a mistake rather than as a level. Where nothing is
      nested, the column is flat and identical to a sample page's. */
   const top = Math.min(...rows.map((r) => r.level));
-  return `<aside class="outline" aria-label="On this page">
+  /* A DIV AROUND A NAMED NAV, not an <aside> around one. Both are landmarks,
+     so naming the nav - which is the one a reader jumps between - left every
+     chapter announcing "On this page" twice: once as a complementary region,
+     once as the navigation inside it. The nav is what is worth landing on and
+     the box around it is layout; `.outline` is what every rule addresses, here
+     and in the borrowed stylesheet, so nothing else changes. The sample pages
+     do the same (tools/sample-pages.mjs over there). */
+  return `<div class="outline">
     <div class="outline-head">On this page</div>
     <nav aria-label="On this page">${rows.map((r) => `<a href="#${r.id}"${r.level > top ? ` class="lvl-${r.level - top + 2}"` : ''}>${esc(r.text)}</a>`).join('')}</nav>
-  </aside>`;
+  </div>`;
 }
 
 function crumbsFor(page) {


### PR DESCRIPTION
Naming the outline's nav in [#250](https://github.com/abap2UI5/docs/pull/250) left every chapter saying it twice: the `<aside>` around it is a landmark of its own, so a reader jumping by landmark heard *"On this page"* as a complementary region and then again as the navigation inside it. One of the two is worth landing on — the nav, which is the rows — and the box around it is layout.

A `<div class="outline">` now, and the landmarks on a chapter read: the bar (`Main`), the chapter menu (`Documentation`), the trail (`Breadcrumb`), `Previous and next page`, and the outline (`On this page`). **Five, each said once.**

Nothing else moves, because every rule addresses `.outline` and none of them the element. Measured after the change:

- the column stands at x 1048, 225 wide, as before; the head still reads "On this page"
- Common Failures' 25 rows still scroll inside the box
- the scrollspy still marks the row you are in, with `aria-current="true"`
- the chapter at 1440×900 is **pixel for pixel** the page it replaces

Twelve gates green, 126 unit tests. The sample pages do the same in the playground's build: [abap2UI5/playground#78](https://github.com/abap2UI5/playground/pull/78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_