### PR TITLE
The front door says what it costs, and where an AI assistant fits

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -131,6 +131,73 @@ ENDCLASS.
 - **Events come back as ABAP.** `check_on_event( )` is where the button press
   arrives, in the same class, with the model already updated.
 
+## What it costs
+
+Nothing, and there is nothing to buy. abap2UI5 is [MIT licensed](/resources/license)
+and free for commercial use: no licence key, no subscription, no per-user and no
+per-app fee, no runtime to activate, no usage anybody meters. You install it from
+GitHub with abapGit, and it sits in your own system as one repository whose source
+you can read, fork and keep.
+
+**Nobody counts your users, because nothing is counting.** An abap2UI5 app is a
+standard UI5 freestyle application served by your own ABAP stack: ten users and ten
+thousand are the same to the framework, and the SAP licensing you already have is
+the licensing you keep — [License](/resources/license) says it in one line, and it
+is the same line every UI5 app in your organization is licensed by.
+
+**Nothing new to operate.** No extra server, no middleware, no service to
+subscribe to: an app is an ABAP class in the system it runs on, installed like any
+other abapGit repository, and a roundtrip goes from the browser to that system and
+back.
+
+<div class="a2ui5-out">
+  <a class="a2ui5-out-card is-inside" href="/docs/resources/license">
+    <span class="a2ui5-out-title">MIT, in full</span>
+    <span class="a2ui5-out-details">The whole licence is one short page. Free for commercial use, and your apps stay yours — plain ABAP classes and standard UI5.</span>
+  </a>
+  <a class="a2ui5-out-card is-inside" href="/docs/resources/support">
+    <span class="a2ui5-out-title">Support</span>
+    <span class="a2ui5-out-details">Issues and the abapGit Slack channel for the community, and companies and freelancers offering implementation, training and support agreements.</span>
+  </a>
+  <a class="a2ui5-out-card is-inside" href="/docs/resources/who_uses">
+    <span class="a2ui5-out-title">In production</span>
+    <span class="a2ui5-out-details">Running in customer projects today — EWM and PP apps on ABAP 7.57 and 7.55, on desktop and on mobile devices.</span>
+  </a>
+</div>
+
+
+## Written with an AI assistant
+
+An abap2UI5 app is one ABAP class — source code, and nothing else. No service to
+generate, no OData artefact, no frontend project, no manifest, no deployment
+pipeline: there is exactly one file for an agent to write, and the thing it writes
+is the thing that runs. Nothing drifts out of step, because there is no second half
+to keep in step with.
+
+**And it can check its own work without an SAP system.** The
+[linter](/advanced/linter) reconstructs the UI5 view out of the ABAP that builds it
+and reports the names UI5 does not have; the [MCP server](/advanced/mcp_server)
+turns that into a development loop for any MCP client — Claude Code, Cursor, VS
+Code:
+
+```sh
+claude mcp add abap2ui5 -- npx --yes @abap2ui5/mcp-server
+```
+
+An agent then searches the three sample catalogues for an app that already does
+what you asked for, asks whether abap2UI5 can express a UI5 feature at all,
+validates the view it just wrote — and, one level further, transpiles the framework
+to Node, boots the app headless and hands back the errors and a screenshot. Two
+files describe this project to a machine on their own:
+[`llms.txt`](https://abap2ui5.github.io/docs/llms.txt) maps every chapter of this
+manual, and [`llms-full.txt`](https://abap2ui5.github.io/docs/llms-full.txt) is all
+of it in one fetch.
+
+[Developing with AI](/get_started/ai) has the whole ladder, from one paragraph you
+paste ahead of a task to the editor extension that registers the loop for every
+client in the window.
+
+
 ## What it needs, and what it does not
 
 | | |
@@ -139,7 +206,7 @@ ENDCLASS.
 | **Installed with** | [abapGit](/get_started/quickstart) — one repository, no transport of frontend artefacts, no BSP application to maintain |
 | **Needs no** | JavaScript, OData service, RAP business object, CDS view, frontend project or Node toolchain |
 | **Speaks** | UI5, over stateless HTTP roundtrips against the framework's own service |
-| **Licence** | MIT, and the code is [on GitHub](https://github.com/abap2UI5/abap2UI5) |
+| **Licence** | MIT — free for commercial use, no per-user fee, and the code is [on GitHub](https://github.com/abap2UI5/abap2UI5) |
 
 Old releases matter here: apps written on 7.02 use the same API as apps on ABAP
 Cloud, and [Downporting](/advanced/downporting) explains what the framework


### PR DESCRIPTION
Two questions the page did not answer. A reader who arrives from a talk or a colleague's link, weighing this against a product with a price list, asks **what it costs** before they ask how it works — and an ABAP team asks whether **their assistant** can write it. Both answers already existed on this site, and neither was on the page people land on: the licence was one row of a fact sheet, and AI was a chapter three clicks in.

Both are now sections of the front door, in the order a stranger needs them: the example that runs → what it costs → where an AI assistant fits → what it needs → what is around it.

## What it costs

> Nothing, and there is nothing to buy. […] no licence key, no subscription, no per-user and no per-app fee, no runtime to activate, no usage anybody meters.
>
> **Nobody counts your users, because nothing is counting.** An abap2UI5 app is a standard UI5 freestyle application served by your own ABAP stack: ten users and ten thousand are the same to the framework, and the SAP licensing you already have is the licensing you keep.

That last clause is deliberately the project's **own** line from [License](https://abap2ui5.github.io/docs/resources/license) — *"license them the same way you license other UI5 apps in your organization"* — rather than a new claim about SAP's licensing. The strong statement is about abap2UI5: it adds no fee and counts nothing.

Three cards under it, each pointing at a page that already existed: the licence in full, support (community best-effort plus the companies and freelancers offering implementation, training and support agreements), and who is running it in production today — EWM and PP apps on ABAP 7.57 and 7.55, on desktop and on mobile.

## Where an AI assistant fits

The reason is the one the example above it demonstrates: an app is one class, so there is exactly one file for an agent to write and no second half to keep in step with. Then what makes it checkable without a system — the linter reconstructs the view out of the ABAP that builds it — and the MCP server that turns that into a loop, in one line to paste:

```sh
claude mcp add abap2ui5 -- npx --yes @abap2ui5/mcp-server
```

Every claim is [Developing with AI](https://abap2ui5.github.io/docs/get_started/ai)'s, shortened: `examples`, `capabilities`, `validate_view`, and the level that transpiles the framework to Node, boots the app headless and hands back the errors and a screenshot. Plus the two indexes a machine can read on its own, `llms.txt` and `llms-full.txt`.

## Also

The fact sheet's licence row now reads *"MIT — free for commercial use, no per-user fee, and the code is on GitHub"*, because a row that only names a licence answers a lawyer, and this page is read by people deciding whether to look further.

Measured on the built page: 166 pages, 538 sections, **37,080 links checked, none dead**, no page errors, nothing scrolling sideways at 390px. Twelve gates green, 126 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_