### PR TITLE
The chapter menu is the navigation on a phone, and its rows were 20px

### DIFF
--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -195,6 +195,36 @@
 .sidebar > .side-group > summary,
 .sidebar > .side-item > a,
 .sidebar > .side-item > span { color: var(--fg); font-weight: 600; padding-top: 14px; }
+
+/* A ROW OF THIS MENU IS 20px TALL, AND ON A PHONE IT IS THE NAVIGATION. Below
+   1680 this list is the drawer, and the drawer is the only way from one chapter
+   to another on a screen with no room for the menu beside the page - 35 rows
+   of it visible at once on a 393px phone, 20px each, with 0 to 4px between
+   them. That is half the height a target is asked to be and none of the
+   spacing, so a thumb aiming at Cookbook got View.
+
+   `min-height` rather than padding, because the paddings here carry the
+   rhythm of the sections - a group heading stands 14px clear of the list above
+   it - and a row that is centred in a taller box keeps every one of them. It
+   costs the drawer its scrollbar, which it already knew how to use: the script
+   scrolls it to the row you are on. */
+@media (pointer: coarse) {
+  .sidebar .side-item > a,
+  .sidebar .side-item > span,
+  .sidebar summary { min-height: 36px; }
+  /* A section heading is a summary with a LINK inside it - the caret opens the
+     list, the words open the page - and a taller row leaves that link its own
+     20px in the middle of it unless it is told to fill the row. Stretched, the
+     words are the target and the rest of the row is still the caret's. */
+  .sidebar summary > a { align-self: stretch; display: flex; align-items: center; }
+  /* ...and a top-level heading stands 14px clear of the list above it, which it
+     did with padding - and padding is the one part of a row a child cannot
+     stretch into, so the link stayed 20px inside a 38px row and the 14 above it
+     toggled the section instead of opening the page. The same 14px as margin:
+     the same gap, outside the row, with the whole row left for the link. */
+  .sidebar > .side-group > summary { padding-top: 0; margin-top: 14px; }
+}
+
 /* A LINK IN THE MENU IS NOT A LINK-COLOURED LINK. Every row here is one, so
    colouring them the accent paints the whole column blue and the one you are
    on stops standing out - which is the only thing the accent is for in this
@@ -230,6 +260,12 @@ details[open] > summary > .side-caret { transform: rotate(90deg); }
 }
 .doc-foot .edit { color: var(--accent); text-decoration: none; }
 .doc-foot .edit:hover { text-decoration: underline; }
+/* 19px of link at the foot of a chapter, with the date beside it: right under a
+   mouse, half a target under a thumb. The height is padding, so nothing moves
+   for a reader with a pointer. */
+@media (pointer: coarse) {
+  .doc-foot .edit { display: inline-block; padding: 4px 0; }
+}
 
 /* ---- the article ---------------------------------------------------- */
 .vp-doc h1 { font-size: 26px; line-height: 1.25; margin: 0 0 16px; }


### PR DESCRIPTION
Measured on five phone shapes under touch emulation — 360×640, 375×667, 393×852, 412×915 and one in landscape — against the rule as it is actually written: a target passes at 24×24, **or** when nothing else to tap comes within 24px of it, **or** when it is a word in a sentence. What was left is what a thumb really misses.

**The menu.** Below 1680px this list is a drawer, and on a phone the drawer is the only way from one chapter to another: 35 rows visible at once, 20px each, 0 to 4px apart. A thumb aiming at Cookbook got View. The rows are 36px on a coarse pointer — `min-height`, not padding, because the paddings here carry the rhythm of the sections and a row centred in a taller box keeps every one of them.

Two things that only showed after that:

- a section heading is a `<summary>` with a **link** inside it — the caret opens the list, the words open the page — and the link kept its own 20px in the middle of the taller row until it was told to stretch;
- the 14px that stands a top-level heading clear of the list above it was **padding**, which is the one part of a row a child cannot stretch into. As margin it is the same gap, outside the row, with the whole row left to the link.

**And the foot of a chapter:** "Edit this page on GitHub" was 19px of link. Padding on touch only, so nothing moves for a reader with a pointer.

| | before | after |
|---|---|---|
| the manual at 360…412 and in landscape | menu rows 20px at 0–4px spacing, a 20px link inside a 38px heading, a 19px foot link | **every target reachable, nothing scrolls sideways** |

The drawer still opens on the row you are on, still closes on a tap outside, and now scrolls — 35 rows at 36px do not fit a phone, which is what a scrollable drawer is for.

The gutter of a listing — 55 line links, 36×19, 19px apart — is fixed in the stylesheet this site borrows, and arrives with it: [abap2UI5/playground#79](https://github.com/abap2UI5/playground/pull/79).

Twelve gates green, 126 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_