### PR TITLE
A description that stops at the premise describes nothing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `scripts/lib/client-interface.mjs` | Where `z2ui5_if_client` is fetched from (the ref comes from `lib/release.mjs`, shared with `check-api-names.mjs`) and the full parser `generate-api-reference.mjs` renders from |
 | `scripts/check-version.mjs` | The release number in the bar's menu, the deprecations page and the changelog, against the newest release tag of the framework |
 | `scripts/generate-search.mjs` | Builds `docs/public/search-index.json` — the pages of this site plus every entry in the three sample catalogues, which is what the box in the middle of the bar searches. Runs inside `docs:build`, so the deploy publishes it; `scripts/lib/search-index.mjs` is what goes in |
-| `scripts/lib/pages.mjs` | What a page of this site IS: the sidebar walk, its title, its first sentence, its headings, its words. Shared by `generate-llms.mjs` and `generate-search.mjs` so a page added to the sidebar reaches both |
+| `scripts/lib/pages.mjs` | What a page of this site IS: the sidebar walk, its title, its opening sentences, its headings, its words. Shared by `build-site.mjs`, `generate-llms.mjs` and `generate-search.mjs` so a page added to the sidebar reaches all three; `summarise( )` — the description of 150 pages and the note in `llms.txt`, which nobody writes and nobody proofreads — is pinned by `test/summarise.test.mjs` |
 | `docs/.vitepress/playground.mjs` | Decides which fenced ABAP example gets a **Run** button, and wraps the fence; `theme/playground.js` is the browser half |
 | `scripts/list-runnable.mjs` | The measurement's worklist: every fenced example that carries a Run button, out of the same `playground.mjs` that decides the button. `--json` adds each example's ABAP verbatim - what the button sends - so the measurement below can be driven rather than clicked |
 | `scripts/check-playground.mjs` | The Run-button bookkeeping: every complete app class either gets a button from `playground.mjs` or carries a `<!-- playground: no Run button — … -->` marker above its fence saying why it cannot run; a stale marker fails as loudly as a missing one. `--list` prints the deliberate exclusions with both reasons |
@@ -449,6 +449,21 @@ Three things to know before touching it:
   six og/twitter values, all with absolute urls: a relative `og:url` is
   silently dropped and the preview falls back to a grey card. That is what
   `transformPageData` used to do and what `meta( )` does now.
+- **The description is written by nobody**, on the 150 pages that declare none
+  in their frontmatter: `summarise( )` in `scripts/lib/pages.mjs` takes it off
+  the top of the page, and it is also the note beside every entry in
+  `llms.txt`. It used to stop at the first full stop, and on thirty-four pages
+  that sentence was the premise rather than the description — "abap2UI5 has no
+  e-mail control of its own", "All examples in these docs work without EML" —
+  the half that says what the page is NOT about, with the answer in the
+  sentence after it. It now takes sentences until there are 110 characters and
+  stops at the last one under 200. Over those 150 pages the median went from 84
+  to 117 characters and the ones under 60 from 34 to 8 — the eight are pages
+  whose opening paragraph is one short sentence, which is the honest answer. Two rules keep
+  it from cutting mid-thought: past the first sentence only a full stop counts
+  — the dash forms exist for a page that opens without one — and a candidate
+  that leaves a bracket open is skipped. `test/summarise.test.mjs` holds all of
+  it, because nothing else reads these before they ship.
 
 Verified against the VitePress build the day it was switched: 168 pages, ten
 content features each — headings, listings, tables, `:::` blocks, list items,

--- a/scripts/lib/pages.mjs
+++ b/scripts/lib/pages.mjs
@@ -130,15 +130,51 @@ export function summarise(body) {
     .replace(/\s+/g, ' ')
     .trim();
   if (!plain) return '';
-  // cut at the end of the first sentence, but not so early that the note says
-  // nothing; a period inside `sap.m.Table` or `1.71` is not a sentence end
-  const stop = plain.search(/\.(?=\s|$)|:\s—|\s—\s/);
-  /* Trimmed, because two of the three cuts land ON a space: the dash forms
-     match `\s—\s`, and keeping the character at `stop` keeps that space. It
-     showed up as "…control of its own " under a search hit, in the note beside
-     an llms.txt entry, and - since the descriptions started coming from here -
-     in the meta description of two pages. */
-  const first = (stop > 40 ? plain.slice(0, stop + 1) : plain).trim();
+  /* SENTENCES UNTIL IT SAYS SOMETHING, then stop.
+   *
+   * This used to cut at the FIRST sentence end, and a page whose first
+   * sentence is short then went out into the world described by it: "abap2UI5
+   * has no e-mail control of its own", "All examples in these docs work
+   * without EML", "Barcode scanning is common in enterprise apps". That is a
+   * premise, not a description - it is the half of the paragraph that says
+   * what the page is NOT about, and the sentence after it is the one that says
+   * what it is. Thirty-four of the hundred and fifty pages that declare no
+   * description of their own were under sixty characters, and the median was
+   * 84. A snippet has room for about 155.
+   *
+   * So: take sentence ends until there are at least 110 characters, and stop
+   * at the last one that stays under 200 - a description is a paragraph's
+   * opening, not the paragraph. The cut itself is unchanged, and a period
+   * inside `sap.m.Table` or `1.71` is still not a sentence end. One sentence
+   * that is already long enough is still one sentence, and a paragraph with
+   * nothing more in it stays as short as it is.
+   *
+   * Trimmed, because two of the three cuts land ON a space: the dash forms
+   * match `\s—\s`, and keeping the character at the cut keeps that space. It
+   * showed up as "…control of its own " under a search hit, in the note beside
+   * an llms.txt entry, and in the meta description of two pages. */
+  let first = '';
+  for (const end of plain.matchAll(/\.(?=\s|$)|:\s—|\s—\s/g)) {
+    if (end.index <= 40) continue;
+    /* A DASH ENDS A FIRST SENTENCE AND NEVER EXTENDS ONE. The two dash forms
+       are here because a page can open with a sentence that never reaches a
+       full stop; cutting a LATER one at a dash stops mid-clause, and it did:
+       "...two additional database tables (z2ui5_t_99 and z2ui5_t_98", with the
+       bracket still open, and "What it cannot do is find out whether the app
+       works". Past the first sentence, only a full stop will do. */
+    if (first && !end[0].startsWith('.')) continue;
+    const candidate = plain.slice(0, end.index + 1).trim();
+    /* AND NOT INSIDE A BRACKET. The quickstart opens "Pull abap2UI5 with
+       abapGit. (New to abapGit? Install it first — see ...)", and the cut at
+       that dash ends the description four words into an aside, with the
+       bracket still open. A candidate that opened something it did not close
+       is not a sentence; the next one is tried instead. */
+    if ((candidate.match(/\(/g) || []).length !== (candidate.match(/\)/g) || []).length) continue;
+    if (first && candidate.length > 200) break;
+    first = candidate;
+    if (first.length >= 110) break;
+  }
+  if (!first) first = plain.trim();
   return first.length > 220 ? `${first.slice(0, 217)}...` : first;
 }
 

--- a/test/summarise.test.mjs
+++ b/test/summarise.test.mjs
@@ -1,0 +1,80 @@
+/*
+ * The sentence a page is described BY — `summarise( )` in scripts/lib/pages.mjs.
+ *
+ * It is the meta description of 150 of the 166 pages (the rest declare one in
+ * their frontmatter), the note beside every entry in llms.txt, and the line
+ * under a search hit. Nobody writes it, so nobody reads it before it ships:
+ * the failures are all quiet ones, and they were all real. It used to stop at
+ * the FIRST full stop, which on thirty-four pages was a premise rather than a
+ * description — "abap2UI5 has no e-mail control of its own" — and it cut at a
+ * dash wherever a dash came first, which is right for an opening sentence and
+ * wrong four words into a bracket.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { summarise, describe } from '../scripts/lib/pages.mjs';
+
+test('a page says what it declares, whatever its first paragraph is', () => {
+  const body = '---\ndescription: The one sentence this page chose\n---\n\n# Title\n\nSomething else entirely.';
+  assert.equal(describe(body), 'The one sentence this page chose');
+});
+
+test('one sentence that already says something is left alone', () => {
+  const one = 'The abap2UI5 HTTP Connector calls abap2UI5 apps remotely over HTTP between two ABAP systems, '
+    + 'which is what makes one system a frontend for another.';
+  assert.ok(one.length >= 110, 'the fixture is long enough to stand on its own');
+  assert.equal(summarise(`# T\n\n${one} It works similarly to the RFC Connector.`), one);
+});
+
+test('a first sentence too short to describe anything takes the next ones', () => {
+  const out = summarise('# T\n\nAll examples in these docs work without EML. But on a recent ABAP release you can '
+    + 'also use this feature in your own apps. A third sentence nobody needs.');
+  assert.equal(out, 'All examples in these docs work without EML. But on a recent ABAP release you can also use '
+    + 'this feature in your own apps.');
+});
+
+test('a paragraph with nothing more in it stays as short as it is', () => {
+  assert.equal(summarise('# T\n\nBarcode scanning is common in enterprise apps.'),
+    'Barcode scanning is common in enterprise apps.');
+});
+
+test('a dash ends a first sentence and never extends one', () => {
+  // The dash forms exist because a page can open with a sentence that never
+  // reaches a full stop - so a dash is where such a page is cut...
+  const opens = 'On SAP HANA you can match strings tolerantly — typos, missing letters, transposed '
+    + 'characters — with the CONTAINS function in fuzzy mode, and no exact match at all';
+  assert.equal(summarise(`# T\n\n${opens}`), 'On SAP HANA you can match strings tolerantly');
+
+  // ...and never where one is extended, which stops mid-clause: the sentence
+  // that follows is taken whole or not at all.
+  const extended = summarise('# T\n\nAn AI coding agent asked to write an abap2UI5 app can write ABAP. '
+    + 'What it cannot do is find out whether the app works — that has always needed a system.');
+  assert.match(extended, /needed a system\.$/);
+});
+
+test('a cut that leaves a bracket open is not a cut', () => {
+  const out = summarise('# T\n\nPull abap2UI5 with abapGit. (New to abapGit? Install it first — see abapGit; it is the one-time tool.) Then pull a release rather than main.');
+  assert.ok(!out.endsWith('Install it first'), 'the aside is not left half-open');
+  assert.equal((out.match(/\(/g) || []).length, (out.match(/\)/g) || []).length);
+});
+
+test('a version number is not the end of a sentence', () => {
+  const one = 'abap2UI5 runs on 7.02 and later, needs nothing installed on the frontend at all, and asks '
+    + 'the system for no service of its own.';
+  assert.equal(summarise(`# T\n\n${one} Which is the point of it.`), one);
+});
+
+test('a paragraph without a full stop in it is still cut to a length', () => {
+  const long = `# T\n\n${'word '.repeat(80)}`;
+  const out = summarise(long);
+  assert.ok(out.length <= 220, `${out.length} characters`);
+  assert.match(out, /\.\.\.$/);
+});
+
+test('code fences, headings and tables are not the description', () => {
+  const body = '# T\n\n```abap\nDATA(lo_x) = NEW cl_y( ).\n```\n\n| a | b |\n\nThe real opening sentence of the page, which is what a reader wants.';
+  assert.equal(summarise(body), 'The real opening sentence of the page, which is what a reader wants.');
+});


### PR DESCRIPTION
`summarise( )` writes the meta description of the 150 pages that declare none of their own, the note beside every entry in `llms.txt`, and the line under a search hit. Nobody writes it and nobody proofreads it, so its failures are all quiet ones — and it stopped at the **first** full stop, whatever that sentence happened to say:

> abap2UI5 has no e-mail control of its own
> All examples in these docs work without EML
> Not every problem raises an ABAP exception
> abap2UI5 works right away on ABAP 7.50 and later

Every one of those is the half of the paragraph that says what the page is *not* about. The sentence after it is the one that says what it is. Thirty-four of the hundred and fifty were under sixty characters; the median was 84, and a search snippet has room for about 155.

It now takes sentence ends until there are at least 110 characters and stops at the last one that stays under 200 — a description is a paragraph's opening, not the paragraph.

| | before | after |
|---|---|---|
| `cookbook/expert_more/email` | abap2UI5 has no e-mail control of its own | abap2UI5 has no e-mail control of its own — sending mail is plain ABAP via `cl_bcs_message` (or `cl_bcs` on older releases). |
| `advanced/downporting` | abap2UI5 works right away on ABAP 7.50 and later. | abap2UI5 works right away on ABAP 7.50 and later. On an earlier release, install the downported version, which supports R/3 NetWeaver 7.02 and later. |
| `cookbook/troubleshooting/common_failures` | Not every problem raises an ABAP exception. | Not every problem raises an ABAP exception. Many failures surface only in the browser, fail silently, or look like framework bugs when they are actually pattern mistakes. |

Two rules keep it from cutting mid-thought, and both are failures this change had before it was finished:

- **Past the first sentence, only a full stop counts.** The two dash forms exist because a page can open with a sentence that never reaches one; reaching for a *later* dash stops mid-clause, and it did — "…two additional database tables (`z2ui5_t_99` and `z2ui5_t_98`", bracket still open.
- **A candidate that leaves a bracket open is skipped.** The quickstart opens "Pull abap2UI5 with abapGit. (New to abapGit? Install it first — see …)", and the cut at that dash ended the description four words into an aside.

### What it moves

Over those 150 pages the median goes from **84 to 117** characters and the ones under 60 from **34 to 8** — the eight are pages whose whole opening paragraph is one short sentence, which is the honest answer for them. Eight pages get a *shorter* description than before, and all eight traded a 220-character cut through the middle of a word for a sentence that ends:

> **before** An ABAP team needs a screen. Not an application — a screen. A maintenance view for a customising table nobody wants to explain in SM30. A cockpit showing what last night's job actually did. An approval step for one de…
> **after** An ABAP team needs a screen. Not an application — a screen. A maintenance view for a customising table nobody wants to explain in SM30.

`llms.txt` grows from 34 to 39 kB for the same reason, which is the point of it.

### Verification

`test/summarise.test.mjs` pins the lot: what a declared description does, what one long sentence does, what a short one does, both dash rules, the bracket rule, a version number not ending a sentence, the length cap, and that a code fence or a table is not the description.

`npm run check` passes — the twelve gates, **135 unit tests**, 166 pages, 37 075 internal links, none of them dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_