### PR TITLE
The links a page writes by hand were the hole in link-samples' own promise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `docs/` | The pages. Sidebar and nav live in `docs/.vitepress/config.mjs` |
 | `docs/public/` | Static assets — **and** the generated `llms.txt`, `llms-full.txt` and per-page `.md`, which are gitignored |
 | `scripts/check-examples.mjs` | Extracts every fenced ABAP block that builds a view, compiles it against the real framework and lints the view it produces |
-| `scripts/link-samples.mjs` | Generates the *Working Samples* block on a page from its `samples:` frontmatter plus `SAMPLES.md` in an `abap2UI5/samples` checkout, and checks the link in both directions |
+| `scripts/link-samples.mjs` | Generates the *Working Samples* block on a page from its `samples:` frontmatter plus `SAMPLES.md` in an `abap2UI5/samples` checkout, checks the link in both directions, and resolves the source links a page writes by hand against the same checkout |
 | `scripts/generate-llms.mjs` | Builds `llms.txt` / `llms-full.txt` / per-page markdown from the sidebar. Runs inside `docs:build`, so the deploy publishes them |
 | `scripts/generate-api-reference.mjs` | Generates the client API reference — the block in `docs/resources/api.md` and `docs/public/api/client-api.json` — from `z2ui5_if_client` on the framework branch this site tracks (`main`); `--check` is the freshness gate |
 | `scripts/lib/client-interface.mjs` | Where `z2ui5_if_client` is fetched from (the ref comes from `lib/release.mjs`, shared with `check-api-names.mjs`) and the full parser `generate-api-reference.mjs` renders from |
@@ -68,7 +68,7 @@ it are decidable, and all twelve are decided before a merge:
 | `check:design` | the values the four bars are made of — the seven palette colours, the two type stacks, the two radii — against the copy [abap2UI5/playground](https://github.com/abap2UI5/playground) keeps, in **both** schemes. They are copied by hand on purpose (a stylesheet fetched across two deployments is a request in front of the first paint), and until this gate nothing compared the copies: they agreed because whoever touched one remembered the other. One had already drifted — two font stacks leading with different families, which is the same face on macOS and Windows and two different ones on Linux, so the same four words in the same bar measured 59/122/78/97px here and 65/141/87/110 there. It compares the EFFECTIVE value (a property the dark block does not redeclare keeps its light one), because the two sides switch schemes differently: `.dark` here, `[data-theme]` over there.
 
 **What it now guards is the second opinion, not the site.** Since the switch, the published pages link the playground's own `catalogue.css`, borrowed whole at build time — so the palette cannot drift from the playground's there, by construction. `style.css` is VitePress's, and VitePress is no longer served. Keep the gate: it is what says so when somebody edits `style.css` expecting the site to change |
-| `check:samples` | the **Working Samples** blocks, against [abap2UI5/samples](https://github.com/abap2UI5/samples) |
+| `check:samples` | the **Working Samples** blocks and the source links a page writes by hand, against [abap2UI5/samples](https://github.com/abap2UI5/samples) |
 
 **All four walking gates carry a floor.** A gate that checked nothing reports
 the same shape as a gate that found nothing wrong — which is precisely how
@@ -587,7 +587,15 @@ Delete a stub when the old URL has stopped receiving traffic, not before.
 - **A generated block in a page is committed.** The *Working Samples* blocks are
   written into the markdown so the site builds without a samples checkout. Run
   `npm run link:samples` after changing a page's `samples:` frontmatter;
-  `check:samples` fails if a rewrite would change anything. The client API
+  `check:samples` fails if a rewrite would change anything. It also resolves
+  every source link a page writes **by hand** — `github.com/abap2UI5/samples/blob/main/…`
+  in the prose rather than in a generated block — against that same checkout.
+  The 37 essay pages under `advanced/insights/` link a sample that way on
+  purpose (none of them carries a block: a "Full source:" sentence is the shape
+  an essay wants, not a see-also list at the end), and the samples repository
+  renumbers, so such a link is one renumber away from a 404 with nothing
+  watching it. Now something is, and it costs no request: CI clones
+  `abap2UI5/samples` in full for the catalogue, so the answer is a file lookup. The client API
   reference on `resources/api.md` works the same way: everything between its
   markers, plus `docs/public/api/client-api.json` next to it, comes from
   `npm run generate:api` — edit the intro around the block by hand, never the

--- a/scripts/link-samples.mjs
+++ b/scripts/link-samples.mjs
@@ -168,6 +168,8 @@ const problems = [];
 let pages = 0;
 let links = 0;
 let written = 0;
+let handwritten = 0;
+let handwrittenGone = 0;
 
 for (const file of markdownFiles(DOCS)) {
   const text = fs.readFileSync(file, 'utf8');
@@ -209,6 +211,54 @@ for (const file of markdownFiles(DOCS)) {
   }
 }
 
+/* And the links a page writes BY HAND, which are the hole in the promise this
+ * script's header makes. The generated block exists so that "a sample that is
+ * DELETED fails this script instead of leaving a 404 on the documentation
+ * site" - but that only covers the classes a page DECLARES. A sentence in the
+ * prose can name a sample the same way, straight at its source file:
+ *
+ *     see [sample 009](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_009.clas.abap)
+ *
+ * and 97 distinct paths across 164 links are written that way. Nothing looked
+ * at them. The samples repository RENUMBERS - its classes are named by number
+ * and the generators close gaps - so a link like that is one renumber away
+ * from a 404, and the reader is the one who finds out.
+ *
+ * check-api-names asks exactly this question for abap2UI5/abap2UI5, and it
+ * asks it over the network, one HEAD per path. Here the whole checkout is
+ * already open (CI clones it in full for the catalogue), so the answer is a
+ * file lookup: no request, and it fails on a path that moved as readily as on
+ * one that was deleted.
+ *
+ * The generated blocks are skipped - they are written FROM the catalogue, so
+ * checking them would only be checking this script against itself, and the
+ * declared-samples loop above already fails on a class the catalogue lost. */
+{
+  const seen = new Map();   // path in the samples repo -> pages that link it
+  for (const file of markdownFiles(DOCS)) {
+    let text = fs.readFileSync(file, 'utf8');
+    const from = text.indexOf(START);
+    if (from !== -1) {
+      const to = text.indexOf(END, from);
+      text = to === -1 ? text.slice(0, from) : text.slice(0, from) + text.slice(to);
+    }
+    for (const m of text.matchAll(/https:\/\/github\.com\/abap2UI5\/samples\/blob\/main\/([^)`"\s>]+)/g)) {
+      const target = m[1].split('#')[0].replace(/[.,;:)]+$/, '');
+      if (!seen.has(target)) seen.set(target, new Set());
+      seen.get(target).add(docsPath(file));
+    }
+  }
+  handwritten = seen.size;
+  for (const [target, onPages] of seen) {
+    if (fs.existsSync(path.join(samplesHome, target))) continue;
+    handwrittenGone += 1;
+    problems.push(
+      `${[...onPages].sort().join(', ')}: links ${target} in abap2UI5/samples, which is not there on main\n`
+      + '    renumbered, moved or deleted - a link every reader who clicks it gets a 404 from',
+    );
+  }
+}
+
 /* And the sweep the other way round, over the WHOLE catalogue rather than only
  * the classes some page happens to declare. Without it, renaming a page here
  * leaves the samples repository pointing at a 404 and nothing notices: the page
@@ -226,6 +276,8 @@ for (const [cls, hit] of catalogue) {
 
 console.log(`${catalogue.size} samples in the catalogue (${path.relative(ROOT, samplesHome) || samplesHome})`);
 console.log(`${pages} page(s) declare ${links} sample link(s)${CHECK ? '' : `, ${written} rewritten`}`);
+console.log(`${handwritten} source path(s) linked by hand in the prose`
+  + (handwrittenGone ? `, ${handwrittenGone} of them gone` : ', all present in the checkout'));
 
 if (problems.length) {
   console.error(`\n${problems.length} problem(s):`);


### PR DESCRIPTION
`scripts/link-samples.mjs` says in its own header why the generated block exists:

> a sample that is DELETED fails this script instead of leaving a 404 on the documentation site

That holds for the classes a page **declares**. It did not hold for the ones a page names in a sentence:

```
Full source: [`Z2UI5_CL_SMP_APP_497`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_497.clas.abap)
```

Nothing looked at that path — and the samples repository **renumbers**: its classes are named by number and its generators close gaps. A link written that way is one renumber away from a 404 that only a reader finds.

## Not an accident of one page

None of the **37 essays under `advanced/insights/` carries a Working Samples block**, and that is right — "Full source:" mid-paragraph is the shape an essay wants; a see-also list at the end is not. So the inline form stays, and it needs the guarantee the block already has.

It gets it **for no request at all**. CI already clones `abap2UI5/samples` in full for the catalogue, so where `check-api-names` asks this question of `abap2UI5/abap2UI5` over the network — one HEAD per path — this one is a file lookup, and it fails on a path that *moved* as readily as on one deleted.

Generated blocks are skipped: they are written *from* the catalogue, so checking them would be checking the script against itself, and the declared-samples loop already fails on a class the catalogue lost.

## Measured first, so the numbers are the site's

| | |
|---|---:|
| distinct `github.com` URLs on the built site | 332 (5801 occurrences) |
| of those, resolve | 280 |
| **404** | **0** |
| not checkable from here (proxy scope) | 50 |
| `"400"` that were a trailing slash in my checker, not the site | 2 |

| paths into `abap2UI5/samples` linked from the manual | |
|---|---:|
| distinct | 98 |
| inside generated blocks — already covered | 96 |
| **written by hand — the gap** | **2** |

And the declared links are exactly symmetric in both directions: **116** class → page claims in the samples repository, **116** page → class declarations here, none one-way.

## Verified

Both hand-written paths resolve today, so this lands green. Broken on purpose it names the page and the path:

```
1 problem(s):
  advanced/insights/01-somewhere-on-the-way-to-ui5: links src/01/z2ui5_cl_smp_app_497_moved.clas.abap
  in abap2UI5/samples, which is not there on main
    renumbered, moved or deleted - a link every reader who clicks it gets a 404 from
```

`npm run check` passes: twelve gates, 136 unit tests, 166 pages, 37,101 internal links, none dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_