### PR TITLE
An example you can type in, a fact sheet you can read, and a front door that says who may edit it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -609,6 +609,17 @@ The code travels in the playground's URL fragment, read out of the rendered
 block at click time — so nothing is hosted here, and the example that runs is
 the text on the page rather than a copy of it.
 
+**One example is editable, and it is marked in the fence.** ```abap edit gives
+the container `data-play="edit"`, and `theme/playground.js` then mounts the
+playground WITHOUT `view=app` — the editor and the running app side by side —
+and hides the printed listing while the frame is open, so the reader sees one
+copy of the code and it is the one they can type in. Close puts the listing
+back. Only the front door carries it: everywhere else the code is printed right
+above the frame and an editor beside that would be the same text twice. The
+flag never decides WHETHER there is a button, only what kind of frame it opens;
+an example the playground would refuse gains nothing by asking to be edited.
+`test/playground.test.mjs` pins all four cases.
+
 **Whether an example runs is the one question CI cannot answer** — only a
 playground can, and a playground is a three-minute build of another repository.
 So the rules in `docs/.vitepress/playground.mjs` are an approximation, they

--- a/docs/.vitepress/playground.mjs
+++ b/docs/.vitepress/playground.mjs
@@ -290,12 +290,23 @@ export function playgroundButton(md) {
   md.renderer.rules.fence = (tokens, idx, options, env, self) => {
     const html = fence(tokens, idx, options, env, self);
     const token = tokens[idx];
-    if (token.info.trim().split(/\s+/)[0] !== 'abap') return html;
+    const info = token.info.trim().split(/\s+/);
+    if (info[0] !== 'abap') return html;
     if (!isRunnable(token.content)) return html;
+    /* ```abap edit — the example the reader may CHANGE, not only start.
+     * The word rides in the fence's info string, which markdown-it hands over
+     * untouched and Shiki ignores: the block is still highlighted as abap and
+     * still says `abap` on its label. Being per-fence rather than per-page is
+     * the point - a page can carry one example to play with among several to
+     * read, and the flag sits on the example it belongs to. What it does to
+     * the frame is in theme/playground.js. */
+    const edit = info.includes('edit');
     return (
-      '<div class="a2ui5-play">' +
+      `<div class="a2ui5-play"${edit ? ' data-play="edit"' : ''}>` +
       html +
-      '<button class="a2ui5-play-run" type="button">Run this example</button>' +
+      '<button class="a2ui5-play-run" type="button">'
+      + (edit ? 'Run and edit this example' : 'Run this example') +
+      '</button>' +
       '</div>'
     );
   };

--- a/docs/.vitepress/theme/playground.js
+++ b/docs/.vitepress/theme/playground.js
@@ -19,13 +19,18 @@
  * example that runs cannot be a different one from the example that is
  * printed — there is only one copy of it, and it is the one on the page.
  *
- * **The app is shown, not the editor.** The code is already above it, in this
- * site's own font and highlighting; a second copy in an editor beside it would
- * be the same thing twice. What the page cannot show is the running app, so
- * that is what the frame shows. "Switch to Playground with this code" is one
- * link away for a reader who wants to change it — and it goes to the full
- * playground, editor and the Problems / abaplint panel included, in this tab,
- * not to another embedded frame.
+ * **The app is shown, not the editor — unless the example is one to play
+ * with.** The code is already above the frame, in this site's own font and
+ * highlighting, so an editor BESIDE it would be the same thing twice. That is
+ * still true, and it is why 63 of the 64 examples on this site mount the app
+ * on its own. The one that does not is the front door's, marked ```abap edit:
+ * there the frame carries the editor and the app, and the printed block is
+ * hidden while it runs — so there is still exactly one copy of the code, and
+ * that copy is the one you can type in. Close puts the listing back.
+ *
+ * "Switch to Playground with this code" stays either way, and goes to the full
+ * playground — the examples menu, Share, and the Problems / abaplint panel —
+ * in this tab, not to another embedded frame.
  */
 
 /* The published playground. Absolute rather than site-relative on purpose: it
@@ -79,14 +84,26 @@ async function start(button) {
   }
 
   const source = sourceOf(container);
+  const editable = container.dataset.play === 'edit';
   const demo = document.createElement('div');
   demo.className = 'abap2ui5-demo';
-  demo.dataset.view = 'app';
+  /* `view=app` is what takes the editor out of the frame; leaving it off is
+   * the embed's own default, which is the editor and the running app side by
+   * side with the rest of the playground's furniture tucked away. */
+  if (!editable) demo.dataset.view = 'app';
+  /* An app alone is content-sized and grows; a split needs room for two panes
+   * before either is worth looking at. */
+  if (editable) demo.dataset.height = '620';
   /* Already clicked — the loader's own button would be a second one. */
   demo.dataset.auto = '1';
   demo.dataset.code = source;
   container.append(demo);
   embed.setUp(container);
+  /* The printed listing steps aside for the editable one: the frame now shows
+   * the same source in a place the reader can type. It is hidden rather than
+   * removed - `sourceOf` reads it, Close brings it back, and a reader who
+   * copies is copying the block that was always there. */
+  if (editable) listing(container)?.toggleAttribute('hidden', true);
 
   button.replaceWith(bar(container, demo, embed, source));
 }
@@ -105,8 +122,9 @@ function bar(container, demo, embed, source) {
     /* The frame is a whole ABAP runtime; removing the element is what frees
      * it. Then the block is back to what it was, button and all. */
     demo.remove();
+    listing(container)?.toggleAttribute('hidden', false);
     delete container.dataset.running;
-    bar.replaceWith(runButton());
+    bar.replaceWith(runButton(container));
   });
 
   /* In THIS tab, and the label says so: a switch to the playground with the
@@ -157,11 +175,15 @@ function standalone(href) {
   return url.href;
 }
 
-const runButton = () => {
+/** The printed block this container was built around. */
+const listing = (container) => container.querySelector('div[class*="language-"]');
+
+const runButton = (container) => {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'a2ui5-play-run';
-  button.textContent = 'Run this example';
+  button.textContent = container?.dataset.play === 'edit'
+    ? 'Run and edit this example' : 'Run this example';
   return button;
 };
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,25 +84,27 @@ features:
     target: _self
 ---
 
-## What it needs, and what it does not
+## abap2UI5 at a glance
 
 | | |
 |---|---|
-| **Runs on** | NetWeaver 7.02 and up, S/4HANA, ABAP Cloud, on-premise, private and public cloud, and the trial systems |
-| **Installed with** | [abapGit](/get_started/quickstart) — one repository, no transport of frontend artefacts, no BSP application to maintain |
+| **Runs on** | NetWeaver 7.02 and up, S/4HANA, ABAP Cloud — on-premise, private and public cloud, and the trial systems |
+| **Same everywhere** | An app written on 7.02 runs unchanged on ABAP Cloud; [Downporting](/advanced/downporting) is how |
+| **Installed with** | [abapGit](/get_started/quickstart) — one repository, no transport of frontend artefacts, no BSP application |
 | **Needs no** | JavaScript, OData service, RAP business object, CDS view, frontend project or Node toolchain |
+| **You write** | One ABAP class per app — the view, the model and the event handling in it |
 | **Speaks** | UI5, over stateless HTTP roundtrips against the framework's own service |
+| **Renders with** | [OpenUI5 from its CDN](/configuration/ui5_versions) by default; one exit points it at SAPUI5, a pinned version, or the UI5 your system already ships |
+| **Reaches users in** | A browser tab, a [Fiori launchpad](/configuration/launchpad) tile, or [SAP Mobile Start](/configuration/mobile_start) on iOS and Android |
 | **Licence** | MIT — free for commercial use, no per-user fee, and the code is [on GitHub](https://github.com/abap2UI5/abap2UI5) |
-
-Old releases are not second-class: an app written on 7.02 uses the same API as
-one on ABAP Cloud. [Downporting](/advanced/downporting) explains how.
 
 ## One class, one app
 
-Here is a whole abap2UI5 app. Press **Run this example** — it starts in your
-browser, on the real framework, with nothing to install.
+Here is a whole abap2UI5 app. Press **Run and edit this example** — it opens in
+your browser on the real framework, with nothing to install, and the code is
+yours to change: edit it, run it again, break it.
 
-```abap
+```abap edit
 CLASS zcl_app_hello DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -670,7 +670,7 @@ const tile = (f) => `<a class="tile" href="${esc(linkOf(f.link))}"${f.target ? `
       <span class="tile-details">${esc(f.details)}</span>
     </a>`;
 
-const home = ({ body, fm }) => {
+const home = ({ body, fm, page }) => {
   const h = fm.hero || {};
   const img = h.image || {};
   return `<main class="home" id="main-content" tabindex="-1">
@@ -698,6 +698,17 @@ const home = ({ body, fm }) => {
   <section class="tiles">${(fm.features || []).map(tile).join('')}
   </section>
   <div class="vp-doc">${body}</div>
+  <!-- The front door is a page of this repository like any other, and it was
+       the only one that did not say so: the home layout has no doc-foot, so the
+       one page most likely to want a correction was the one page with no way
+       to offer it. Same markup and same class as a chapter's, so it is the
+       same footer a reader has already met 165 times. (No backticks in here -
+       this comment is inside a template literal, and one would end it.) -->
+  <div class="doc-foot">
+    <a class="edit" href="${esc((config.themeConfig.editLink?.pattern || '').replace(':path', page))}"
+       target="_blank" rel="noopener">${esc(config.themeConfig.editLink?.text || 'Edit this page on GitHub')} ↗</a>
+    <span class="updated">Last updated: <time datetime="${lastTouched(page)}">${lastTouched(page)}</time></span>
+  </div>
 </main>`;
 };
 
@@ -1035,7 +1046,7 @@ for (const page of pages) {
       description: isHome ? (fm.description || SITE_DESC) : (describe(src) || SITE_DESC),
     }),
     bar: isHome ? BAR_HOME : BAR_DOCS,
-    main: isHome ? home({ body, fm }) : chapter({ body, page, route }),
+    main: isHome ? home({ body, fm, page }) : chapter({ body, page, route }),
   });
 
   const to = path.join(OUT, 'docs', page.replace(/\.md$/, '.html'));

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -683,6 +683,21 @@ html { scroll-padding-top: 62px; }
 /* 32 from the bottom of the last card, which is the gap the theme leaves; it
    writes it as 24 under a row that pads its cards by 8. */
 .home .vp-doc { margin-top: 32px; }
+/* The fact sheet is a two-column list, not a spreadsheet: its right-hand cells
+   are sentences, and a sentence set across the full 1160 is a line nobody
+   tracks back. `.vp-doc > p` is already held to 74ch for that reason, and the
+   table ran to twice the width of the paragraph under it. It gets the same
+   measure, and the label column takes only what its longest label needs. */
+.home .vp-doc table { max-width: 74ch; }
+/* Its header row is empty - the left column is labels, not a heading - and an
+   empty grey band over the first label is furniture with nothing in it. */
+.home .vp-doc table thead { display: none; }
+.home .vp-doc table td:first-child { width: 1%; white-space: nowrap; }
+@media (max-width: 620px) {
+  /* …except on a phone, where "Reaches users in" on one line is what pushes
+     the page sideways. Below the fold the labels wrap like everything else. */
+  .home .vp-doc table td:first-child { white-space: normal; }
+}
 .home .vp-doc > :first-child { margin-top: 0; }
 
 @media (max-width: 860px) {

--- a/test/playground.test.mjs
+++ b/test/playground.test.mjs
@@ -19,6 +19,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { abapOnly, playgroundExample } from '../docs/.vitepress/playground.mjs';
+import { playgroundButton } from '../docs/.vitepress/playground.mjs';
+
+/** The fence as markdown-it renders it once `playgroundButton` is installed —
+ *  a stub renderer, because what is under test is the wrapper this adds and
+ *  not Shiki's highlighting. */
+function renderFence(info, code) {
+  const md = { renderer: { rules: { fence: () => '<div class="language-abap"><pre><code/></pre></div>' } } };
+  playgroundButton(md);
+  return md.renderer.rules.fence([{ info, content: code }], 0, {}, {}, {});
+}
 
 /** A complete app class, with `body` as the whole of `main`. */
 const app = (name, body) => `CLASS ${name} DEFINITION PUBLIC.
@@ -224,4 +234,43 @@ test('comments go, string templates keep their braces', () => {
   // The delimiters stay so nothing shifts; a double quote inside a literal is
   // not the start of a comment.
   assert.match(stripped, /DATA\(z\) = ` {5}`\./);
+});
+
+/* ---------------------------------------------------------------------------
+ * ```abap edit — the example a reader may CHANGE.
+ *
+ * Everywhere else on this site the frame shows the running app alone: the code
+ * is printed right above it, so an editor beside that would be the same text
+ * twice. The front door is the exception. There the point IS to type in it, so
+ * the frame carries the editor and the app, and the printed block is hidden
+ * while it runs — one copy of the code, and it is the editable one.
+ *
+ * The flag rides in the fence's info string. That is the half these tests can
+ * reach: whether the marker survives markdown-it and reaches the container as
+ * `data-play="edit"`, which is what theme/playground.js reads to decide the
+ * frame. The frame itself is the playground's, and not in this repository.
+ */
+test('a plain runnable fence is a Run button and nothing else', () => {
+  const html = renderFence('abap', app('z2ui5_cl_sample_x', DISPLAY));
+  assert.match(html, /class="a2ui5-play"/);
+  assert.equal(html.includes('data-play'), false);
+  assert.match(html, />Run this example</);
+});
+
+test('`edit` marks the container and says so on the button', () => {
+  const html = renderFence('abap edit', app('z2ui5_cl_sample_x', DISPLAY));
+  assert.match(html, /class="a2ui5-play" data-play="edit"/);
+  assert.match(html, />Run and edit this example</);
+});
+
+test('`edit` on a fence that cannot run is still no button', () => {
+  // The flag says what KIND of frame, never whether there is one: an example
+  // the playground would refuse must not gain a button by asking to be edited.
+  const html = renderFence('abap edit', 'DATA(x) = 1.');
+  assert.equal(html.includes('a2ui5-play'), false);
+});
+
+test('the marker only counts on an abap fence', () => {
+  const html = renderFence('json edit', app('z2ui5_cl_sample_x', DISPLAY));
+  assert.equal(html.includes('a2ui5-play'), false);
 });


### PR DESCRIPTION
Four things on the front door.

## 1. The example is editable

The Run button mounted the running app alone, and `theme/playground.js` argued why: the code is printed right above the frame, so an editor beside it would be the same text twice. That holds for the 63 examples inside chapters. It does not hold for the front door, where the point is to **have a go**.

So the fence there is ` ```abap edit `: the frame carries the editor **and** the app, and the printed listing is hidden while it runs. One copy of the code, and it is the one you can type in. `Close` puts the listing back.

The flag rides in the fence's info string — markdown-it hands it over untouched and Shiki ignores it, so the block is still highlighted as `abap` and still labelled `abap`. Per-fence rather than per-page on purpose: a page can carry one example to play with among several to read. It decides what *kind* of frame opens, **never whether there is a button** — an example the playground would refuse gains nothing by asking to be edited.

**Verified against a locally built playground**, not by reading the code:

```
after : {"frame":true,"src":"…/playground/?embed=1#2jVNdb6MwEPwrezwR6cJDpb5USiQKjmKJkCjQ…",
         "height":620,"listingVisible":false,"bar":["Close","Switch to Playground with this code"]}
closed: {"frame":false,"listingVisible":true,"button":"Run and edit this example"}
```

No `view=app` in the URL, Monaco on the left with the class in it, "Hello abap2UI5" running on the right. No page errors.

## 2. The fact sheet is an overview, and fits the measure

"What it needs, and what it does not" was five rows set across the full 1160px — twice the width of the paragraph under it, and a sentence that wide is a line nobody tracks back.

It is **"abap2UI5 at a glance"** now: **nine rows**, capped at the same `74ch` the prose keeps (**1160 → 607px**), the label column taking only what its longest label needs and wrapping again below 620. Its empty header band is gone.

Four rows are new, each sourced from the chapter it links:

| row | from |
|---|---|
| **Same everywhere** — an app written on 7.02 runs unchanged on ABAP Cloud | the sentence that stood *under* the table, moved into it and deleted below |
| **You write** — one ABAP class per app | — |
| **Renders with** — OpenUI5 from its CDN by default; one exit for SAPUI5, a pin, or the system's own | `get_started/about` |
| **Reaches users in** — a browser tab, a launchpad tile, or SAP Mobile Start | `configuration/launchpad`, `configuration/mobile_start` |

## 3. The front door has an edit link

Every one of the other 165 pages ends with "Edit this page on GitHub". The home layout has no `doc-foot`, so the page most likely to attract a correction was the only one with no way to offer one. Same markup, same class, same footer the reader has already met.

## 4. Measured after

| | desktop | phone (390) |
|---|---:|---:|
| horizontal overflow | 0 | 0 |
| fact table | 607px | 350px |
| prose measure | 654px | 350px |

`test/playground.test.mjs` pins the fence flag in all four cases: a plain fence carries no marker, `edit` marks the container and the button, `edit` on an example that cannot run is still no button, and the marker only counts on an `abap` fence.

`npm run check` passes: twelve gates, 140 unit tests, 166 pages, 37,104 internal links, none dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_