### PR TITLE
The front door stops being one column with an empty half

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -609,6 +609,18 @@ The code travels in the playground's URL fragment, read out of the rendered
 block at click time — so nothing is hosted here, and the example that runs is
 the text on the page rather than a copy of it.
 
+**The front door's example starts itself.** Everywhere else nothing is fetched
+until a click — a chapter with seven Run buttons must not pull seven ABAP
+runtimes. The one marked `edit` is watched by an `IntersectionObserver` and
+mounts when it scrolls within 400px of the viewport, because "one ABAP class is
+one UI5 app" is a claim while it is printed and a fact once it runs beside its
+own source. A reader who never scrolls past the tiles still fetches nothing; one
+who asks for less data (`prefers-reduced-data`, or `navigator.connection
+.saveData`) is never sent it and keeps the button. **A self-start that fails is
+silent** — the button comes back and no error is printed, because a message
+about something nobody asked for reads as a broken front door when what is
+broken is the network.
+
 **One example is editable, and it is marked in the fence.** ```abap edit gives
 the container `data-play="edit"`, and `theme/playground.js` then mounts the
 playground WITHOUT `view=app` — the editor and the running app side by side —

--- a/docs/.vitepress/playground.mjs
+++ b/docs/.vitepress/playground.mjs
@@ -301,12 +301,18 @@ export function playgroundButton(md) {
      * read, and the flag sits on the example it belongs to. What it does to
      * the frame is in theme/playground.js. */
     const edit = info.includes('edit');
+    const button = '<button class="a2ui5-play-run" type="button">'
+      + (edit ? 'Run and edit this example' : 'Run this example')
+      + '</button>';
+    /* Under the code everywhere else - the reader has just read the example and
+     * the button is the next thing. ABOVE it for an editable one: the offer is
+     * the point there, and 41 lines of ABAP between the sentence that makes it
+     * and the button that takes it up is a scroll nobody should need. What
+     * replaces the button when it is pressed - Close, and the link into the
+     * full playground - lands in the same place. */
     return (
       `<div class="a2ui5-play"${edit ? ' data-play="edit"' : ''}>` +
-      html +
-      '<button class="a2ui5-play-run" type="button">'
-      + (edit ? 'Run and edit this example' : 'Run this example') +
-      '</button>' +
+      (edit ? button + html : html + button) +
       '</div>'
     );
   };

--- a/docs/.vitepress/theme/playground.js
+++ b/docs/.vitepress/theme/playground.js
@@ -67,10 +67,11 @@ function fail(container, message) {
   container.append(note);
 }
 
-async function start(button) {
+async function start(button, { unasked = false } = {}) {
   const container = button.closest('.a2ui5-play');
   if (!container || container.dataset.running) return;
   container.dataset.running = '1';
+  const label = button.textContent;
   button.disabled = true;
   button.textContent = 'Starting the ABAP runtime…';
 
@@ -78,6 +79,16 @@ async function start(button) {
   try {
     embed = await loader();
   } catch (e) {
+    /* A reader who PRESSED the button is owed an explanation. A reader who did
+     * not - the front door's example starts itself - is owed silence and the
+     * button back: an error message for something nobody asked for is a broken
+     * front door, and the page is not broken, the network is. */
+    if (unasked) {
+      delete container.dataset.running;
+      button.disabled = false;
+      button.textContent = label;
+      return;
+    }
     button.remove();
     fail(container, String(e.message || e));
     return;
@@ -187,12 +198,54 @@ const runButton = (container) => {
   return button;
 };
 
+/* Has the reader asked not to be sent three megabytes? Two ways to say it -
+ * the media query and the Save-Data header's client-side twin - and either is
+ * enough. Neither takes the example away: the button is still there, and it
+ * still starts on a press. */
+const wantsLessData = () =>
+  matchMedia?.('(prefers-reduced-data: reduce)').matches
+  || navigator.connection?.saveData === true;
+
+/* The editable example starts ITSELF, once, when it comes into view.
+ *
+ * "Nothing is fetched until somebody clicks" is why every other example on
+ * this site waits, and it still holds for them: a chapter with seven Run
+ * buttons must not pull seven runtimes. The front door is one example, and it
+ * is the whole argument the page makes - "one ABAP class is one UI5 app" is a
+ * claim while it is printed and a fact once it is running beside its own
+ * source. A reader who never scrolls past the tiles still fetches nothing, and
+ * a reader who asked for less data is never sent it.
+ *
+ * `rootMargin` starts it a screen early so it is already up by the time it is
+ * read, and the observer lets go after the first hit - this happens once. */
+function armSelfStart() {
+  if (!window.IntersectionObserver || wantsLessData()) return;
+  const seen = new WeakSet();
+  const watch = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      watch.unobserve(entry.target);
+      const button = entry.target.querySelector('.a2ui5-play-run');
+      if (button) start(button, { unasked: true });
+    }
+  }, { rootMargin: '400px 0px' });
+  for (const el of document.querySelectorAll('.a2ui5-play[data-play="edit"]')) {
+    if (seen.has(el)) continue;
+    seen.add(el);
+    watch.observe(el);
+  }
+}
+
 /* One listener for the whole site, installed once. VitePress swaps pages
  * without reloading, so anything bound per page has to be re-bound on every
- * navigation; a delegated listener never notices. */
+ * navigation; a delegated listener never notices. The observer does, so it is
+ * armed again after a navigation - and on the published site, where every
+ * navigation is a load, the second call never happens. */
 export function setUpPlayground() {
   document.addEventListener('click', (e) => {
     const button = e.target.closest?.('.a2ui5-play-run');
     if (button) start(button);
   });
+  armSelfStart();
+  return armSelfStart;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,14 @@ hero:
     - theme: alt
       text: What it is
       link: /get_started/about
+  # The one thing a stranger checks before anything else: does somebody
+  # actually run this? It was the third paragraph of "What it costs", 2400px
+  # down the page, which is nowhere. One line, under the buttons that answer
+  # "what do I do", saying it is not a demo.
+  proof: In productive use today — EWM and PP apps on ABAP 7.57 and 7.55, on desktop and on mobile.
+  proofLink:
+    text: who is building with it
+    link: /resources/who_uses
 
 # The other three places the bar names, in the order the bar names them. Not
 # three sections of this site any more: a reader on this page is choosing
@@ -97,6 +105,21 @@ features:
 | **Renders with** | [OpenUI5 from its CDN](/configuration/ui5_versions) by default; one exit points it at SAPUI5, a pinned version, or the UI5 your system already ships |
 | **Reaches users in** | A browser tab, a [Fiori launchpad](/configuration/launchpad) tile, or [SAP Mobile Start](/configuration/mobile_start) on iOS and Android |
 | **Licence** | MIT — free for commercial use, no per-user fee, and the code is [on GitHub](https://github.com/abap2UI5/abap2UI5) |
+
+## What it costs
+
+Nothing. [MIT licensed](/resources/license) and free commercially — no licence
+key, no subscription, no per-user fee, nothing to activate.
+
+**Nobody counts your users, because nothing is counting.** An abap2UI5 app is
+a standard UI5 freestyle application served by your own ABAP stack: ten users and
+ten thousand are the same to it, and the SAP licensing you have is the licensing
+you keep. Nothing new to operate either — the app is an ABAP class in the system
+it already runs on.
+
+**And you are not on your own with it.** [Support](/resources/support) is the
+community on GitHub and in the abapGit Slack channel, plus companies and
+freelancers offering implementation, training and support agreements.
 
 ## One class, one app
 
@@ -156,23 +179,6 @@ ENDCLASS.
   repository, no build step.
 - **Events come back as ABAP.** The button press arrives in `check_on_event( )`,
   in the same class, with the model already updated.
-
-## What it costs
-
-Nothing. [MIT licensed](/resources/license) and free commercially — no licence
-key, no subscription, no per-user fee, nothing to activate.
-
-**Nobody counts your users, because nothing is counting.** An abap2UI5 app is
-a standard UI5 freestyle application served by your own ABAP stack: ten users and
-ten thousand are the same to it, and the SAP licensing you have is the licensing
-you keep. Nothing new to operate either — the app is an ABAP class in the system
-it already runs on.
-
-**And you are not on your own with it.** [Support](/resources/support) is the
-community on GitHub and in the abapGit Slack channel, plus companies and
-freelancers offering implementation, training and support agreements. It is
-already carrying customer work [on their own account](/resources/who_uses) — EWM
-and PP apps on 7.57 and 7.55, on desktop and on mobile.
 
 ## Developing with AI
 

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -670,6 +670,33 @@ const tile = (f) => `<a class="tile" href="${esc(linkOf(f.link))}"${f.target ? `
       <span class="tile-details">${esc(f.details)}</span>
     </a>`;
 
+/* ---- the front door's bands ------------------------------------------
+ *
+ * Every chapter is one column of prose with a sidebar and an outline beside
+ * it; the front door has neither, so under the tiles it was 654px of text in
+ * a 1160px container and the right half of the page was empty from the fact
+ * sheet down. That reads as a page that ran out of material.
+ *
+ * So the markdown's H2 sections become BANDS, and the stylesheet decides which
+ * of them share a row and which take the width. Nothing is written twice and
+ * the markdown stays flat markdown - the only thing this adds is a wrapper per
+ * section, carrying the id VitePress already put on the heading, which is what
+ * the CSS keys on. A section nobody has styled is simply a band on its own,
+ * which is what every one of them was before.
+ *
+ * Split on the H2s rather than on a marker in the source: the heading is what
+ * a section IS here, and a marker would be a second thing to keep in step. */
+const bands = (body) => {
+  const parts = body.split(/(?=<h2\b)/);
+  /* Anything before the first heading - there is none today - stays as it is
+   * rather than being given a band it did not ask for. */
+  const lead = parts[0].startsWith('<h2') ? '' : parts.shift();
+  return lead + parts.map((part) => {
+    const id = (part.match(/^<h2 id="([^"]+)"/) || [, ''])[1];
+    return `<section class="band"${id ? ` data-band="${esc(id)}"` : ''}>${part}</section>`;
+  }).join('');
+};
+
 const home = ({ body, fm, page }) => {
   const h = fm.hero || {};
   const img = h.image || {};
@@ -682,6 +709,8 @@ const home = ({ body, fm, page }) => {
       <div class="hero-actions">${(h.actions || []).map((a) => `
         <a class="hero-action ${a.theme === 'brand' ? 'primary' : 'plain'}" href="${esc(linkOf(a.link))}"${a.target ? ` target="${esc(a.target)}"` : ''}>${esc(a.text)}</a>`).join('')}
       </div>
+      ${h.proof ? `<p class="hero-proof">${esc(h.proof)}${h.proofLink
+        ? ` <a href="${esc(linkOf(h.proofLink.link))}">${esc(h.proofLink.text)} &rsaquo;</a>` : ''}</p>` : ''}
     </div>
     ${img.src ? (() => {
       /* The one image on this site that is NOT lazy - it is the first thing on
@@ -697,7 +726,7 @@ const home = ({ body, fm, page }) => {
   </section>
   <section class="tiles">${(fm.features || []).map(tile).join('')}
   </section>
-  <div class="vp-doc">${body}</div>
+  <div class="vp-doc bands">${bands(body)}</div>
   <!-- The front door is a page of this repository like any other, and it was
        the only one that did not say so: the home layout has no doc-foot, so the
        one page most likely to want a correction was the one page with no way

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -683,6 +683,65 @@ html { scroll-padding-top: 62px; }
 /* 32 from the bottom of the last card, which is the gap the theme leaves; it
    writes it as 24 under a row that pads its cards by 8. */
 .home .vp-doc { margin-top: 32px; }
+
+/* ---- the front door uses its whole width ----------------------------
+ *
+ * Under the tiles the page was one 654px column in a 1160px container, and
+ * everything right of it was empty from the fact sheet down. The bands are
+ * one grid row each by default - which is what every section was - and two of
+ * them are told otherwise:
+ *
+ *   at a glance | what it costs   two short, scannable sections, side by side
+ *   one class, one app            the whole width, because the live editor in
+ *                                 it is a code pane AND a running app
+ *
+ * Everything else keeps the 74ch measure prose is set in. A narrow section
+ * between two wide ones reads as rhythm; a narrow PAGE reads as an empty one.
+ *
+ * The pair is ADJACENT IN THE MARKDOWN, and has to be. Placing them on one row
+ * with grid-row while a full-width band sat between them in the source would
+ * have put the visual order and the reading order out of step - a keyboard
+ * moving down the page would have jumped from the left column to something two
+ * screens below and back. So the source says what the eye sees. It costs
+ * nothing to read either: "what it runs on" and "what it costs" are the two
+ * questions asked before anybody looks at code, and the example now starts
+ * ~300px higher for being under one row instead of two. */
+.home .vp-doc.bands {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 48px;
+}
+.home .band { grid-column: 1 / -1; min-width: 0; }
+.home .band > :first-child { margin-top: 0; }
+/* The prose measure is per band now: a half-width band is already narrower
+   than 74ch, and capping it again would leave a gutter inside a gutter. */
+.home .band > p, .home .band > ul, .home .band > ol { max-width: 74ch; }
+
+.home .band[data-band="abap2ui5-at-a-glance"] { grid-column: 1; }
+.home .band[data-band="what-it-costs"] { grid-column: 2; }
+/* Two columns of one row: the rule over the second would cut the first in
+   half, and its heading sits on the same line as the other's. */
+.home .band[data-band="what-it-costs"] > h2 { border-top-color: transparent; }
+
+/* The example is the widest thing on the page because what it opens is two
+   panes - the ABAP on the left, the app it renders on the right. Held to a
+   column, neither is worth looking at. */
+.home .band[data-band="one-class-one-app"] .a2ui5-play,
+.home .band[data-band="one-class-one-app"] > p { max-width: none; }
+
+@media (max-width: 860px) {
+  /* One column again: two 300px columns of prose are worse than a long page. */
+  .home .vp-doc.bands { display: block; }
+  .home .band[data-band="what-it-costs"] > h2 { border-top-color: var(--line); }
+}
+
+/* ---- what a stranger checks first ----------------------------------- */
+.hero-proof {
+  margin: 14px 0 0; font-size: 13px; line-height: 20px; color: var(--fg-dim);
+  max-width: 46ch;
+}
+.hero-proof a { color: var(--a2ui5-red); text-decoration: none; white-space: nowrap; }
+.hero-proof a:hover { text-decoration: underline; }
 /* The fact sheet is a two-column list, not a spreadsheet: its right-hand cells
    are sentences, and a sentence set across the full 1160 is a line nobody
    tracks back. `.vp-doc > p` is already held to 74ch for that reason, and the

--- a/test/playground.test.mjs
+++ b/test/playground.test.mjs
@@ -274,3 +274,13 @@ test('the marker only counts on an abap fence', () => {
   const html = renderFence('json edit', app('z2ui5_cl_sample_x', DISPLAY));
   assert.equal(html.includes('a2ui5-play'), false);
 });
+
+test('the editable example puts its button ABOVE the code', () => {
+  // 41 lines of ABAP between the sentence that offers the example and the
+  // button that takes it up is a scroll nobody should need. Everywhere else
+  // the button stays under the code, where the reader arrives having read it.
+  const plain = renderFence('abap', app('z2ui5_cl_sample_x', DISPLAY));
+  const edit = renderFence('abap edit', app('z2ui5_cl_sample_x', DISPLAY));
+  assert.ok(plain.indexOf('<button') > plain.indexOf('language-abap'));
+  assert.ok(edit.indexOf('<button') < edit.indexOf('language-abap'));
+});


### PR DESCRIPTION
The four things still wrong with this page, measured and fixed.

## 1. The right half was empty from the fact sheet down

Every chapter is a column of prose with a sidebar and an outline beside it. The front door has neither, so under the tiles it was **654px of text in a 1160px container** — which reads as a page that ran out of material.

The `H2` sections are **bands** now, and the stylesheet decides which share a row:

| band | width |
|---|---|
| `at a glance` \| `what it costs` | half each — two short, scannable sections, and the two questions anybody asks before looking at code |
| `one class, one app` | the whole width, because what it opens is two panes |

Below 860px it is one column again; two 300px columns of prose are worse than a long page.

**The pair is adjacent in the markdown, and had to be.** Placing them on one row with `grid-row` while a full-width band sat between them in the source would have put the visual order and the reading order out of step — a keyboard moving down the page would have jumped two screens and back. So the source says what the eye sees. It costs nothing to read, and the example starts **300px higher** for being under one row instead of two.

## 2. 870 pixels of code before the button

The sentence said "Press **Run and edit this example**" and the button sat under 41 lines of ABAP. It is above them now — for an editable example only. Everywhere else the reader arrives at the button having just read the code, which is where it belongs.

## 3. Nowhere did you see a finished app

No screenshot: the live editor already has an output pane, so it shows itself. The front door's example is watched by an `IntersectionObserver` and mounts when it scrolls within 400px of the viewport — the ABAP on the left, **"Hello abap2UI5" running on the right**, 1118 of the 1160 pixels wide.

"Nothing is fetched until somebody clicks" still holds everywhere else, and it needed answering here rather than waving past:

- a reader who never scrolls past the tiles fetches nothing;
- one who asks for less data (`prefers-reduced-data`, `navigator.connection.saveData`) is never sent it and keeps the button;
- **a self-start that fails is silent** — the button comes back, no error is printed. A message about something nobody asked for reads as a broken front door when what is broken is the network.

Verified both ways. Against a locally built playground:

```
on load, before any scroll: {"frame":false}
after scrolling to it     : {"frame":true,"height":620,"width":1118,"listingVisible":false}
```

and with the playground unreachable:

```
{"button":"Run and edit this example","disabled":false,"failNote":false,"listingVisible":true}
```

— indistinguishable from a page that never tried.

## 4. The proof was buried

"Already carrying customer work — EWM and PP apps on 7.57 and 7.55" was the third paragraph of *What it costs*, 2400px down. It is one line under the hero buttons now, where a stranger is still looking — and gone from where it was, rather than said twice.

## Measured

| width | overflow | glance | costs | example |
|---|---:|---|---|---|
| 1440 | 0 | 153..689 | 737..1273 | 153..1273 |
| 1280 | 0 | 73..609 | 657..1193 | 73..1193 |
| 860 | 0 | full | full | full |
| 390 | 0 | full | full | full |

Page height **3485 → 3164px (−9%)**, no console errors at any width.

`npm run check` passes: twelve gates, 141 unit tests, 166 pages, 37,104 internal links, none dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_