### PR TITLE
Retitle #2 to what it now argues

### DIFF
--- a/blog/teaser-posts.md
+++ b/blog/teaser-posts.md
@@ -27,7 +27,7 @@ attached article preview, so the post carries no inline URL. 744 characters.
 >
 > #ABAP #SAP #UI5
 
-## abap2UI5 Is Not a Programming Model
+## abap2UI5 in Your Favourite Programming Model
 
 Plain text — LinkedIn renders no markdown.
 

--- a/blog/teaser-posts.md
+++ b/blog/teaser-posts.md
@@ -31,25 +31,24 @@ attached article preview, so the post carries no inline URL. 744 characters.
 
 Plain text — LinkedIn renders no markdown.
 
-> Before you use a framework, you want to know what it expects from you: a
-> structure to follow, a lifecycle to fit into, layers to fill in.
+> With abap2UI5 you start by writing an ABAP class, the way you used to start a
+> report with a selection screen. One interface, one method — that is the whole
+> contract.
 >
-> For abap2UI5 it is one interface with one method. No data model, no service,
-> no binding, no annotations, no BSP per app, no frontend artefact to transport.
+> Beyond that there are no rules. No service, no binding, no annotations,
+> nothing to transport but the class — and no demands on how you design your
+> model.
 >
-> Which is why it composes instead of competing. The new article shows one app
-> and three save handlers: EML against a business object, MODIFY against a
-> table, a BAPI call. The framework never learns which — it could just as well
-> be the EWM classes, or whatever SAP releases next.
+> The new article shows the same edit screen three times: through a RAP business
+> object, straight to a database table, and against a BAPI from twenty years
+> ago. Three programming models, one unchanged UI class.
 >
-> And what it does not give you: no data model, no transactional buffer, no
-> generated UI. That is what RAP is for, and for a straightforward use case done
-> the standard way that is where you want to be. abap2UI5 sits next to it, for
-> the screen that would otherwise not get built at all.
+> Where a strict programming model fits, use it. This is one more option next to
+> it, for the screen that would otherwise not get built at all.
 >
 > New article 🎉
 >
-> What does your UI framework ask of your architecture?
+> Which programming model would sit behind your screen?
 >
 > #ABAP #SAP #UI5
 

--- a/blog/teaser-posts.md
+++ b/blog/teaser-posts.md
@@ -27,7 +27,7 @@ attached article preview, so the post carries no inline URL. 744 characters.
 >
 > #ABAP #SAP #UI5
 
-## abap2UI5 in Your Favourite Programming Model
+## abap2UI5 in Your Favorite Programming Model
 
 Plain text — LinkedIn renders no markdown.
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -632,7 +632,7 @@ export default defineConfig({
               // numbers are part of each title on purpose: the articles are
               // posted one at a time, and "#21" is how a reader refers to one.
               { text: "#1 Somewhere on the Way to UI5, We Lost RTTS", link: "/advanced/insights/01-somewhere-on-the-way-to-ui5" },
-              { text: "#2 abap2UI5 in Your Favourite Programming Model", link: "/advanced/insights/02-your-favourite-programming-model" },
+              { text: "#2 abap2UI5 in Your Favorite Programming Model", link: "/advanced/insights/02-your-favorite-programming-model" },
               { text: "#3 The Cost of a Screen", link: "/advanced/insights/03-the-cost-of-a-screen" },
               { text: "#4 No Annotation in Between", link: "/advanced/insights/04-no-annotation-in-between" },
               { text: "#5 UI5 Over-the-Wire", link: "/advanced/insights/05-ui5-over-the-wire" },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -632,7 +632,7 @@ export default defineConfig({
               // numbers are part of each title on purpose: the articles are
               // posted one at a time, and "#21" is how a reader refers to one.
               { text: "#1 Somewhere on the Way to UI5, We Lost RTTS", link: "/advanced/insights/01-somewhere-on-the-way-to-ui5" },
-              { text: "#2 abap2UI5 Is Not a Programming Model", link: "/advanced/insights/02-not-a-programming-model" },
+              { text: "#2 abap2UI5 in Your Favourite Programming Model", link: "/advanced/insights/02-your-favourite-programming-model" },
               { text: "#3 The Cost of a Screen", link: "/advanced/insights/03-the-cost-of-a-screen" },
               { text: "#4 No Annotation in Between", link: "/advanced/insights/04-no-annotation-in-between" },
               { text: "#5 UI5 Over-the-Wire", link: "/advanced/insights/05-ui5-over-the-wire" },

--- a/docs/advanced/insights/02-your-favorite-programming-model.md
+++ b/docs/advanced/insights/02-your-favorite-programming-model.md
@@ -1,9 +1,12 @@
-# #2 abap2UI5 in Your Favourite Programming Model
+# #2 abap2UI5 in Your Favorite Programming Model
 
 Before you use a framework, you want to know what it expects from you: a
-structure to follow, a lifecycle to fit into, layers to fill in.
+structure to follow, a lifecycle to fit into, layers to fill in. Usually that
+list is long, and most of it exists before anything shows up on a screen.
 
-For abap2UI5 it is one interface with one method:
+With abap2UI5 you start by writing an ABAP class, the way you used to start a
+report with a selection screen. The only thing asked of you is to implement one
+interface with one method:
 
 ```abap
 INTERFACE z2ui5_if_app PUBLIC.
@@ -16,21 +19,20 @@ INTERFACE z2ui5_if_app PUBLIC.
 ENDINTERFACE.
 ```
 
-The framework calls `main( )` on every roundtrip, your class decides what to
-display and how to react. That is the whole contract.
+abap2UI5 calls `main( )` on every roundtrip; your class decides what to display
+and how to react. That is the whole contract. And getting it on the screen is
+about as short as pressing F8: activate the class, append `?app_start=zcl_my_app`
+to your service URL, and there it is.
 
-So abap2UI5 is not a programming model and does not bring one. Whichever one you
-already work in stays in charge.
+Beyond that, there are no rules. No service to define, no binding to maintain,
+no annotations, nothing to transport but the class itself. And it is entirely up
+to you whether you build one huge app of 10,000 lines, split it across several
+apps, or design an architecture of your own out of parent and child classes.
+abap2UI5 makes no demands on how you write your code or design your model — use
+whichever programming model you like behind it.
 
-## What Is Not in It
-
-No data model. No behavior definition. No service, no binding, no annotations.
-No BSP application per app, no frontend artefact to transport. You activate the
-class, call the ICF endpoint, and the app is there.
-
-That is about scope, not about size — and it has a pleasant side effect. Since
-abap2UI5 just serves a UI5 screen and never asks where your data comes from, it
-can come from wherever it already lives.
+This has a pleasant side effect. Since abap2UI5 just serves a UI and never asks
+where your data comes from, the data can come from wherever it already lives.
 
 ## The Same Class Around Three Backends
 
@@ -111,12 +113,16 @@ CLASS zcl_travel_edit IMPLEMENTATION.
 ENDCLASS.
 ```
 
-Nothing in the save handler is abap2UI5 except the toast. The business object
-does not notice anything unusual — validations, determinations, authorizations
-and draft handling all still run, because EML does not care who calls it.
+*The entity is invented — use your favorite RAP object instead.*
 
-That handler is also the only place in the class that knows what is behind the
-screen. Straight to a database table:
+Nothing in the save handler is abap2UI5's responsibility, and the RAP object
+does not notice anything unusual — validations, determinations and
+authorizations all still run. EML does not care who calls it.
+
+That handler belongs to the consuming app, and it is the only place in the class
+that knows what is behind the screen. abap2UI5 does not.
+
+So the same class can write straight to a database table instead:
 
 ```abap
   METHOD on_save.
@@ -134,8 +140,10 @@ screen. Straight to a database table:
   ENDMETHOD.
 ```
 
-Or against a BAPI you have had in the system for twenty years — different
-object, different decade, same class around it:
+*The table is invented — use your favorite database table instead.*
+
+Or a classic BAPI you have been using in the system for the last twenty years —
+different object, different decade, same UI around it:
 
 ```abap
   METHOD on_save.
@@ -163,20 +171,18 @@ object, different decade, same class around it:
   ENDMETHOD.
 ```
 
+*The BAPI is just an example — use your favorite BAPI instead.*
+
 abap2UI5 sees the same thing in all three: a method that ran and returned. It
-never looks inside. The same handler could call your EWM delivery classes, a
-proxy to another system, or whatever SAP releases next year — none of it has to
-be taught to abap2UI5.
+never looks inside. The same app could call your EWM delivery classes, a proxy
+to another system, or whatever SAP releases next year.
 
-And that is the advantage, a modest one: a framework that asks for one method
-cannot reorganise your architecture. It never learns enough about it to try.
-What you have already built stays where it is and keeps its rules.
+## Conclusion
 
-## And What You Do Not Get
-
-No data model, no transactional buffer, no generated user interface. RAP gives
-you all of that. For an application with a straightforward use case, done the
-standard way, that is where you want to be.
+There are plenty of use cases where a strict programming model is exactly what
+you want. But there are also the ones where a developer needs more freedom —
+customers who are not on the newest release, and logic that never quite fits the
+shape a programming model has in mind.
 
 So this is not an either-or. abap2UI5 runs in the same system, under the same
 authorizations, in the same launchpad, and it reaches your business logic

--- a/docs/advanced/insights/02-your-favorite-programming-model.md
+++ b/docs/advanced/insights/02-your-favorite-programming-model.md
@@ -187,10 +187,11 @@ you want. But there are also the ones where a developer needs more freedom —
 customers who are not on the newest release, and logic that never quite fits the
 shape a programming model has in mind.
 
-So this is not an either-or. abap2UI5 runs in the same system, under the same
-authorizations, in the same launchpad, and it reaches your business logic
-however you like. It is one more option next to what you already run, for the
-screen that would otherwise not get built at all.
+abap2UI5 runs in the same system, under the same authorizations, in the same
+launchpad as all your other UI5 and RAP apps. It reaches your business logic
+however you like, with the programming model of your choice. One more option
+next to what you already run, for the screen that would otherwise not get built
+at all.
 
 One interface, one method, and no opinion about what is behind the screen.
 

--- a/docs/advanced/insights/02-your-favorite-programming-model.md
+++ b/docs/advanced/insights/02-your-favorite-programming-model.md
@@ -28,13 +28,14 @@ Beyond that, there are no rules. No service to define, no binding to maintain,
 no annotations, nothing to transport but the class itself. And it is entirely up
 to you whether you build one huge app of 10,000 lines, split it across several
 apps, or design an architecture of your own out of parent and child classes.
+
 abap2UI5 makes no demands on how you write your code or design your model — use
 whichever programming model you like behind it.
 
 This has a pleasant side effect. Since abap2UI5 just serves a UI and never asks
 where your data comes from, the data can come from wherever it already lives.
 
-## The Same Class Around Three Backends
+## The Same Class, Three Programming Models
 
 Here is a small edit screen writing through a RAP business object:
 
@@ -122,7 +123,8 @@ authorizations all still run. EML does not care who calls it.
 That handler belongs to the consuming app, and it is the only place in the class
 that knows what is behind the screen. abap2UI5 does not.
 
-So the same class can write straight to a database table instead:
+So the same class can leave RAP out of it and write straight to a database
+table, the classic way:
 
 ```abap
   METHOD on_save.
@@ -173,9 +175,10 @@ different object, different decade, same UI around it:
 
 *The BAPI is just an example — use your favorite BAPI instead.*
 
-abap2UI5 sees the same thing in all three: a method that ran and returned. It
-never looks inside. The same app could call your EWM delivery classes, a proxy
-to another system, or whatever SAP releases next year.
+Three programming models, one unchanged UI class. abap2UI5 sees the same thing
+in all three: a method that ran and returned. It never looks inside. The same
+app could call your EWM delivery classes, a proxy to another system, or whatever
+SAP releases next year.
 
 ## Conclusion
 

--- a/docs/advanced/insights/02-your-favourite-programming-model.md
+++ b/docs/advanced/insights/02-your-favourite-programming-model.md
@@ -1,4 +1,4 @@
-# #2 abap2UI5 Is Not a Programming Model
+# #2 abap2UI5 in Your Favourite Programming Model
 
 Before you use a framework, you want to know what it expects from you: a
 structure to follow, a lifecycle to fit into, layers to fill in.
@@ -18,6 +18,9 @@ ENDINTERFACE.
 
 The framework calls `main( )` on every roundtrip, your class decides what to
 display and how to react. That is the whole contract.
+
+So abap2UI5 is not a programming model and does not bring one. Whichever one you
+already work in stays in charge.
 
 ## What Is Not in It
 

--- a/docs/advanced/insights/index.md
+++ b/docs/advanced/insights/index.md
@@ -29,7 +29,7 @@ What the framework is for, before how it works.
 | | |
 |---|---|
 | [#1 Somewhere on the Way to UI5, We Lost RTTS](/advanced/insights/01-somewhere-on-the-way-to-ui5) | a table whose structure is only known at runtime, drawn in UI5 |
-| [#2 abap2UI5 Is Not a Programming Model](/advanced/insights/02-not-a-programming-model) | one interface, one method, and no opinion about what is behind the screen |
+| [#2 abap2UI5 in Your Favourite Programming Model](/advanced/insights/02-your-favourite-programming-model) | one interface, one method, and no opinion about what is behind the screen |
 | [#3 The Cost of a Screen](/advanced/insights/03-the-cost-of-a-screen) | why the thirty-line screen never gets built, and a whole one as a class |
 | [#4 No Annotation in Between](/advanced/insights/04-no-annotation-in-between) | the vocabulary is the UI5 control library, all of it |
 

--- a/docs/advanced/insights/index.md
+++ b/docs/advanced/insights/index.md
@@ -29,7 +29,7 @@ What the framework is for, before how it works.
 | | |
 |---|---|
 | [#1 Somewhere on the Way to UI5, We Lost RTTS](/advanced/insights/01-somewhere-on-the-way-to-ui5) | a table whose structure is only known at runtime, drawn in UI5 |
-| [#2 abap2UI5 in Your Favourite Programming Model](/advanced/insights/02-your-favourite-programming-model) | one interface, one method, and no opinion about what is behind the screen |
+| [#2 abap2UI5 in Your Favorite Programming Model](/advanced/insights/02-your-favorite-programming-model) | one interface, one method, and no opinion about what is behind the screen |
 | [#3 The Cost of a Screen](/advanced/insights/03-the-cost-of-a-screen) | why the thirty-line screen never gets built, and a whole one as a class |
 | [#4 No Annotation in Between](/advanced/insights/04-no-annotation-in-between) | the vocabulary is the UI5 control library, all of it |
 


### PR DESCRIPTION
**#2 abap2UI5 Is Not a Programming Model → abap2UI5 in Your Favourite Programming Model**

The old title states the article's premise rather than its point, and the piece has since grown a closing that a negative title works against: *this is not an either-or… RAP gives you all of that… abap2UI5 is one more option next to what you already run.* The new title says that from the first line, and the three-backend section — EML, a table `MODIFY`, a twenty-year-old BAPI — is exactly the evidence for it.

**The old claim moves into the text.** Worth noting, because it was nearly lost: the article never actually said abap2UI5 is not a programming model. It only implied it through what the contract lacks. Two sentences after the interface now say it outright and hand over to the new promise — whichever model you already work in stays in charge.

**The slug follows the title.** A file called `02-not-a-programming-model` under a heading that no longer says that is the kind of drift this repository keeps gates for. Three places pointed at it: the sidebar, the index table, and `blog/teaser-posts.md`.

If you would rather keep the URL, say so and I will revert just the rename — nothing else depends on it.

## Verification

Green here: `vitepress build` with no dead links (the check that matters for a slug rename), `check:examples`, `check:conventions`, `check:playground`, `check:api-names`, `check:api-reference`, `check:cross-site`.

Not decidable in this environment: the outer `build` and `check:design` both need `abap2ui5.github.io`, which the agent proxy refuses with 403. `check:design` reports that it has nothing to compare against rather than passing — so CI is the first place those two are really exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5aUUqLaxN6kxKxsHhuicp

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5aUUqLaxN6kxKxsHhuicp)_