### PR TITLE
Try it out now — the demo, and nothing standing in front of it

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -121,11 +121,21 @@ it already runs on.
 community on GitHub and in the abapGit Slack channel, plus companies and
 freelancers offering implementation, training and support agreements.
 
-## One class, one app
+## Developing with AI
 
-Here is a whole abap2UI5 app. Press **Run and edit this example** — it opens in
-your browser on the real framework, with nothing to install, and the code is
-yours to change: edit it, run it again, break it.
+One class is one file for an agent to write — and no second half that can drift
+out of step with it.
+
+**And it can check its own work without an SAP system.** The
+[linter](/advanced/linter) rebuilds the UI5 view out of the ABAP that builds it and
+reports the names UI5 does not have; the [MCP server](/advanced/mcp_server) turns
+that into a loop for any MCP client — search the catalogues for an app that already
+does it, validate the view just written, and one step further boot the app headless
+and get the errors and a screenshot back. [The whole ladder](/get_started/ai) runs
+from a paragraph you paste ahead of a task to the editor extension that registers
+the loop for every client in the window.
+
+## Try it out now
 
 ```abap edit
 CLASS zcl_app_hello DEFINITION PUBLIC.
@@ -170,29 +180,6 @@ CLASS zcl_app_hello IMPLEMENTATION.
   ENDMETHOD.
 ENDCLASS.
 ```
-
-- **The attribute is the model.** `recipient` goes to the browser, comes back
-  edited, and is a plain ABAP string on both sides — the framework carries your
-  instance between roundtrips, so the class keeps its state with no session
-  handling of your own.
-- **The view is ABAP.** Built at runtime and sent as data: no XML file in a
-  repository, no build step.
-- **Events come back as ABAP.** The button press arrives in `check_on_event( )`,
-  in the same class, with the model already updated.
-
-## Developing with AI
-
-One class is one file for an agent to write — and no second half that can drift
-out of step with it.
-
-**And it can check its own work without an SAP system.** The
-[linter](/advanced/linter) rebuilds the UI5 view out of the ABAP that builds it and
-reports the names UI5 does not have; the [MCP server](/advanced/mcp_server) turns
-that into a loop for any MCP client — search the catalogues for an app that already
-does it, validate the view just written, and one step further boot the app headless
-and get the errors and a screenshot back. [The whole ladder](/get_started/ai) runs
-from a paragraph you paste ahead of a task to the editor extension that registers
-the loop for every client in the window.
 
 ## Around the project
 

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -692,7 +692,7 @@ html { scroll-padding-top: 62px; }
  * them are told otherwise:
  *
  *   at a glance | what it costs   two short, scannable sections, side by side
- *   one class, one app            the whole width, because the live editor in
+ *   try it out now                the whole width, because the live editor in
  *                                 it is a code pane AND a running app
  *
  * Everything else keeps the 74ch measure prose is set in. A narrow section
@@ -717,8 +717,16 @@ html { scroll-padding-top: 62px; }
    than 74ch, and capping it again would leave a gutter inside a gutter. */
 .home .band > p, .home .band > ul, .home .band > ol { max-width: 74ch; }
 
-.home .band[data-band="abap2ui5-at-a-glance"] { grid-column: 1; }
-.home .band[data-band="what-it-costs"] { grid-column: 2; }
+/* The right column stacks: the fact table is the tall one, so it spans both
+   rows and the two short sections sit beside it, one under the other. Placed
+   explicitly rather than left to auto-flow, which would have started the AI
+   section on a new row BELOW the table and left a hole under the costs. Source
+   order is glance -> costs -> AI, which is the order they are read in, so the
+   reading order and the visual order still agree. */
+.home .band[data-band="abap2ui5-at-a-glance"] { grid-column: 1; grid-row: 1 / span 2; }
+.home .band[data-band="what-it-costs"] { grid-column: 2; grid-row: 1; }
+.home .band[data-band="developing-with-ai"] { grid-column: 2; grid-row: 2; }
+.home .band[data-band="developing-with-ai"] > h2 { border-top-color: transparent; }
 /* Two columns of one row: the rule over the second would cut the first in
    half, and its heading sits on the same line as the other's. */
 .home .band[data-band="what-it-costs"] > h2 { border-top-color: transparent; }
@@ -726,13 +734,18 @@ html { scroll-padding-top: 62px; }
 /* The example is the widest thing on the page because what it opens is two
    panes - the ABAP on the left, the app it renders on the right. Held to a
    column, neither is worth looking at. */
-.home .band[data-band="one-class-one-app"] .a2ui5-play,
-.home .band[data-band="one-class-one-app"] > p { max-width: none; }
+.home .band[data-band="try-it-out-now"] .a2ui5-play,
+.home .band[data-band="try-it-out-now"] > p { max-width: none; }
 
 @media (max-width: 860px) {
   /* One column again: two 300px columns of prose are worse than a long page. */
   .home .vp-doc.bands { display: block; }
   .home .band[data-band="what-it-costs"] > h2 { border-top-color: var(--line); }
+  .home .band[data-band="developing-with-ai"] > h2 { border-top-color: var(--line); }
+  /* the explicit placement goes with the grid */
+  .home .band[data-band="abap2ui5-at-a-glance"],
+  .home .band[data-band="what-it-costs"],
+  .home .band[data-band="developing-with-ai"] { grid-column: auto; grid-row: auto; }
 }
 
 /* ---- what a stranger checks first ----------------------------------- */


### PR DESCRIPTION
## The example section is the demo

"One class, one app" opened with a sentence telling the reader to press a button, and closed with three bullets explaining what the code above them does. **Both are gone.**

The heading invites instead of labelling — **"Try it out now"** — and under it is the editable frame, which starts itself when it scrolls into view and shows the ABAP on the left with the app running on the right.

A paragraph telling somebody to press a button they can already see is a paragraph *between* them and the button. And three bullets explaining code they can now **edit** are notes beside a thing that answers questions faster than they do.

## Developing with AI moves up, under What it costs

The fact table is the tall band and the two short sections are the narrow ones, so the table spans both rows of the grid and the other two stack beside it:

```
┌──────────────────┬──────────────────┐
│                  │  What it costs   │
│  …at a glance    ├──────────────────┤
│                  │ Developing w/ AI │
└──────────────────┴──────────────────┘
│           Try it out now            │
```

Placed explicitly rather than left to auto-flow, which would have started the AI section on a new row *below* the table and left a hole under the costs. Source order is glance → costs → AI, which is the order they are read in, so reading order and visual order still agree — the same rule the pair already followed.

## Measured

| | before | after |
|---|---:|---:|
| page height at 1280 | 3164px | **2739px** (−13%) |
| horizontal overflow at 1440 / 1280 / 860 / 390 | 0 | 0 |

The right column now runs the full height of the left one instead of ending two thirds of the way down.

`npm run check` passes: twelve gates, 141 unit tests, 166 pages, 37,104 internal links, none dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_