### PR TITLE
Four things the reader did not ask for: a page that moves, a menu that forgets, a runtime that restarts

### DIFF
--- a/docs/.vitepress/theme/playground.js
+++ b/docs/.vitepress/theme/playground.js
@@ -108,6 +108,10 @@ async function start(button, { unasked = false } = {}) {
   /* Already clicked — the loader's own button would be a second one. */
   demo.dataset.auto = '1';
   demo.dataset.code = source;
+  /* Before the frame exists: an unasked start holds the page still while it
+   * boots (holdStill above). A reader who pressed the button asked to be
+   * taken to what they started, so that one is left alone. */
+  if (unasked) holdStill(container);
   container.append(demo);
   embed.setUp(container);
   /* The printed listing steps aside for the editable one: the frame now shows
@@ -205,6 +209,62 @@ const runButton = (container) => {
 const wantsLessData = () =>
   matchMedia?.('(prefers-reduced-data: reduce)').matches
   || navigator.connection?.saveData === true;
+
+/* An example nobody asked for must not move the page under the reader.
+ *
+ * Three documents down, the frame boots a real UI5 app, and a UI5 app focuses
+ * a control when it renders. That focus travels outwards - the app's iframe
+ * inside the playground, the playground's iframe inside this page - and the
+ * browser scrolls the last one into view. Measured on the front door: 4.4s
+ * after load, scrollY 0 to 911, with nothing on the page touched.
+ *
+ * There is no focus event here to intercept. A subframe taking the focus
+ * dispatches nothing at this level - no focus, no focusin, not on the iframe
+ * and not on the document. All that arrives is a `blur` whose target is the
+ * window, and then the scroll. So the signal this reads is the one the browser
+ * does give: the page moved AND what now holds the focus is inside the frame
+ * this page mounted. Anything else that scrolls - a wheel, a key, a hand on
+ * the scrollbar - leaves the focus where it was and is none of this
+ * function's business.
+ *
+ * Both halves are put back, because both were taken: the position, and the
+ * focus itself. A reader whose next keypress goes to an app they never opened
+ * has lost their page just as surely as one who was scrolled away from it.
+ *
+ * It lets go the moment the reader does anything at all - a press, a key, a
+ * wheel, a touch - so somebody who deliberately clicks into the editor, or
+ * tabs to it, keeps the focus they asked for. The timeout is the other way
+ * out, for a reader who never touches this page: booting is over long before
+ * it, and a guard that outlived the boot would be a guard fighting nobody.
+ */
+function holdStill(container) {
+  const home = window.scrollY;
+  const asked = ['pointerdown', 'keydown', 'wheel', 'touchstart'];
+  let live = true;
+  const release = () => {
+    if (!live) return;
+    live = false;
+    removeEventListener('scroll', putBack);
+    removeEventListener('blur', putBack, true);
+    for (const ev of asked) removeEventListener(ev, release, true);
+    clearTimeout(timer);
+  };
+  const putBack = () => {
+    if (!live) return;
+    /* The frame is what holds the focus, and nobody here asked it to. */
+    if (!container.contains(document.activeElement)) return;
+    document.activeElement.blur?.();
+    if (Math.abs(window.scrollY - home) > 1) {
+      /* `instant` rather than the site's own scrolling: this is an undo, and
+       * an undo that animates is a second thing the reader did not ask for. */
+      window.scrollTo({ top: home, left: 0, behavior: 'instant' });
+    }
+  };
+  addEventListener('scroll', putBack, { passive: true });
+  addEventListener('blur', putBack, true);
+  for (const ev of asked) addEventListener(ev, release, { capture: true, passive: true });
+  const timer = setTimeout(release, 30000);
+}
 
 /* The editable example starts ITSELF, once, when it comes into view.
  *

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,30 +101,35 @@ features:
 ## What it costs
 
 Nothing. [MIT licensed](/resources/license) and free commercially — no licence
-key, no subscription, no per-user fee, nothing to activate.
+key, no subscription, no per-user fee.
 
-**Nobody counts your users, because nothing is counting.** An abap2UI5 app is
-a standard UI5 freestyle application served by your own ABAP stack: ten users and
-ten thousand are the same to it, and the SAP licensing you have is the licensing
-you keep. Nothing new to operate either — the app is an ABAP class in the system
-it already runs on.
+**Nobody counts your users, because nothing is counting.** The app is a standard
+UI5 application served by your own ABAP stack: ten users and ten thousand are the
+same to it, and the SAP licensing you have is the licensing you keep.
 
-**And you are not on your own with it.** [Support](/resources/support) is the
-community on GitHub and in the abapGit Slack channel.
+## Enterprise ready
+
+**It runs inside the security you already have.** One HTTP endpoint, standard SAP
+logon, no second user store — your
+[authorizations](/configuration/authorization) and
+[session handling](/configuration/security) apply unchanged.
+
+**And it is kept that way.** Every merge is tested against Standard ABAP and ABAP
+Cloud, then [downported](/advanced/downporting) and linted against 7.02 before the
+`702` branch ships. [Support](/resources/support) is GitHub and Slack, with
+commercial options listed beside them.
 
 ## Developing with AI
 
-One class is one file for an agent to write — and no second half that can drift
-out of step with it.
+One class is one file for an agent to write — no second half that can drift out
+of step with it.
 
 **And it can check its own work without an SAP system.** The
-[linter](/advanced/linter) rebuilds the UI5 view out of the ABAP that builds it and
-reports the names UI5 does not have; the [MCP server](/advanced/mcp_server) turns
-that into a loop for any MCP client — search the catalogues for an app that already
-does it, validate the view just written, and one step further boot the app headless
-and get the errors and a screenshot back. [The whole ladder](/get_started/ai) runs
-from a paragraph you paste ahead of a task to the editor extension that registers
-the loop for every client in the window.
+[linter](/advanced/linter) rebuilds the UI5 view out of the ABAP and reports the
+names UI5 does not have; the [MCP server](/advanced/mcp_server) turns that into a
+loop — validate the view just written, boot the app headless, get the errors and
+a screenshot back. [The whole ladder](/get_started/ai) starts with a paragraph you
+paste ahead of a task.
 
 ## Try it out now
 

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -308,7 +308,16 @@ const routeOf = (page) => '/' + page.replace(/\.md$/, '').replace(/\/index$/, ''
 function sidebarFor(route) {
   const same = (link) => link && link.replace(/\/$/, '') === route.replace(/\/$/, '');
   const holds = (i) => same(i.link) || (i.items || []).some(holds);
-  const tree = (items, level) => items.map((i) => {
+  /* THE KEY A SECTION IS REMEMBERED BY, and it has to be its own. It used to
+     be the section's link, falling back to its text - and four sections in
+     this menu share a link with another one (Walkthrough, View / Definition,
+     Model / Binding, Configuration / Setup all point at their own first page,
+     which is also a section). Two <details> with one key are one entry in the
+     reader's stored menu: opening either wrote both, and the store came back
+     with the same key twice. The trail of headings down to it is unique, and
+     it stays the same when the menu is reordered - which a position would
+     not. */
+  const tree = (items, level, trail = []) => items.map((i) => {
     /* ONE ROW IS MARKED, and it is the deepest one that names this page. A
        section often points at its own first page - Model and Binding are the
        same link - and marking both painted two rows in the accent, which is
@@ -317,9 +326,10 @@ function sidebarFor(route) {
     const href = i.link ? `${BASE.slice(0, -1)}${i.link}${i.link.endsWith('/') ? 'index.html' : '.html'}` : null;
     const label = href ? `<a href="${esc(href)}"${on}>${esc(i.text)}</a>` : `<span>${esc(i.text)}</span>`;
     if (!i.items) return `<div class="side-item level-${level}">${label}</div>`;
-    return `<details class="side-group level-${level}" data-key="${esc(i.link || i.text)}"${holds(i) ? ' open' : ''}>`
+    const key = [...trail, i.text].join(' / ');
+    return `<details class="side-group level-${level}" data-key="${esc(key)}"${holds(i) ? ' open' : ''}>`
       + `<summary><span class="side-caret" aria-hidden="true"></span>${label}</summary>`
-      + `<div class="side-items">${tree(i.items, level + 1)}</div></details>`;
+      + `<div class="side-items">${tree(i.items, level + 1, [...trail, i.text])}</div></details>`;
   }).join('');
   return `<nav class="sidebar" aria-label="Documentation">${tree(config.themeConfig.sidebar, 0)}</nav>`;
 }

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -723,10 +723,13 @@ html { scroll-padding-top: 62px; }
    section on a new row BELOW the table and left a hole under the costs. Source
    order is glance -> costs -> AI, which is the order they are read in, so the
    reading order and the visual order still agree. */
-.home .band[data-band="abap2ui5-at-a-glance"] { grid-column: 1; grid-row: 1 / span 2; }
+.home .band[data-band="abap2ui5-at-a-glance"] { grid-column: 1; grid-row: 1 / span 3; }
 .home .band[data-band="what-it-costs"] { grid-column: 2; grid-row: 1; }
-.home .band[data-band="developing-with-ai"] { grid-column: 2; grid-row: 2; }
-.home .band[data-band="developing-with-ai"] > h2 { border-top-color: transparent; }
+.home .band[data-band="enterprise-ready"] { grid-column: 2; grid-row: 2; }
+.home .band[data-band="developing-with-ai"] { grid-column: 2; grid-row: 3; }
+/* The two lower ones keep their rules: inside a column a rule reads as a
+   divider between the sections, which is what it is. Only the topmost of the
+   two columns loses it, below. */
 /* Two columns of one row: the rule over the second would cut the first in
    half, and its heading sits on the same line as the other's. */
 .home .band[data-band="what-it-costs"] > h2 { border-top-color: transparent; }
@@ -741,10 +744,10 @@ html { scroll-padding-top: 62px; }
   /* One column again: two 300px columns of prose are worse than a long page. */
   .home .vp-doc.bands { display: block; }
   .home .band[data-band="what-it-costs"] > h2 { border-top-color: var(--line); }
-  .home .band[data-band="developing-with-ai"] > h2 { border-top-color: var(--line); }
   /* the explicit placement goes with the grid */
   .home .band[data-band="abap2ui5-at-a-glance"],
   .home .band[data-band="what-it-costs"],
+  .home .band[data-band="enterprise-ready"],
   .home .band[data-band="developing-with-ai"] { grid-column: auto; grid-row: auto; }
 }
 

--- a/scripts/site-js/site.js
+++ b/scripts/site-js/site.js
@@ -152,28 +152,50 @@ document.addEventListener('click', (e) => {
   addEventListener('resize', schedule, { passive: true });
 })();
 
-/* ---- the chapter menu keeps the shape you left it in -------------------
+/* ---- the chapter menu keeps the shape YOU left it in --------------------
  *
  * Every page is a fresh document here, so the sections the build opened - the
  * one holding this page - were the only ones open, and every other section a
- * reader had unfolded shut itself on the next click. What is written down is
- * the set of sections that are OPEN, by the key the build gives each one.
+ * reader had unfolded shut itself on the next click. So the menu is written
+ * down and put back.
+ *
+ * WHAT IS WRITTEN DOWN IS WHAT THE READER DID, and nothing else. The first
+ * version wrote the whole visible menu on every `toggle` event, which sounds
+ * the same and is not: `toggle` is queued, so the events fired by putting the
+ * menu BACK arrive after this listener is attached, and every navigation wrote
+ * the path to wherever the reader had landed as though they had opened it by
+ * hand. Measured over five pages with the menu never touched once: the store
+ * grew from 1 entry to 8, and the reader's own choices were buried under a
+ * trail of rooms they had merely walked through. The menu remembered a shape;
+ * it just was not theirs.
+ *
+ * So a decision is recorded per section, on the click that makes it - one
+ * section, the state it now has - and the store holds only sections somebody
+ * actually opened or closed. Nothing a navigation does can reach it.
  *
  * The section holding the current page is opened regardless of what is
  * stored: it is where the reader is, and a menu that hid it would be worse
- * than one that forgets. */
+ * than one that forgets. Opened, and NOT written down - that was the bug. */
 (function tree() {
-  const KEY = 'abap2ui5-playground:docs-tree';
+  /* A second name, because every value under the first one was written by the
+     navigation bug above and none of it is the reader's. A store that cannot
+     be trusted is worse than an empty one. */
+  const KEY = 'abap2ui5-playground:docs-sections';
   const groups = [...document.querySelectorAll('.sidebar details[data-key]')];
   if (!groups.length) return;
+  /* key -> true when the reader opened that section, false when they closed
+     it. A section they never touched is simply absent, and keeps whatever
+     shape the build gave it. */
   const read = () => {
     try {
-      const v = JSON.parse(localStorage.getItem(KEY) || '[]');
-      return Array.isArray(v) ? new Set(v.filter((k) => typeof k === 'string')) : null;
-    } catch { return null; }
+      const v = JSON.parse(localStorage.getItem(KEY) || 'null');
+      return v && typeof v === 'object' && !Array.isArray(v) ? v : {};
+    } catch { return {}; }
   };
-  const open = read();
-  if (open) for (const g of groups) g.open = open.has(g.dataset.key);
+  const chosen = read();
+  for (const g of groups) {
+    if (Object.prototype.hasOwnProperty.call(chosen, g.dataset.key)) g.open = !!chosen[g.dataset.key];
+  }
   /* ...and the way to where you are, whatever was stored. */
   const here = document.querySelector('.sidebar a.here');
   if (here) for (let el = here.closest('details'); el; el = el.parentElement?.closest('details')) el.open = true;
@@ -198,10 +220,18 @@ document.addEventListener('click', (e) => {
 
   const write = () => {
     try {
-      localStorage.setItem(KEY, JSON.stringify(groups.filter((g) => g.open).map((g) => g.dataset.key)));
+      localStorage.setItem(KEY, JSON.stringify(chosen));
     } catch { /* a browser that refuses storage keeps the build's own shape */ }
   };
-  for (const g of groups) g.addEventListener('toggle', write);
+  /* The CLICK, not the toggle: a click on a summary is the reader, and it is
+     the only thing that is. Reading the state on the next task, once the
+     browser has done the opening the click asked for - and a keyboard reaches
+     a summary through a click too, so Enter and Space are the same path. */
+  box?.addEventListener('click', (e) => {
+    const group = e.target.closest?.('summary')?.parentElement;
+    if (!group || !groups.includes(group)) return;
+    setTimeout(() => { chosen[group.dataset.key] = group.open; write(); }, 0);
+  });
 })();
 /* ---- copy a listing ---------------------------------------------------
  *

--- a/scripts/site-js/site.js
+++ b/scripts/site-js/site.js
@@ -97,6 +97,64 @@ document.addEventListener('click', (e) => {
   if (e.target.closest?.('a[data-site]')) lift();
 }, true);
 
+/* ---- and the Playground item goes BACK when the playground is behind you --
+ *
+ * Reported: "the Playground tab - when I go to it the app is always run again,
+ * although it had already run before."
+ *
+ * It is a link, so a press builds a NEW document: the whole ABAP runtime boots
+ * and the app starts from the top. Measured against a local copy with no
+ * network in the way, that is 2.4 to 2.8 seconds every single time - and the
+ * app's own state, a half-filled form or a table scrolled to row 200, is gone
+ * with the document that held it. No browser preserves a running page across a
+ * forward navigation. Exactly one mechanism preserves it at all, and it is the
+ * back/forward cache, which applies to going BACK.
+ *
+ * So when going back is what the reader means, this goes back. The condition
+ * is narrow and checkable: this document was opened FROM the playground itself
+ * (not from a sample page under it, which is a different page), the history has
+ * not grown since - a text fragment or an anchor pushed onto it would make one
+ * step back something else - and there is an entry to go back to at all, which
+ * a tab the playground opened with target=_blank does not have.
+ *
+ * It can only ever match the link: the item's href is lifted to the last
+ * playground URL, and that is the entry this steps back to. What it adds is the
+ * browser's option to hand the page back alive instead of rebuilding it - and
+ * where the browser declines, a reload is what the link would have done anyway.
+ *
+ * The fallback is for the one case that would be worse than today: a back that
+ * does not navigate would be a dead press. If this document is still here 400ms
+ * later, the link is followed after all - and the timer is dropped on pagehide,
+ * so a document that WAS cached does not fire it on the way back in and bounce
+ * the reader out of the page they returned to. */
+(function playgroundBehindYou() {
+  const item = document.querySelector('a[data-site="playground"]');
+  if (!item || history.length < 2) return;
+  const bare = (u) => u.pathname.replace(/index\.html$/, '');
+  let home;
+  let came;
+  try {
+    home = new URL(item.getAttribute('href'), location.href);
+    came = new URL(document.referrer);
+  } catch { return; }
+  /* The playground itself, not the catalogue and not a sample page - both of
+     those live under the same path and are not what the item opens. */
+  if (came.origin !== home.origin || bare(came) !== bare(home)) return;
+  const behind = history.length;
+  document.addEventListener('click', (e) => {
+    const a = e.target.closest?.('a[data-site="playground"]');
+    if (!a || e.defaultPrevented) return;
+    /* A press that means "in a new tab" still means that. */
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    if (history.length !== behind) return;
+    e.preventDefault();
+    const href = a.href;
+    const fallback = setTimeout(() => { location.href = href; }, 400);
+    addEventListener('pagehide', () => clearTimeout(fallback), { once: true });
+    history.back();
+  }, true);
+})();
+
 /* Where on the page, not only which page. A bar link writes down how far down
    this page the reader is AND where they are being sent; the page that arrives
    within seconds, and only that page, puts them back (restoreScroll above). */

--- a/test/playground-back.test.mjs
+++ b/test/playground-back.test.mjs
@@ -1,0 +1,67 @@
+/*
+ * The bar's Playground item, and the one case where it goes back instead.
+ *
+ * Reported as "the Playground tab — when I go to it the app is always run
+ * again, although it had already run before". It is a link, so a press builds
+ * a new document: the ABAP runtime boots and the app starts from the top.
+ * Measured against a local copy with no network in the way, 2.4 to 2.8 seconds
+ * every time, and the app's own state gone with the document. No browser keeps
+ * a running page across a FORWARD navigation; the back/forward cache is the
+ * only mechanism that keeps one at all, and it applies to going back.
+ *
+ * So when the playground is the page the reader just came from, the item goes
+ * back to it. Measured on the built site, all three cases: arrived from the
+ * playground -> history.back() and the playground again; arrived from another
+ * docs page -> the link, untouched; arrived from a SAMPLE page, which lives
+ * under the same path -> the link, because that is a different page.
+ *
+ * Whether the browser then hands the page back alive is the browser's call and
+ * cannot be measured here at all - this sandbox's headless Chromium has the
+ * back/forward cache switched off, and a page with nothing in it is not
+ * restored either. What can be checked is that the shortcut is never worse
+ * than the link: same destination, and a way out if the step back does
+ * nothing.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SITE = readFileSync(join(ROOT, 'scripts/site-js/site.js'), 'utf8');
+const shortcut = SITE.slice(
+  SITE.indexOf('(function playgroundBehindYou()'),
+  SITE.indexOf('/* Where on the page, not only which page.'),
+);
+
+test('the shortcut exists and is about the Playground item', () => {
+  assert.ok(shortcut.length > 200, 'the block should still be there to reason about');
+  assert.match(shortcut, /a\[data-site="playground"\]/);
+});
+
+test('it only fires for a reader who came from the playground itself', () => {
+  assert.match(shortcut, /document\.referrer/, 'where this document was opened from is the whole condition');
+  assert.match(shortcut, /came\.origin !== home\.origin \|\| bare\(came\) !== bare\(home\)/,
+    'a sample page lives under the same path and is a different page');
+  assert.match(shortcut, /history\.length < 2/,
+    'a tab the playground OPENED has nothing behind it, and a dead press is worse than a reload');
+  assert.match(shortcut, /history\.length !== behind/,
+    'an anchor or a text fragment pushed since means one step back is something else');
+});
+
+test('a press that means "in a new tab" still means that', () => {
+  for (const key of ['metaKey', 'ctrlKey', 'shiftKey', 'altKey']) {
+    assert.ok(shortcut.includes(`e.${key}`), `${key} must keep the browser's own handling`);
+  }
+  assert.match(shortcut, /e\.button !== 0/);
+});
+
+test('a step back that does not navigate still follows the link', () => {
+  assert.match(shortcut, /setTimeout\(\(\) => \{ location\.href = href; \}, \d+\)/,
+    'the fallback is what keeps this from ever being a dead press');
+  assert.match(shortcut, /addEventListener\('pagehide', \(\) => clearTimeout\(fallback\), \{ once: true \}\)/,
+    'a cached document must not fire it on the way back in and bounce the reader out');
+});

--- a/test/playground.test.mjs
+++ b/test/playground.test.mjs
@@ -18,6 +18,9 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { abapOnly, playgroundExample } from '../docs/.vitepress/playground.mjs';
 import { playgroundButton } from '../docs/.vitepress/playground.mjs';
 
@@ -283,4 +286,62 @@ test('the editable example puts its button ABOVE the code', () => {
   const edit = renderFence('abap edit', app('z2ui5_cl_sample_x', DISPLAY));
   assert.ok(plain.indexOf('<button') > plain.indexOf('language-abap'));
   assert.ok(edit.indexOf('<button') < edit.indexOf('language-abap'));
+});
+
+/*
+ * The one example that starts itself must not move the page.
+ *
+ * Measured on the front door before this was here: 4.4s after load, with
+ * nothing on the page touched, scrollY went 0 -> 911 and the focus was inside
+ * the frame. The frame boots a real UI5 app, an app focuses a control when it
+ * renders, and that focus climbs out through two iframes until the browser
+ * scrolls the outermost one into view.
+ *
+ * No browser runs in this suite, so what is checked is the wiring that was
+ * measured working - the same arrangement as the Run bar's link in
+ * cross-site.test.mjs, and for the same reason: the behaviour lives in a
+ * browser, the decision lives in this text.
+ */
+const THEME = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'docs/.vitepress/theme/playground.js'),
+  'utf8',
+);
+
+test('the unasked start holds the page still, and only the unasked one', () => {
+  assert.match(THEME, /if \(unasked\) holdStill\(container\);/,
+    'a start nobody asked for must guard the scroll position');
+  const started = THEME.slice(THEME.indexOf('async function start('));
+  /* The prose in there names the function too; what is under test is the code
+   * that calls it. */
+  const guarded = started.slice(0, started.indexOf('container.append(demo)'))
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  assert.deepEqual(guarded.match(/holdStill\(/g), ['holdStill('],
+    'a reader who PRESSED the button asked to be taken to what they started, so it is called once and only under `unasked`');
+});
+
+test('the guard reads blur and scroll, because no focus event reaches this page', () => {
+  const guard = THEME.slice(THEME.indexOf('function holdStill('), THEME.indexOf('function armSelfStart('));
+  assert.match(guard, /addEventListener\('scroll'/, 'the scroll is the harm');
+  assert.match(guard, /addEventListener\('blur', [^,]+, true\)/,
+    'a subframe taking the focus dispatches nothing but a window blur here');
+  assert.equal(/addEventListener\('focus(in)?'/.test(guard), false,
+    'there is no focus event at this level - listening for one is a guard that never fires');
+});
+
+test('the guard puts back the focus as well as the position', () => {
+  const guard = THEME.slice(THEME.indexOf('function holdStill('), THEME.indexOf('function armSelfStart('));
+  assert.match(guard, /container\.contains\(document\.activeElement\)/,
+    'only a scroll that came WITH the frame taking the focus is undone - a wheel or a scrollbar is the reader');
+  assert.match(guard, /document\.activeElement\.blur\?\.\(\)/,
+    'a reader whose next keypress goes into an app they never opened has lost the page too');
+  assert.match(guard, /behavior: 'instant'/, 'an undo that animates is a second thing nobody asked for');
+});
+
+test('the guard lets go the moment the reader does anything', () => {
+  const guard = THEME.slice(THEME.indexOf('function holdStill('), THEME.indexOf('function armSelfStart('));
+  for (const gesture of ['pointerdown', 'keydown', 'wheel', 'touchstart']) {
+    assert.ok(guard.includes(`'${gesture}'`), `${gesture} is the reader speaking; the guard stands down`);
+  }
+  assert.match(guard, /setTimeout\(release,/,
+    'and it stands down anyway, for a reader who never touches the page');
 });

--- a/test/sidebar-memory.test.mjs
+++ b/test/sidebar-memory.test.mjs
@@ -1,0 +1,103 @@
+/*
+ * The chapter menu, and whose shape it keeps.
+ *
+ * The menu is a tree of <details>; every page is a fresh document, so what a
+ * reader unfolds is written to localStorage and put back on the next page.
+ * That much worked. What it wrote was the wrong thing.
+ *
+ * `toggle` on a <details> is QUEUED, not synchronous. The old code attached
+ * one `toggle` listener per section after putting the menu back — so the
+ * events fired BY putting it back arrived at that listener, and every
+ * navigation wrote the path down to wherever the reader had landed, as though
+ * they had opened each of those sections by hand. Measured on the built site
+ * over five pages with the menu never touched once: the store went from 1
+ * entry to 8. The reader's own choices were still in there, buried under a
+ * trail of rooms they had walked through — which is what "it remembers
+ * something, just not what I did" looks like from a chair.
+ *
+ * And two sections could share one entry: the key was the section's link or
+ * its text, and four sections in this menu point at their own first page,
+ * which is also a section. One key, two <details> — the store came back with
+ * the same key twice.
+ *
+ * No browser runs in this suite, so the second half of this file checks the
+ * wiring that was measured working. The first half checks the invariant
+ * itself, against the real sidebar: every section's key is its own.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import config from '../docs/.vitepress/config.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Every section of the real menu, keyed the way build-site.mjs keys it. */
+function sectionKeys(items, trail = [], out = []) {
+  for (const i of items) {
+    if (!i.items) continue;
+    out.push([...trail, i.text].join(' / '));
+    sectionKeys(i.items, [...trail, i.text], out);
+  }
+  return out;
+}
+
+test('every section in the menu has a key of its own', () => {
+  const keys = sectionKeys(config.themeConfig.sidebar);
+  assert.ok(keys.length > 20, `the menu should have real depth, found ${keys.length} sections`);
+  const seen = new Map();
+  for (const k of keys) seen.set(k, (seen.get(k) ?? 0) + 1);
+  const shared = [...seen].filter(([, n]) => n > 1).map(([k]) => k);
+  assert.deepEqual(shared, [], 'two sections with one key move together and cannot be told apart');
+});
+
+test('the old key would NOT have been its own — this is what was fixed', () => {
+  /* Kept as the reason the trail exists: with `link || text` this menu has
+     four collisions today, so the change is not a preference. */
+  const linkKeys = (items, out = []) => {
+    for (const i of items) {
+      if (!i.items) continue;
+      out.push(i.link || i.text);
+      linkKeys(i.items, out);
+    }
+    return out;
+  };
+  const seen = new Map();
+  for (const k of linkKeys(config.themeConfig.sidebar)) seen.set(k, (seen.get(k) ?? 0) + 1);
+  assert.ok([...seen.values()].some((n) => n > 1),
+    'if this ever passes, the sidebar changed - not the reasoning');
+});
+
+const SITE = readFileSync(join(ROOT, 'scripts/site-js/site.js'), 'utf8');
+const menu = SITE.slice(SITE.indexOf('(function tree()'), SITE.indexOf('---- copy a listing'));
+
+test('only a click writes the menu down, never a toggle', () => {
+  assert.equal(/addEventListener\('toggle'/.test(menu), false,
+    'toggle is queued, so it also fires for the sections the page itself opened');
+  assert.match(menu, /addEventListener\('click'/,
+    'a click on a summary is the reader, and it is the only thing that is');
+  assert.match(menu, /closest\?\.\('summary'\)/, 'and only a click on a section heading');
+});
+
+test('what is written is one decision, not the whole visible menu', () => {
+  assert.match(menu, /chosen\[group\.dataset\.key\] = group\.open/,
+    'the section that was clicked, and the state it now has');
+  assert.match(menu, /JSON\.stringify\(chosen\)/, 'the store is those decisions and nothing else');
+  assert.equal(/groups\.filter\(\(g\) => g\.open\)/.test(menu), false,
+    'writing every open section is what let a navigation pass for a reader');
+});
+
+test('a section nobody touched keeps the shape the build gave it', () => {
+  assert.match(menu, /hasOwnProperty\.call\(chosen, g\.dataset\.key\)/,
+    'absent is a third state, and it means "the build decides"');
+});
+
+test('the way to the current page is opened, and never written down', () => {
+  const here = menu.slice(menu.indexOf('const here ='));
+  const untilWrite = here.slice(0, here.indexOf('const write ='));
+  assert.match(untilWrite, /el\.open = true/, 'a menu that hid the page you are on would be worse');
+  assert.equal(/chosen\[/.test(untilWrite), false, 'walking somewhere is not choosing it');
+});


### PR DESCRIPTION
Three reports from reading the published site, and one addition to the front door. Each commit carries the measurement that found it.

## The front door stays where the reader opened it

Opening the home page scrolled it down to the demo on its own. Measured at 1440×1000: **4.4s after load, with nothing on the page touched, `scrollY` went 0 → 911** and `document.activeElement` became the frame.

The editable example starts itself when it comes into view; the frame boots a real UI5 app; a UI5 app focuses a control when it renders. That focus climbs out through the app's iframe inside the playground and the playground's iframe inside this page, and the browser scrolls the outermost one into view.

There is no focus event to intercept at this level — a subframe taking the focus dispatches nothing here, not on the iframe and not on the document. All that arrives is a `blur` whose target is the window, and then the scroll. So the guard reads those two, and acts only when the page moved **and** what holds the focus is inside the frame this page mounted. A wheel, a key, a hand on the scrollbar all leave the focus where it was and are none of its business.

Both halves are put back, because both were taken: the position, and the focus. It stands down on the reader's first gesture, so somebody who deliberately clicks into the editor keeps what they asked for. Only the unasked start is guarded; the 63 examples that wait for a click are untouched.

Measured after: `scrollY` 0 for the full 14s with the app rendering inside the frame, and a clicked start on a chapter page still mounts its one frame.

## A third column entry: Enterprise ready

The right column carried two sections beside the fact table. The question an enterprise asks first — whose security is this inside, and who keeps it working — was not among them. It goes between the other two, out of the framework README's own section, and the Support sentence moves here from What it costs, where it sat only because there was nowhere else.

Three sections need the room two had, so all three are shorter. Measured at 1440: **the left column ends at 1208 and the right column ends at 1208.**

## The chapter menu keeps YOUR shape, not the trail you walked

Reported as *"it remembers a state and leaves things open, but not what I did"* — which is exactly right, and two bugs deep.

A `<details>` fires `toggle` in a **queued** task, not synchronously. The old code put the menu back and then attached one `toggle` listener per section, so the events fired *by* putting it back arrived at that listener: every navigation wrote the path down to wherever the reader had landed, as though they had unfolded each of those sections by hand. **Measured over five pages with the menu never touched once, the store grew from 1 entry to 8.**

And the key a section was remembered by was its link, falling back to its text — but four sections point at their own first page, which is also a section. **33 sections, 29 keys.** Two `<details>` sharing one entry move together, and the stored list came back with the same key twice.

A decision is now recorded per section, on the click that makes it, and nothing a navigation does can reach the store. A section nobody has touched is absent from it and keeps the shape the build gave it. The way down to the current page is still opened regardless — and now not written down; that was the bug. The key is the trail of headings.

Measured after: five pages untouched → store empty; one section opened and another closed → exactly those two; three pages later both still held.

## The Playground item goes back to the playground you left

Reported as *"the Playground tab — when I go to it the app is always run again, although it had already run before."*

It is a link, so a press builds a new document: the runtime boots and the app starts from the top. **Measured against a local copy with no network in the way, 2.4 to 2.8 seconds every time**, and the app's own state gone with the document.

No browser preserves a running page across a forward navigation. The back/forward cache is the only mechanism that preserves one at all, and it applies to going back — so when going back is what the reader means, the item goes back. The condition is narrow: this document was opened from the playground itself, the history has not grown since, and there is an entry to step back to. A sample page is excluded although it lives under the same path; a tab the playground opened is excluded because a step back there would be a dead press.

It can only ever match the link — the item's href is already lifted to the last playground URL, which is the entry this steps back to. What it adds is the browser's option to hand the page back alive. A 400ms fallback covers a step back that does not navigate, dropped on `pagehide` so a cached document cannot fire it on the way back in.

Measured on the built site, all three cases behave as described. **Whether the browser then restores it alive could not be measured** — this sandbox's headless Chromium has the back/forward cache switched off, and a page with nothing in it is not restored either.

The catalogue and the sample pages carry the same bar out of the playground repository and do not have this yet.

## Checks

155/155 tests pass (14 new), twelve gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_