### PR TITLE
The front door answers in four cards, and the fact table goes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -98,15 +98,6 @@ features:
 | **Reaches users in** | A browser tab, a [Fiori launchpad](/configuration/launchpad) tile, or [SAP Mobile Start](/configuration/mobile_start) on iOS and Android |
 | **Licence** | MIT — free for commercial use, no per-user fee, and the code is [on GitHub](https://github.com/abap2UI5/abap2UI5) |
 
-## What it costs
-
-Nothing. [MIT licensed](/resources/license) and free commercially — no licence
-key, no subscription, no per-user fee.
-
-**Nobody counts your users, because nothing is counting.** The app is a standard
-UI5 application served by your own ABAP stack: ten users and ten thousand are the
-same to it, and the SAP licensing you have is the licensing you keep.
-
 ## Enterprise ready
 
 **It runs inside the security you already have.** One HTTP endpoint, standard SAP
@@ -118,6 +109,15 @@ logon, no second user store — your
 Cloud, then [downported](/advanced/downporting) and linted against 7.02 before the
 `702` branch ships. [Support](/resources/support) is GitHub and Slack, with
 commercial options listed beside them.
+
+## What it costs
+
+Nothing. [MIT licensed](/resources/license) and free commercially — no licence
+key, no subscription, no per-user fee.
+
+**Nobody counts your users, because nothing is counting.** The app is a standard
+UI5 application served by your own ABAP stack: ten users and ten thousand are the
+same to it, and the SAP licensing you have is the licensing you keep.
 
 ## Developing with AI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,31 +84,31 @@ features:
     target: _self
 ---
 
-## abap2UI5 at a glance
-
-| | |
-|---|---|
-| **Runs on** | NetWeaver 7.02 and up, S/4HANA, ABAP Cloud — on-premise, private and public cloud, and the trial systems |
-| **Same everywhere** | An app written on 7.02 runs unchanged on ABAP Cloud; [Downporting](/advanced/downporting) is how |
-| **Installed with** | [abapGit](/get_started/quickstart) — one repository, no transport of frontend artefacts, no BSP application |
-| **Needs no** | JavaScript, OData service, RAP business object, CDS view, frontend project or Node toolchain |
-| **You write** | One ABAP class per app — the view, the model and the event handling in it |
-| **Speaks** | UI5, over stateless HTTP roundtrips against the framework's own service |
-| **Renders with** | [OpenUI5 from its CDN](/configuration/ui5_versions) by default; one exit points it at SAPUI5, a pinned version, or the UI5 your system already ships |
-| **Reaches users in** | A browser tab, a [Fiori launchpad](/configuration/launchpad) tile, or [SAP Mobile Start](/configuration/mobile_start) on iOS and Android |
-| **Licence** | MIT — free for commercial use, no per-user fee, and the code is [on GitHub](https://github.com/abap2UI5/abap2UI5) |
-
 ## Enterprise ready
 
-**It runs inside the security you already have.** One HTTP endpoint, standard SAP
-logon, no second user store — your
+**It runs inside the security you already have.** One HTTP endpoint, standard
+SAP logon, no second user store — your
 [authorizations](/configuration/authorization) and
 [session handling](/configuration/security) apply unchanged.
 
-**And it is kept that way.** Every merge is tested against Standard ABAP and ABAP
-Cloud, then [downported](/advanced/downporting) and linted against 7.02 before the
-`702` branch ships. [Support](/resources/support) is GitHub and Slack, with
-commercial options listed beside them.
+**And it is kept that way.** Every merge is tested against Standard ABAP and
+ABAP Cloud, then [downported](/advanced/downporting) and linted against 7.02
+before the `702` branch ships, so one app runs unchanged from NetWeaver 7.02 to
+ABAP Cloud. [Support](/resources/support) is GitHub and Slack.
+
+## Integration
+
+**It complements UI5 freestyle and RAP — it does not replace them.** Your RAP
+business objects and OData services stay where they are; this is for the app
+that would otherwise need a frontend project of its own. One ABAP class, in the
+same system, [installed with abapGit](/get_started/quickstart).
+
+**And it reaches users where they already are.** A browser tab, a
+[Fiori launchpad](/configuration/launchpad) tile, [SAP Build Work
+Zone](/configuration/btp), or [SAP Mobile Start](/configuration/mobile_start) on
+iOS and Android — rendering with
+[OpenUI5 from its CDN](/configuration/ui5_versions) or the UI5 your system
+already ships.
 
 ## What it costs
 

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -717,22 +717,25 @@ html { scroll-padding-top: 62px; }
    than 74ch, and capping it again would leave a gutter inside a gutter. */
 .home .band > p, .home .band > ul, .home .band > ol { max-width: 74ch; }
 
-/* The right column stacks: the fact table is the tall one, so it spans both
-   rows and the two short sections sit beside it, one under the other. Placed
-   explicitly rather than left to auto-flow, which would have started the AI
-   section on a new row BELOW the table and left a hole under the costs. Source
-   order is glance -> costs -> AI, which is the order they are read in, so the
-   reading order and the visual order still agree. */
+/* The right column stacks: the fact table is the tall one, so it spans all
+   three rows and the three short sections sit beside it, one under the other.
+   Placed explicitly rather than left to auto-flow, which would have started
+   the last of them on a new row BELOW the table and left a hole above it.
+   Source order is glance -> enterprise -> costs -> AI, which is the order they
+   are read in, so the reading order and the visual order still agree. */
 .home .band[data-band="abap2ui5-at-a-glance"] { grid-column: 1; grid-row: 1 / span 3; }
-.home .band[data-band="what-it-costs"] { grid-column: 2; grid-row: 1; }
-.home .band[data-band="enterprise-ready"] { grid-column: 2; grid-row: 2; }
+.home .band[data-band="enterprise-ready"] { grid-column: 2; grid-row: 1; }
+.home .band[data-band="what-it-costs"] { grid-column: 2; grid-row: 2; }
 .home .band[data-band="developing-with-ai"] { grid-column: 2; grid-row: 3; }
-/* The two lower ones keep their rules: inside a column a rule reads as a
-   divider between the sections, which is what it is. Only the topmost of the
-   two columns loses it, below. */
-/* Two columns of one row: the rule over the second would cut the first in
-   half, and its heading sits on the same line as the other's. */
-.home .band[data-band="what-it-costs"] > h2 { border-top-color: transparent; }
+/* AND THE COLUMN READS AS ONE CHAPTER. Every h2 on this site carries a rule
+   over it, which is right for a page of sections and wrong for three answers
+   to one question standing in a column beside a table: two hairlines cut the
+   column into three boxes and made it look like three unrelated things. The
+   band's own top rule, drawn over the table on the left, is the top of the
+   whole chapter and stays. The ones between go. */
+.home .band[data-band="enterprise-ready"] > h2,
+.home .band[data-band="what-it-costs"] > h2,
+.home .band[data-band="developing-with-ai"] > h2 { border-top-color: transparent; }
 
 /* The example is the widest thing on the page because what it opens is two
    panes - the ABAP on the left, the app it renders on the right. Held to a
@@ -743,7 +746,11 @@ html { scroll-padding-top: 62px; }
 @media (max-width: 860px) {
   /* One column again: two 300px columns of prose are worse than a long page. */
   .home .vp-doc.bands { display: block; }
-  .home .band[data-band="what-it-costs"] > h2 { border-top-color: var(--line); }
+  /* One after another under the table now, which is what a rule over a heading
+     is for - so they come back. */
+  .home .band[data-band="enterprise-ready"] > h2,
+  .home .band[data-band="what-it-costs"] > h2,
+  .home .band[data-band="developing-with-ai"] > h2 { border-top-color: var(--line); }
   /* the explicit placement goes with the grid */
   .home .band[data-band="abap2ui5-at-a-glance"],
   .home .band[data-band="what-it-costs"],

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -709,7 +709,11 @@ html { scroll-padding-top: 62px; }
 .home .vp-doc.bands {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  column-gap: 48px;
+  column-gap: 24px;
+  row-gap: 24px;
+  /* Two cards on a row are two panels, and two panels of different heights
+     read as one of them being unfinished. */
+  align-items: stretch;
 }
 .home .band { grid-column: 1 / -1; min-width: 0; }
 .home .band > :first-child { margin-top: 0; }
@@ -717,25 +721,56 @@ html { scroll-padding-top: 62px; }
    than 74ch, and capping it again would leave a gutter inside a gutter. */
 .home .band > p, .home .band > ul, .home .band > ol { max-width: 74ch; }
 
-/* The right column stacks: the fact table is the tall one, so it spans all
-   three rows and the three short sections sit beside it, one under the other.
-   Placed explicitly rather than left to auto-flow, which would have started
-   the last of them on a new row BELOW the table and left a hole above it.
-   Source order is glance -> enterprise -> costs -> AI, which is the order they
-   are read in, so the reading order and the visual order still agree. */
-.home .band[data-band="abap2ui5-at-a-glance"] { grid-column: 1; grid-row: 1 / span 3; }
-.home .band[data-band="enterprise-ready"] { grid-column: 2; grid-row: 1; }
-.home .band[data-band="what-it-costs"] { grid-column: 2; grid-row: 2; }
-.home .band[data-band="developing-with-ai"] { grid-column: 2; grid-row: 3; }
-/* AND THE COLUMN READS AS ONE CHAPTER. Every h2 on this site carries a rule
-   over it, which is right for a page of sections and wrong for three answers
-   to one question standing in a column beside a table: two hairlines cut the
-   column into three boxes and made it look like three unrelated things. The
-   band's own top rule, drawn over the table on the left, is the top of the
-   whole chapter and stays. The ones between go. */
+/* THE FOUR ANSWERS, AS FOUR CARDS.
+ *
+ * They used to be three sections in a column beside a nine-row fact table, and
+ * the table was the problem: a stranger who has read the tagline already knows
+ * what it runs on and what it does not need, and reading it again as a grid of
+ * label/value pairs is homework, not an answer. What was load-bearing in it
+ * went into the four - the 7.02-to-Cloud claim into Enterprise ready, the
+ * launchpads and the UI5 source into Integration, the licence into What it
+ * costs - and the rest was the tagline said twice.
+ *
+ * Four is what makes the shape: two by two, every card the same width and, by
+ * `align-items: stretch`, the same height as the one beside it. Three never
+ * balanced against anything; four balance against each other.
+ *
+ * Raised rather than ruled. A hairline over a heading separates sections read
+ * in order; these four are read in any order, so each is a panel of its own -
+ * the border and radius the tiles above already use, on the sunken ground,
+ * with the heading in the accent so the four titles carry the page at a
+ * glance. */
+.home .band[data-band="enterprise-ready"],
+.home .band[data-band="integration"],
+.home .band[data-band="what-it-costs"],
+.home .band[data-band="developing-with-ai"] {
+  grid-column: auto;
+  padding: 22px 24px 24px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg-sunken);
+}
 .home .band[data-band="enterprise-ready"] > h2,
+.home .band[data-band="integration"] > h2,
 .home .band[data-band="what-it-costs"] > h2,
-.home .band[data-band="developing-with-ai"] > h2 { border-top-color: transparent; }
+.home .band[data-band="developing-with-ai"] > h2 {
+  margin: 0 0 4px;
+  padding-top: 0;
+  border-top: 0;
+  color: var(--accent);
+  font-size: 15px;
+}
+/* The card is already the measure; capping the paragraphs again would leave a
+   gutter inside a gutter. */
+.home .band[data-band="enterprise-ready"] > p,
+.home .band[data-band="integration"] > p,
+.home .band[data-band="what-it-costs"] > p,
+.home .band[data-band="developing-with-ai"] > p { max-width: none; }
+/* A card is a box with a floor: the last paragraph must not push against it. */
+.home .band[data-band="enterprise-ready"] > p:last-child,
+.home .band[data-band="integration"] > p:last-child,
+.home .band[data-band="what-it-costs"] > p:last-child,
+.home .band[data-band="developing-with-ai"] > p:last-child { margin-bottom: 0; }
 
 /* The example is the widest thing on the page because what it opens is two
    panes - the ABAP on the left, the app it renders on the right. Held to a
@@ -746,16 +781,14 @@ html { scroll-padding-top: 62px; }
 @media (max-width: 860px) {
   /* One column again: two 300px columns of prose are worse than a long page. */
   .home .vp-doc.bands { display: block; }
-  /* One after another under the table now, which is what a rule over a heading
-     is for - so they come back. */
-  .home .band[data-band="enterprise-ready"] > h2,
-  .home .band[data-band="what-it-costs"] > h2,
-  .home .band[data-band="developing-with-ai"] > h2 { border-top-color: var(--line); }
-  /* the explicit placement goes with the grid */
-  .home .band[data-band="abap2ui5-at-a-glance"],
-  .home .band[data-band="what-it-costs"],
+  /* One card per row, and they stay cards: what a card says here is "this is
+     one of four answers, read them in any order", which is as true on a phone
+     as on a desk. `display: block` drops the row gap with the grid, so the
+     card carries its own. */
   .home .band[data-band="enterprise-ready"],
-  .home .band[data-band="developing-with-ai"] { grid-column: auto; grid-row: auto; }
+  .home .band[data-band="integration"],
+  .home .band[data-band="what-it-costs"],
+  .home .band[data-band="developing-with-ai"] { margin-top: 24px; }
 }
 
 /* ---- what a stranger checks first ----------------------------------- */


### PR DESCRIPTION
Two commits on the same part of the home page: the three sections beside the fact table become four cards, and the table goes.

## The table goes

It was nine rows of label/value. A stranger who has read the tagline already knows what it runs on and what it does not need, and being shown it again as a grid is homework rather than an answer. What was load-bearing in it moves into the cards — the 7.02-to-Cloud claim into **Enterprise ready**, the launchpads and the UI5 source into **Integration**, the licence into **What it costs**. The rest was the tagline said a second time.

## Integration is the new fourth

It answers the question a table cannot: not *what is this*, but *what does it sit next to*.

It complements UI5 freestyle and RAP rather than replacing them — the RAP business objects and OData services stay where they are, and this is for the app that would otherwise need a frontend project of its own. And it reaches users where they already are: a browser tab, a Fiori launchpad tile, SAP Build Work Zone, SAP Mobile Start.

## Four is what makes the shape

Two by two, every card the same width and — by `align-items: stretch` — the same height as the one beside it. Three sections in a column beside a table never balanced against anything; four balance against each other. **Measured at 1440: 548 wide each, 269/269 on the first row, 247/247 on the second.**

Raised rather than ruled. A hairline over a heading separates sections read in order; these four are read in any order, so each is a panel of its own — the border and radius the tiles above already use, on the sunken ground, heading in the accent so the four titles carry the page at a glance. Both palettes resolve: `#f4f5f7` on `#d9dbe0` in light, `#1e2024` on `#303338` in dark.

Below 860 it is one card per row, still cards — *"this is one of four answers, read them in any order"* is as true on a phone as on a desk. 335 wide at 390, nothing scrolling sideways.

## Also in here

Enterprise ready leads, because whose security this is inside and who keeps it working is asked before the licence and long before the tooling.

## Checks

155/155 tests, twelve gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW