### PR TITLE
A reworded heading must not be able to break the layout

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -696,14 +696,34 @@ const tile = (f) => `<a class="tile" href="${esc(linkOf(f.link))}"${f.target ? `
  *
  * Split on the H2s rather than on a marker in the source: the heading is what
  * a section IS here, and a marker would be a second thing to keep in step. */
+/* WHICH BANDS ARE THE CARDS IS A QUESTION OF POSITION, NOT OF NAME.
+ *
+ * The four answers used to be styled by their heading slugs -
+ * `[data-band="what-it-costs"]` and three more. Then that heading was renamed
+ * to "Licensing & What it costs" from the Edit-on-GitHub link, the slug became
+ * something else, and the card silently stopped being one: it fell out of the
+ * grid, drew a rule nobody wanted and left the fourth card alone on a row. The
+ * page broke on a wording change, which is the one edit that page invites.
+ *
+ * So the rule reads off the shape instead. The bands before the runnable
+ * example are the answers - the example is the page's hinge, everything above
+ * it is the case being made and everything below it is where to go next - and
+ * the example is found by the markup the fence generator writes, not by a name
+ * anybody can retype. Rename all four, reorder them, add a fifth: they stay
+ * cards, and the grid follows. */
 const bands = (body) => {
   const parts = body.split(/(?=<h2\b)/);
   /* Anything before the first heading - there is none today - stays as it is
    * rather than being given a band it did not ask for. */
   const lead = parts[0].startsWith('<h2') ? '' : parts.shift();
-  return lead + parts.map((part) => {
+  const hinge = parts.findIndex((part) => part.includes('a2ui5-play'));
+  return lead + parts.map((part, i) => {
     const id = (part.match(/^<h2 id="([^"]+)"/) || [, ''])[1];
-    return `<section class="band"${id ? ` data-band="${esc(id)}"` : ''}>${part}</section>`;
+    const card = hinge > 0 && i < hinge ? ' data-card' : '';
+    /* ...and the hinge marks itself, for the same reason: what needs the full
+       width is the band the example is IN, whatever it ends up being called. */
+    const demo = i === hinge ? ' data-demo' : '';
+    return `<section class="band"${id ? ` data-band="${esc(id)}"` : ''}${card}${demo}>${part}</section>`;
   }).join('');
 };
 

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -721,39 +721,36 @@ html { scroll-padding-top: 62px; }
    than 74ch, and capping it again would leave a gutter inside a gutter. */
 .home .band > p, .home .band > ul, .home .band > ol { max-width: 74ch; }
 
-/* THE FOUR ANSWERS, AS FOUR CARDS.
+/* THE ANSWERS, AS CARDS.
  *
  * They used to be three sections in a column beside a nine-row fact table, and
  * the table was the problem: a stranger who has read the tagline already knows
  * what it runs on and what it does not need, and reading it again as a grid of
  * label/value pairs is homework, not an answer. What was load-bearing in it
- * went into the four - the 7.02-to-Cloud claim into Enterprise ready, the
- * launchpads and the UI5 source into Integration, the licence into What it
- * costs - and the rest was the tagline said twice.
+ * went into the answers themselves.
  *
- * Four is what makes the shape: two by two, every card the same width and, by
- * `align-items: stretch`, the same height as the one beside it. Three never
- * balanced against anything; four balance against each other.
+ * Two by two, every card the same width and, by `align-items: stretch`, the
+ * same height as the one beside it. Three sections in a column beside a table
+ * never balanced against anything; four balance against each other.
  *
- * Raised rather than ruled. A hairline over a heading separates sections read
- * in order; these four are read in any order, so each is a panel of its own -
- * the border and radius the tiles above already use, on the sunken ground,
- * with the heading in the accent so the four titles carry the page at a
- * glance. */
-.home .band[data-band="enterprise-ready"],
-.home .band[data-band="integration"],
-.home .band[data-band="what-it-costs"],
-.home .band[data-band="developing-with-ai"] {
+ * Raised rather than ruled. A hairline over a heading separates bands read in
+ * order; these are read in any order, so each is a panel of its own - the
+ * border and radius the tiles above already use, on the sunken ground, with
+ * the heading in the accent so the titles carry the page at a glance.
+ *
+ * KEYED ON `data-card`, WHICH THE BUILD PUTS THERE BY POSITION. It used to be
+ * keyed on each heading's slug, and renaming one heading from the
+ * Edit-on-GitHub link dropped that card out of the grid without a word. A
+ * wording change is the one edit this page invites; it must not be able to
+ * break the layout. See bands( ) in build-site.mjs. */
+.home .band[data-card] {
   grid-column: auto;
   padding: 22px 24px 24px;
   border: 1px solid var(--line);
   border-radius: 6px;
   background: var(--bg-sunken);
 }
-.home .band[data-band="enterprise-ready"] > h2,
-.home .band[data-band="integration"] > h2,
-.home .band[data-band="what-it-costs"] > h2,
-.home .band[data-band="developing-with-ai"] > h2 {
+.home .band[data-card] > h2 {
   margin: 0 0 4px;
   padding-top: 0;
   border-top: 0;
@@ -762,33 +759,24 @@ html { scroll-padding-top: 62px; }
 }
 /* The card is already the measure; capping the paragraphs again would leave a
    gutter inside a gutter. */
-.home .band[data-band="enterprise-ready"] > p,
-.home .band[data-band="integration"] > p,
-.home .band[data-band="what-it-costs"] > p,
-.home .band[data-band="developing-with-ai"] > p { max-width: none; }
+.home .band[data-card] > p { max-width: none; }
 /* A card is a box with a floor: the last paragraph must not push against it. */
-.home .band[data-band="enterprise-ready"] > p:last-child,
-.home .band[data-band="integration"] > p:last-child,
-.home .band[data-band="what-it-costs"] > p:last-child,
-.home .band[data-band="developing-with-ai"] > p:last-child { margin-bottom: 0; }
+.home .band[data-card] > p:last-child { margin-bottom: 0; }
 
 /* The example is the widest thing on the page because what it opens is two
    panes - the ABAP on the left, the app it renders on the right. Held to a
    column, neither is worth looking at. */
-.home .band[data-band="try-it-out-now"] .a2ui5-play,
-.home .band[data-band="try-it-out-now"] > p { max-width: none; }
+.home .band[data-demo] .a2ui5-play,
+.home .band[data-demo] > p { max-width: none; }
 
 @media (max-width: 860px) {
   /* One column again: two 300px columns of prose are worse than a long page. */
   .home .vp-doc.bands { display: block; }
   /* One card per row, and they stay cards: what a card says here is "this is
-     one of four answers, read them in any order", which is as true on a phone
+     one of the answers, read them in any order", which is as true on a phone
      as on a desk. `display: block` drops the row gap with the grid, so the
      card carries its own. */
-  .home .band[data-band="enterprise-ready"],
-  .home .band[data-band="integration"],
-  .home .band[data-band="what-it-costs"],
-  .home .band[data-band="developing-with-ai"] { margin-top: 24px; }
+  .home .band[data-card] { margin-top: 24px; }
 }
 
 /* ---- what a stranger checks first ----------------------------------- */

--- a/test/playground.test.mjs
+++ b/test/playground.test.mjs
@@ -345,3 +345,32 @@ test('the guard lets go the moment the reader does anything', () => {
   assert.match(guard, /setTimeout\(release,/,
     'and it stands down anyway, for a reader who never touches the page');
 });
+
+/*
+ * WHICH BANDS ARE CARDS IS A QUESTION OF POSITION, NOT OF NAME.
+ *
+ * The four answers on the front door were styled by their heading slugs -
+ * `[data-band="what-it-costs"]` and three more. Then that heading was renamed
+ * to "Licensing & What it costs" from the page's own Edit-on-GitHub link, the
+ * slug became something else, and the card silently stopped being one: out of
+ * the grid, a rule nobody wanted, and the fourth card alone on a row.
+ *
+ * A wording change is the one edit that page invites. It must not be able to
+ * break the layout, so nothing in the stylesheet may name a heading.
+ */
+const CSS = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'scripts/site-css/docs.css'), 'utf8');
+const BUILD = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'scripts/build-site.mjs'), 'utf8');
+
+test('the home page stylesheet names no heading of the home page', () => {
+  const named = [...CSS.matchAll(/\.home[^{]*\[data-band="([^"]+)"\]/g)].map((m) => m[1]);
+  assert.deepEqual(named, [],
+    'a slug in a selector is a layout that breaks when somebody rewords a heading');
+});
+
+test('the build marks the cards and the demo by where they are', () => {
+  const fn = BUILD.slice(BUILD.indexOf('const bands = (body)'), BUILD.indexOf('const home = ('));
+  assert.match(fn, /includes\('a2ui5-play'\)/,
+    'the runnable example is the hinge, and it is found by its markup');
+  assert.match(fn, /i < hinge \? ' data-card'/, 'everything above the hinge is an answer');
+  assert.match(fn, /i === hinge \? ' data-demo'/, 'the hinge itself is the one that wants the full width');
+});


### PR DESCRIPTION
Renaming **What it costs** to **Licensing & What it costs** from the page's own Edit-on-GitHub link dropped that card out of the grid: it stopped being a card, drew a rule nobody wanted, and left the fourth alone on a row.

Nothing was wrong with the edit. The layout was keyed on each heading's **slug** — `[data-band="what-it-costs"]` and three more — so a wording change silently changed the selector out from under it. That edit is live on `main`, so the front door is showing it now.

## The rule reads off the shape instead

The bands **above** the runnable example are the answers; the band the example is **in** is the one that wants the full width. The build marks both, and it finds the example by the markup the fence generator writes — not by a name anybody can retype.

Rename all four, reorder them, add a fifth: they stay cards and the grid follows.

Nothing in the stylesheet names a heading of this page any more, and a test holds that — the failure it describes is the one that just happened, in the words it happened in.

## Measured

On the reworded page: four cards again, **548 wide each, 269/269 on the first row and 247/247 on the second**, the example full width at 1120.

157/157 tests, twelve gates green.

## Left alone

Two content decisions from the web edit stay as they are — they are the author's, not a bug: the two shortened tile blurbs, and the removal of the downporting sentence, which took with it the last place on the page that says an app runs unchanged from 7.02 to ABAP Cloud and the only link to `/advanced/downporting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_