### PR TITLE
The front door says each thing once, in one shape per card

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ title: Home
 # preview card carries. It used to be the slogan alone - four words for the
 # most important page on the site, where every chapter has a sentence of its
 # own. What it is, what it needs, what it costs, where it runs.
-description: One ABAP class is one UI5 app - no JavaScript, no OData service, no RAP. Free and MIT licensed, installed with abapGit, from NetWeaver 7.02 to ABAP Cloud.
+description: One ABAP class is one UI5 app - no JavaScript, no OData, no frontend project. Free and MIT licensed, installed with abapGit, from NetWeaver 7.02 to ABAP Cloud.
 
 # THIS PAGE IS THE PROJECT'S FRONT DOOR, NOT THE MANUAL'S.
 #
@@ -18,16 +18,21 @@ description: One ABAP class is one UI5 app - no JavaScript, no OData service, no
 # colleague's link, and who has not decided to read a manual yet.
 #
 # So the page answers, in this order: what it is (the hero), where to go next
-# (the three cards), what it runs on and what it does NOT need, what one app
-# looks like — with a button that RUNS it, right here — what it costs, what an
-# agent makes of it, and what is built around it. A reader who wants the manual
-# is one word away in the bar; this page does not compete with it.
+# (the three tiles), the four answers a decision needs — security, integration,
+# cost, AI — what one app looks like, with a button that RUNS it right here,
+# and what is built around it. A reader who wants the manual is one word away
+# in the bar; this page does not compete with it.
 #
 # KEEP IT SHORT. Every claim on this page is made once. The tagline, the fact
 # table, the example's bullets and the AI section each used to carry their own
 # copy of "no JavaScript, no OData service, no frontend project" - four times on
 # one page, and the reader who needed it had it after the first. It lives in the
-# tagline and in the table's "Needs no" row now, and nowhere else.
+# tagline now, and nowhere else. abapGit is the same story: the tagline and the
+# second button say it, so no card says it again.
+#
+# AND EVERY CARD MAKES ONE BOLD CLAIM, with plain sentences around it. The
+# four used to share a formula - bold lead, explanation, "**And it ...**",
+# explanation - which reads as a template by the third card.
 hero:
   # The greeting, because this is the front door and a reader who arrives from
   # a talk or a colleague's link should be met rather than pitched at. The
@@ -40,14 +45,19 @@ hero:
   # to do with, so the first line stopped two words short of the measure and
   # the second started under a ragged edge. Two sentences that belong together
   # wrap where the column says they wrap.
-  tagline: "One ABAP class is one UI5 app — no JavaScript, no OData service, no RAP, no frontend project. Install it with abapGit and run it on anything from NetWeaver 7.02 to ABAP Cloud."
+  # THREE "no"s. There were four - "no RAP" stood between them - and a list of
+  # negatives stops being read at the third. RAP has its own sentence in the
+  # Integration card, where the point is that the two work side by side.
+  tagline: "One ABAP class is one UI5 app — no JavaScript, no OData, no frontend project. Install it with abapGit and run it on anything from NetWeaver 7.02 to ABAP Cloud."
   image:
     src: /logo-hero.png
     alt: abap2UI5 Logo
     width: 200px
     height: 200px
-  # Three buttons, in the order a stranger needs them: try it without
-  # installing anything, install it, understand it. The playground is first on
+  # Two buttons, in the order a stranger needs them: try it without installing
+  # anything, then install it. There was a third, "What it is", and it opened
+  # the same page as the Documentation tile directly under it - two doors into
+  # one room, and a reader cannot tell them apart. The playground is first on
   # purpose — it is the one claim on this page a reader can check in ten
   # seconds, and it costs them nothing. It is an absolute URL, so VitePress
   # draws it as an external link and gives it a `target` of its own, which is
@@ -60,9 +70,6 @@ hero:
     - theme: alt
       text: Install with abapGit
       link: /get_started/quickstart
-    - theme: alt
-      text: What it is
-      link: /get_started/about
 
 # The other three places the bar names, in the order the bar names them. Not
 # three sections of this site any more: a reader on this page is choosing
@@ -70,7 +77,7 @@ hero:
 features:
   - title: Documentation
     icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" d="M12 6.9C10.4 5.5 8.2 4.8 5.4 4.8H2.4v12.6h3c2.8 0 5 .7 6.6 2.1 1.6-1.4 3.8-2.1 6.6-2.1h3V4.8h-3c-2.8 0-5 .7-6.6 2.1z"/><path fill="none" stroke="currentColor" stroke-width="1.7" d="M12 6.9v12.6"/></svg>
-    details: The manual — a tutorial you build along with, a cookbook of tables, popups, navigation and uploads, and everything between your first app and real users.
+    details: Tutorial, cookbook and reference — everything from your first app to production.
     link: /get_started/about
   - title: Samples
     icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.6" y="4.2" width="18.8" height="15.6" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M2.6 9.1h18.8M8.2 9.1v10.7"/></svg>
@@ -86,48 +93,40 @@ features:
 
 ## Enterprise ready
 
-**It runs inside the security you already have.** One HTTP endpoint, standard
-SAP logon, no second user store — your
-[authorizations](/configuration/authorization) and
-[session handling](/configuration/security) apply unchanged.
-
-**And it is kept that way.** Every merge is tested against Standard ABAP and
-ABAP Cloud. [Support](/resources/support) is GitHub and Slack.
+**Runs inside the security you already have.** One HTTP endpoint, standard SAP
+logon — your [authorizations](/configuration/authorization) and
+[session handling](/configuration/security) apply unchanged. Every merge is
+tested against Standard ABAP and ABAP Cloud. [Support](/resources/support) is on
+GitHub and Slack.
 
 ## Integration
 
-**It complements UI5 freestyle and RAP — it does not replace them.** Your RAP
-business objects and OData services stay where they are; this is for the app
-that would otherwise need a frontend project of its own. One ABAP class, in the
-same system, [installed with abapGit](/get_started/quickstart).
+**Complements UI5 freestyle and RAP — it does not replace them.** Your RAP
+business objects and OData services stay where they are; abap2UI5 covers the app
+that would otherwise need a frontend project of its own.
 
-**And it reaches users where they already are.** A browser tab, a
+It runs where your users already are: a browser tab, a
 [Fiori launchpad](/configuration/launchpad) tile, [SAP Build Work
-Zone](/configuration/btp), or [SAP Mobile Start](/configuration/mobile_start) on
-iOS and Android — rendering with
-[OpenUI5 from its CDN](/configuration/ui5_versions) or the UI5 your system
-already ships.
+Zone](/configuration/btp) or [SAP Mobile Start](/configuration/mobile_start) —
+rendering with [OpenUI5 from its CDN](/configuration/ui5_versions) or the UI5
+your system already ships.
 
-## Licensing & What it costs
+## What it costs
 
 Nothing. [MIT licensed](/resources/license) and free commercially — no licence
 key, no subscription, no per-user fee.
 
-**Nobody counts your users, because nothing is counting.** The app is a standard
-UI5 application served by your own ABAP stack: ten users and ten thousand are the
-same to it, and the SAP licensing you have is the licensing you keep.
+**Nobody counts your users, because nothing is counting.** It is a standard UI5
+app served by your own ABAP stack — ten users or ten thousand, the SAP licence
+you have is the one you keep.
 
 ## Developing with AI
 
-One class is one file for an agent to write — no second half that can drift out
-of step with it.
-
-**And it can check its own work without an SAP system.** The
-[linter](/advanced/linter) rebuilds the UI5 view out of the ABAP and reports the
-names UI5 does not have; the [MCP server](/advanced/mcp_server) turns that into a
-loop — validate the view just written, boot the app headless, get the errors and
-a screenshot back. [The whole ladder](/get_started/ai) starts with a paragraph you
-paste ahead of a task.
+**One class is one file — the whole app, for an agent to write.** It can check
+its own work without an SAP system: the [linter](/advanced/linter) validates the
+view, the [MCP server](/advanced/mcp_server) boots the app headless and returns
+the errors and a screenshot. [The AI guide](/get_started/ai) starts with one
+paragraph you paste ahead of a task.
 
 ## Try it out now
 
@@ -184,26 +183,26 @@ ENDCLASS.
   </a>
   <a class="a2ui5-out-card" href="https://abap2ui5.github.io/linter/" target="_self">
     <span class="a2ui5-out-title">Linter</span>
-    <span class="a2ui5-out-details">Rules that read abap2UI5 code as abap2UI5 — view chains, bindings, event wiring — with a rule reference you can read on its own.</span>
+    <span class="a2ui5-out-details">Rules that understand abap2UI5 code — view chains, bindings, events — with a rule reference you can read on its own.</span>
   </a>
   <a class="a2ui5-out-card is-inside" href="/docs/advanced/mcp_server">
     <span class="a2ui5-out-title">Tooling</span>
-    <span class="a2ui5-out-details">A VS Code extension, an MCP server so an AI assistant answers from the real API, and an app template to start from.</span>
+    <span class="a2ui5-out-details">A VS Code extension, an MCP server for AI assistants, and an app template to start from.</span>
   </a>
 
   <a class="a2ui5-out-card" href="https://github.com/abap2UI5/abap2UI5/" target="_blank" rel="noreferrer">
     <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg></span>
     <span class="a2ui5-out-title">Community</span>
-    <span class="a2ui5-out-details">Read the code, open an issue, send a pull request — abap2UI5 is built in the open, and contributions are welcome.</span>
+    <span class="a2ui5-out-details">Built in the open — read the code, open an issue, send a pull request.</span>
   </a>
   <a class="a2ui5-out-card" href="https://www.linkedin.com/company/abap2ui5/" target="_blank" rel="noreferrer">
     <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg></span>
     <span class="a2ui5-out-title">LinkedIn</span>
-    <span class="a2ui5-out-details">Follow along — new releases, articles, and what people are building with it right now.</span>
+    <span class="a2ui5-out-details">New releases, articles, and what people are building with it.</span>
   </a>
   <a class="a2ui5-out-card is-inside" href="/docs/resources/sponsor">
     <span class="a2ui5-out-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 21s-7.6-4.9-9.5-9.2C1.1 8.4 3 5 6.4 5c2 0 3.4 1.1 4.3 2.3l1.3 1.7 1.3-1.7C14.2 6.1 15.6 5 17.6 5c3.4 0 5.3 3.4 3.9 6.8C19.6 16.1 12 21 12 21z"/></svg></span>
     <span class="a2ui5-out-title">Sponsor</span>
-    <span class="a2ui5-out-details">The framework is free and maintained by volunteers. If it saved your project time, there is a way to give some back.</span>
+    <span class="a2ui5-out-details">Free and maintained by volunteers. If it saved your project time, here is a way to give some back.</span>
   </a>
 </div>

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -296,7 +296,7 @@ const urlOf = (page) => BASE + page.replace(/\.md$/, '.html');
 /** A link out of the FRONTMATTER, based.
  *
  * The renderer rewrites every link in the body and cannot see these: the hero's
- * three buttons and the three tiles are frontmatter, and `/get_started/about`
+ * two buttons and the three tiles are frontmatter, and `/get_started/about`
  * arrived in the page as `/get_started/about` - a path that is not on this
  * deployment at all. An absolute URL is left exactly as written; it is another
  * site, and one of them carries a `target` that keeps a router off it. */
@@ -661,7 +661,7 @@ const chapter = ({ body, page, route }) => `<main class="manual">
 /* ---- the front door ---------------------------------------------------
  *
  * The one page of this site that is not a chapter: a greeting, the headline,
- * the tagline, three buttons and three tiles, and then the markdown under the
+ * the tagline, two buttons and three tiles, and then the markdown under the
  * frontmatter as an ordinary article. Every value it is drawn with - 20/28 for
  * the greeting, 38/46 for the headline, 17/26 for the tagline, 13 on a 34px
  * button, a 15/22 tile title over 13/22 of detail - is the one the page


### PR DESCRIPTION
Shorter, punchier copy on the home page (`docs/index.md`). No layout or script change beyond two comments.

## What changes

- **Tagline and description:** three negatives instead of four — "no JavaScript, no OData, no frontend project". RAP keeps its sentence in the Integration card, where the point is that the two work side by side.
- **Hero:** two buttons instead of three. "What it is" opened the same page as the Documentation tile directly under it.
- **Documentation tile:** as short as the two beside it — "Tutorial, cookbook and reference — everything from your first app to production."
- **The four cards:** each makes one bold claim and says the rest plainly. The "**And it …**" formula that all four shared is gone; abapGit is no longer repeated in the Integration card; "Licensing & What it costs" is "What it costs" again; the AI card opens on a claim like the others and names what the linter and the MCP server do in one sentence each.
- **Around the project:** the six cards lose about a third of their words and none of their content.
- **Comments:** the frontmatter's own plan of the page is brought up to date (no fact table since #266, two buttons), and two comments in `scripts/build-site.mjs` that counted three buttons count two.

The one thing kept where it was: the support sentence stays in the Enterprise card, shortened. The Community card below is a single link to GitHub and cannot carry the link to the support page, which is where the commercial support is described.

## Verified locally

`npm test` (157 pass), `docs:build`, `check:cross-site`, `check:examples`, `check:conventions`, `check:playground`, `check:samples`, `check:design`. The gates that fetch from GitHub (`check:version`, `check:api-names`, `check:api-reference`, the `.site` build's frame) could not run in the sandbox; none of them reads the prose this changes — CI is the proof for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY)_