### PR TITLE
The four cards get headings that promise something

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,9 @@ description: One ABAP class is one UI5 app - no JavaScript, no OData, no fronten
 #
 # AND EVERY CARD MAKES ONE BOLD CLAIM, with plain sentences around it. The
 # four used to share a formula - bold lead, explanation, "**And it ...**",
-# explanation - which reads as a template by the third card.
+# explanation - which reads as a template by the third card. The headings
+# are claims too, not labels: "Fits right in" promises something, where
+# "Integration" only named a topic.
 hero:
   # The greeting, because this is the front door and a reader who arrives from
   # a talk or a colleague's link should be met rather than pitched at. The
@@ -91,7 +93,7 @@ features:
     target: _self
 ---
 
-## Enterprise ready
+## Enterprise ready from day one
 
 **Runs inside the security you already have.** One HTTP endpoint, standard SAP
 logon — your [authorizations](/configuration/authorization) and
@@ -99,7 +101,7 @@ logon — your [authorizations](/configuration/authorization) and
 tested against Standard ABAP and ABAP Cloud. [Support](/resources/support) is on
 GitHub and Slack.
 
-## Integration
+## Fits right in
 
 **Complements UI5 freestyle and RAP — it does not replace them.** Your RAP
 business objects and OData services stay where they are; abap2UI5 covers the app
@@ -111,16 +113,16 @@ Zone](/configuration/btp) or [SAP Mobile Start](/configuration/mobile_start) —
 rendering with [OpenUI5 from its CDN](/configuration/ui5_versions) or the UI5
 your system already ships.
 
-## What it costs
+## Free, no strings attached
 
-Nothing. [MIT licensed](/resources/license) and free commercially — no licence
-key, no subscription, no per-user fee.
+[MIT licensed](/resources/license) and free commercially — no licence key, no
+subscription, no per-user fee.
 
 **Nobody counts your users, because nothing is counting.** It is a standard UI5
 app served by your own ABAP stack — ten users or ten thousand, the SAP licence
 you have is the one you keep.
 
-## Developing with AI
+## Made for AI agents
 
 **One class is one file — the whole app, for an agent to write.** It can check
 its own work without an SAP system: the [linter](/advanced/linter) validates the

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,8 +33,8 @@ description: One ABAP class is one UI5 app - no JavaScript, no OData, no fronten
 # AND EVERY CARD MAKES ONE BOLD CLAIM, with plain sentences around it. The
 # four used to share a formula - bold lead, explanation, "**And it ...**",
 # explanation - which reads as a template by the third card. The headings
-# are claims too, not labels: "Fits right in" promises something, where
-# "Integration" only named a topic.
+# are claims too, not labels: "Plays well with what you have" promises
+# something, where "Integration" only named a topic.
 hero:
   # The greeting, because this is the front door and a reader who arrives from
   # a talk or a colleague's link should be met rather than pitched at. The
@@ -93,7 +93,7 @@ features:
     target: _self
 ---
 
-## Enterprise ready from day one
+## Ready for the enterprise
 
 **Runs inside the security you already have.** One HTTP endpoint, standard SAP
 logon — your [authorizations](/configuration/authorization) and
@@ -101,7 +101,7 @@ logon — your [authorizations](/configuration/authorization) and
 tested against Standard ABAP and ABAP Cloud. [Support](/resources/support) is on
 GitHub and Slack.
 
-## Fits right in
+## Plays well with what you have
 
 **Complements UI5 freestyle and RAP — it does not replace them.** Your RAP
 business objects and OData services stay where they are; abap2UI5 covers the app
@@ -113,10 +113,10 @@ Zone](/configuration/btp) or [SAP Mobile Start](/configuration/mobile_start) —
 rendering with [OpenUI5 from its CDN](/configuration/ui5_versions) or the UI5
 your system already ships.
 
-## Free, no strings attached
+## Free. Really.
 
-[MIT licensed](/resources/license) and free commercially — no licence key, no
-subscription, no per-user fee.
+[MIT licensed](/resources/license), commercial use included — no licence key,
+no subscription, no per-user fee.
 
 **Nobody counts your users, because nothing is counting.** It is a standard UI5
 app served by your own ABAP stack — ten users or ten thousand, the SAP licence


### PR DESCRIPTION
Follow-up to #268. The four cards on the home page had headings that named a topic — "Enterprise ready", "Integration", "What it costs", "Developing with AI" — while the bold claim under each did the talking. The heading is now the first claim.

| before | after |
|---|---|
| Enterprise ready | Ready for the enterprise |
| Integration | Plays well with what you have |
| What it costs | Free. Really. |
| Developing with AI | Made for AI agents |

Two consequential edits in the costs card: the opening "Nothing." goes, since it answered a question the heading no longer asks, and "free commercially" becomes "commercial use included" because the heading already says free twice. The frontmatter comment that describes the cards' shape names the new rule.

Nothing in the stylesheet or the build keys on a heading of this page (#267), so the cards stay cards.

Verified locally: `npm test` (157 pass), `docs:build`, `check:cross-site`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY)_