### PR TITLE
The Playground item finds the playground anywhere in the tab's history

### DIFF
--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -98,6 +98,57 @@ export function lastVisited(site, fallback, scope = fallback) {
   }
 }
 
+/* ── THE PLAYGROUND ITEM GOES BACK when the playground is behind you ────────
+ *
+ * The item is a link, a link makes a NEW document, and a new playground boots
+ * the whole ABAP runtime and runs the app from the top - two to three seconds,
+ * and the app's own state gone with the document that held it. The one
+ * mechanism that hands a running page back alive is the back/forward cache,
+ * and it applies to a page the reader has BEEN on. So when the page the item
+ * opens is still in this tab's history, the click (scripts/site-js/site.js)
+ * traverses to it there instead. This is the half with no DOM in it: which
+ * entry that is. The counterpart is src/shell/site-memory.mjs in
+ * abap2UI5/playground, and the sample pages' inline copy - change one, change
+ * the others.
+ */
+
+/** A page, as two history entries are compared: origin, path and query, a
+ *  trailing index.html taken off. The fragment is left out - it carries the
+ *  code, and the playground drops it from its own URL once the code has been
+ *  read, so the entry and the remembered URL can differ in it and still be
+ *  one page. */
+const pageOf = (url) => url.origin + url.pathname.replace(/index\.html$/, '') + url.search;
+
+/**
+ * The key of the history entry nearest to `current` that is the page `href`
+ * opens, or null. `entries` is what navigation.entries() answers - the tab's
+ * same-origin history - and `current` the index of the entry the reader is
+ * on. Nearest first, because the newer of two playgrounds is the one the href
+ * was lifted to; either direction, because the reader may have LEFT the
+ * playground with the Back button.
+ */
+export function entryOf(entries, current, href, base = location.href) {
+  let want;
+  try {
+    want = pageOf(new URL(href, base));
+  } catch {
+    return null;
+  }
+  const is = (entry) => {
+    try {
+      return typeof entry?.url === 'string' && pageOf(new URL(entry.url)) === want;
+    } catch {
+      return false;
+    }
+  };
+  for (let d = 1; d < entries.length; d++) {
+    for (const i of [current - d, current + d]) {
+      if (i >= 0 && i < entries.length && is(entries[i])) return entries[i].key ?? null;
+    }
+  }
+  return null;
+}
+
 /* ── WHERE ON THE PAGE, not only which page ─────────────────────────────────
  *
  * The item above comes back to the page you left. It came back to the TOP of

--- a/scripts/site-js/site.js
+++ b/scripts/site-js/site.js
@@ -14,7 +14,7 @@
 import { setUpPlayground } from './playground.js';
 import { setUpCodeLines, watchCodeLines } from './code-lines.js';
 import { markDirective, setUpLinkToSelection } from './link-to-selection.js';
-import { handOff, lastVisited, rememberHere, rememberScroll, restoreScroll } from './site-memory.js';
+import { entryOf, handOff, lastVisited, rememberHere, rememberScroll, restoreScroll } from './site-memory.js';
 
 /* The Run button under a runnable ABAP example, and "copy link to selection":
    one delegated listener each, for the whole document. */
@@ -108,50 +108,66 @@ document.addEventListener('click', (e) => {
  * app's own state, a half-filled form or a table scrolled to row 200, is gone
  * with the document that held it. No browser preserves a running page across a
  * forward navigation. Exactly one mechanism preserves it at all, and it is the
- * back/forward cache, which applies to going BACK.
+ * back/forward cache, which applies to a page the reader has BEEN on.
  *
- * So when going back is what the reader means, this goes back. The condition
- * is narrow and checkable: this document was opened FROM the playground itself
- * (not from a sample page under it, which is a different page), the history has
- * not grown since - a text fragment or an anchor pushed onto it would make one
- * step back something else - and there is an entry to go back to at all, which
- * a tab the playground opened with target=_blank does not have.
+ * So when the page the item opens is still in this tab's history, the press
+ * goes to it there. Two ways of knowing which entry that is:
  *
- * It can only ever match the link: the item's href is lifted to the last
- * playground URL, and that is the entry this steps back to. What it adds is the
+ *   - The Navigation API: navigation.entries() is the tab's same-origin
+ *     history, and entryOf( ) (theme/site-memory.js) finds the nearest entry
+ *     that IS the item's page - same path, same query. Any distance, either
+ *     direction: a reader who read two chapters since is two steps behind
+ *     it, and one who left it with the Back button is one step in front.
+ *   - Without it, the one case that can be known: this document was opened
+ *     FROM the playground itself (not from a sample page under it, which is a
+ *     different page), and the history has not grown since - an anchor or a
+ *     text fragment pushed onto it would make one step back something else.
+ *     A tab the playground opened with target=_blank has nothing behind it
+ *     at all.
+ *
+ * It can only ever land on the link: the item's href is lifted to the last
+ * playground URL, and that is the page this looks for. What it adds is the
  * browser's option to hand the page back alive instead of rebuilding it - and
- * where the browser declines, a reload is what the link would have done anyway.
+ * where the browser declines, a reload is what the link would have done
+ * anyway (the playground says why in its console, main.mjs over there).
  *
- * The fallback is for the one case that would be worse than today: a back that
- * does not navigate would be a dead press. If this document is still here 400ms
- * later, the link is followed after all - and the timer is dropped on pagehide,
- * so a document that WAS cached does not fire it on the way back in and bounce
- * the reader out of the page they returned to. */
+ * The fallback is for the one case that would be worse than today: a press
+ * that does not navigate would be a dead press. A traversal the browser cannot
+ * make rejects, and if this document is still here after a moment the link is
+ * followed after all - and the timer is dropped on pagehide, so a document
+ * that WAS cached does not fire it on the way back in and bounce the reader
+ * out of the page they returned to. */
 (function playgroundBehindYou() {
-  const item = document.querySelector('a[data-site="playground"]');
-  if (!item || history.length < 2) return;
-  const bare = (u) => u.pathname.replace(/index\.html$/, '');
-  let home;
-  let came;
-  try {
-    home = new URL(item.getAttribute('href'), location.href);
-    came = new URL(document.referrer);
-  } catch { return; }
-  /* The playground itself, not the catalogue and not a sample page - both of
-     those live under the same path and are not what the item opens. */
-  if (came.origin !== home.origin || bare(came) !== bare(home)) return;
+  if (!document.querySelector('a[data-site="playground"]')) return;
+  const bare = (u) => u.origin + u.pathname.replace(/index\.html$/, '') + u.search;
   const behind = history.length;
+  const cameFromIt = (href) => {
+    if (history.length < 2 || history.length !== behind) return false;
+    try {
+      return bare(new URL(document.referrer)) === bare(new URL(href, location.href));
+    } catch { return false; }
+  };
   document.addEventListener('click', (e) => {
     const a = e.target.closest?.('a[data-site="playground"]');
     if (!a || e.defaultPrevented) return;
     /* A press that means "in a new tab" still means that. */
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-    if (history.length !== behind) return;
-    e.preventDefault();
     const href = a.href;
-    const fallback = setTimeout(() => { location.href = href; }, 400);
+    const nav = globalThis.navigation;
+    let step;
+    if (nav?.entries && nav.traverseTo) {
+      const key = entryOf(nav.entries(), nav.currentEntry?.index ?? -1, href);
+      if (key === null) return;
+      step = () => nav.traverseTo(key).committed;
+    } else if (cameFromIt(href)) {
+      step = () => history.back();
+    } else {
+      return;
+    }
+    e.preventDefault();
+    const fallback = setTimeout(() => { location.href = href; }, 1500);
     addEventListener('pagehide', () => clearTimeout(fallback), { once: true });
-    history.back();
+    Promise.resolve().then(step).catch(() => { clearTimeout(fallback); location.href = href; });
   }, true);
 })();
 

--- a/test/playground-back.test.mjs
+++ b/test/playground-back.test.mjs
@@ -1,5 +1,5 @@
 /*
- * The bar's Playground item, and the one case where it goes back instead.
+ * The bar's Playground item, and when it goes back instead.
  *
  * Reported as "the Playground tab — when I go to it the app is always run
  * again, although it had already run before". It is a link, so a press builds
@@ -7,13 +7,17 @@
  * Measured against a local copy with no network in the way, 2.4 to 2.8 seconds
  * every time, and the app's own state gone with the document. No browser keeps
  * a running page across a FORWARD navigation; the back/forward cache is the
- * only mechanism that keeps one at all, and it applies to going back.
+ * only mechanism that keeps one at all, and it applies to a page the reader
+ * has been on.
  *
- * So when the playground is the page the reader just came from, the item goes
- * back to it. Measured on the built site, all three cases: arrived from the
- * playground -> history.back() and the playground again; arrived from another
- * docs page -> the link, untouched; arrived from a SAMPLE page, which lives
- * under the same path -> the link, because that is a different page.
+ * So when the playground is still in the tab's history, the item goes to it
+ * there. Which entry that is comes out of `entryOf` (theme/site-memory.js),
+ * over what navigation.entries() answers - the half with no DOM in it, checked
+ * here against histories of every shape. The click itself is source read as
+ * text, the way test/cross-site.test.mjs reads the Run bar's link: the
+ * Navigation API first, the one case a page can know without it (opened from
+ * the playground, history not grown since) as the fallback, and a way out if
+ * the step goes nowhere.
  *
  * Whether the browser then hands the page back alive is the browser's call and
  * cannot be measured here at all - this sandbox's headless Chromium has the
@@ -31,10 +35,77 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const SITE = readFileSync(join(ROOT, 'scripts/site-js/site.js'), 'utf8');
-const shortcut = SITE.slice(
-  SITE.indexOf('(function playgroundBehindYou()'),
-  SITE.indexOf('/* Where on the page, not only which page.'),
+const { entryOf } = await import('../docs/.vitepress/theme/site-memory.js');
+
+const SITE = 'https://abap2ui5.github.io';
+const PLAYGROUND = `${SITE}/playground/`;
+/** A history as navigation.entries() answers it: same-origin entries, in
+ *  order, each with a url and a key. */
+const history = (...urls) => urls.map((url, i) => ({ url: url && new URL(url, SITE).href, key: `k${i}`, index: i }));
+
+test('the playground one step behind is found', () => {
+  const h = history('/playground/', '/docs/get_started/about.html');
+  assert.equal(entryOf(h, 1, PLAYGROUND, h[1].url), 'k0');
+});
+
+test('...and two steps behind, which a plain step back could not reach', () => {
+  const h = history('/playground/', '/docs/get_started/about.html', '/docs/cookbook/model.html');
+  assert.equal(entryOf(h, 2, PLAYGROUND, h[2].url), 'k0');
+});
+
+test('...and one step in FRONT, for a reader who left it with the Back button', () => {
+  const h = history('/docs/get_started/about.html', '/playground/');
+  assert.equal(entryOf(h, 0, PLAYGROUND, h[0].url), 'k1');
+});
+
+test('the nearest of two playgrounds wins, and behind wins a tie', () => {
+  const h = history('/playground/', '/docs/a.html', '/playground/', '/docs/b.html', '/playground/');
+  assert.equal(entryOf(h, 3, PLAYGROUND, h[3].url), 'k2', 'k2 and k4 are both one step away; behind first');
+  assert.equal(entryOf(h, 1, PLAYGROUND, h[1].url), 'k0');
+});
+
+test('the page is the path AND the query: a playground on another sample is another page', () => {
+  const opened = `${PLAYGROUND}?src=https%3A%2F%2Fraw.githubusercontent.com%2Fx%2Fy.clas.abap`;
+  const h = history('/playground/', '/docs/a.html');
+  assert.equal(entryOf(h, 1, opened, h[1].url), null, 'the entry is the empty editor, the link is a sample');
+  const h2 = history(opened, '/docs/a.html');
+  assert.equal(entryOf(h2, 1, opened, h2[1].url), 'k0');
+});
+
+test('the fragment is not part of it - the playground drops the code from its own URL once read', () => {
+  const h = history('/playground/', '/docs/a.html');
+  assert.equal(entryOf(h, 1, `${PLAYGROUND}#code=AAAA`, h[1].url), 'k0');
+  const h2 = history('/playground/#code=AAAA', '/docs/a.html');
+  assert.equal(entryOf(h2, 1, PLAYGROUND, h2[1].url), 'k0');
+});
+
+test('index.html and the directory are one page', () => {
+  const h = history('/playground/index.html', '/docs/a.html');
+  assert.equal(entryOf(h, 1, PLAYGROUND, h[1].url), 'k0');
+});
+
+test('a sample page lives under the same path and is a different page', () => {
+  const h = history('/playground/samples/z2ui5_cl_demo_app_001/', '/docs/a.html');
+  assert.equal(entryOf(h, 1, PLAYGROUND, h[1].url), null);
+});
+
+test('the current entry itself is never the answer', () => {
+  const h = history('/playground/');
+  assert.equal(entryOf(h, 0, PLAYGROUND, h[0].url), null);
+});
+
+test('an entry the API will not describe, and a link that is not a URL, are simply not matches', () => {
+  const h = [{ url: null, key: 'k0', index: 0 }, ...history('/docs/a.html').map((e) => ({ ...e, key: 'k1', index: 1 }))];
+  assert.equal(entryOf(h, 1, PLAYGROUND, h[1].url), null, 'a cross-origin entry has no url');
+  assert.equal(entryOf(history('/playground/', '/docs/a.html'), 1, 'javascript:alert(1)', `${SITE}/docs/a.html`), null);
+  assert.equal(entryOf([], 0, PLAYGROUND, PLAYGROUND), null);
+});
+
+/* ---- the click, as written --------------------------------------------- */
+const SRC = readFileSync(join(ROOT, 'scripts/site-js/site.js'), 'utf8');
+const shortcut = SRC.slice(
+  SRC.indexOf('(function playgroundBehindYou()'),
+  SRC.indexOf('/* Where on the page, not only which page.'),
 );
 
 test('the shortcut exists and is about the Playground item', () => {
@@ -42,14 +113,23 @@ test('the shortcut exists and is about the Playground item', () => {
   assert.match(shortcut, /a\[data-site="playground"\]/);
 });
 
-test('it only fires for a reader who came from the playground itself', () => {
+test('it asks the Navigation API first, over the whole same-origin history', () => {
+  assert.match(shortcut, /nav\.entries\(\)/, 'navigation.entries() is the history it searches');
+  assert.match(shortcut, /entryOf\(nav\.entries\(\), nav\.currentEntry\?\.index \?\? -1, href\)/,
+    'the same function the tests above hold, on the lifted href');
+  assert.match(shortcut, /nav\.traverseTo\(key\)\.committed/, 'a traversal, with its rejection as the signal');
+  assert.match(SRC, /import \{ entryOf, /, 'entryOf comes from theme/site-memory.js like the rest of the memory');
+});
+
+test('without it, only a reader who came from the playground itself steps back', () => {
   assert.match(shortcut, /document\.referrer/, 'where this document was opened from is the whole condition');
-  assert.match(shortcut, /came\.origin !== home\.origin \|\| bare\(came\) !== bare\(home\)/,
-    'a sample page lives under the same path and is a different page');
+  assert.match(shortcut, /bare\(new URL\(document\.referrer\)\) === bare\(new URL\(href, location\.href\)\)/,
+    'the whole page - a sample page lives under the same path and is a different page');
   assert.match(shortcut, /history\.length < 2/,
     'a tab the playground OPENED has nothing behind it, and a dead press is worse than a reload');
   assert.match(shortcut, /history\.length !== behind/,
     'an anchor or a text fragment pushed since means one step back is something else');
+  assert.match(shortcut, /history\.back\(\)/);
 });
 
 test('a press that means "in a new tab" still means that', () => {
@@ -59,9 +139,11 @@ test('a press that means "in a new tab" still means that', () => {
   assert.match(shortcut, /e\.button !== 0/);
 });
 
-test('a step back that does not navigate still follows the link', () => {
+test('a step that does not navigate still follows the link', () => {
   assert.match(shortcut, /setTimeout\(\(\) => \{ location\.href = href; \}, \d+\)/,
     'the fallback is what keeps this from ever being a dead press');
   assert.match(shortcut, /addEventListener\('pagehide', \(\) => clearTimeout\(fallback\), \{ once: true \}\)/,
     'a cached document must not fire it on the way back in and bounce the reader out');
+  assert.match(shortcut, /\.catch\(\(\) => \{ clearTimeout\(fallback\); location\.href = href; \}\)/,
+    'a traversal the browser refuses is followed as the link, at once');
 });


### PR DESCRIPTION
Since #265 the bar's Playground item stepped back to the playground when this document had been opened from it and the history had not grown since. One step, one case. A reader who read two chapters in between, who came from the catalogue, or who had left the playground with the Back button got the link: a new document, the runtime booted again, the app run from the top.

## What changes

- **The click asks the Navigation API first.** `navigation.entries()` is the tab's same-origin history, and `entryOf()` (new in `theme/site-memory.js`) finds the nearest entry that IS the item's page: same origin, path and query, the fragment left out because the playground drops the code from its own URL once it has read it. Any distance, either direction. Then `navigation.traverseTo()`.
- **The referrer case stays as the fallback** for a browser without the API: opened from the playground itself, history not grown since, one step back.
- **A press always navigates.** A traversal the browser refuses is followed as the link at once; a document still here after a moment follows it too, and the timer is dropped on `pagehide` as before.

The same entry search lands in abap2UI5/playground for the catalogue and the sample pages, which had no step back at all (abap2UI5/playground#85).

Whether the browser then hands the page back alive is the back/forward cache's call. Where it rebuilt the playground instead, the playground now prints `notRestoredReasons` to its console on arrival, which is the one place the browser says why.

## Tests

`test/playground-back.test.mjs` holds `entryOf` over histories of every shape (one behind, two behind, one in front, two playgrounds, another query, a fragment, `index.html`, a sample page under the same path, a cross-origin entry) and reads the click for the API path, the fallback, the modifier keys and the way out.

Verified locally: `npm test` (168 pass), `docs:build`, `check:cross-site`, and `site.js` bundled with esbuild the way `build-site.mjs` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY