### PR TITLE
The last card asks the price instead of announcing it

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,13 @@ description: One ABAP class is one UI5 app - no JavaScript, no OData, no fronten
 # four used to share a formula - bold lead, explanation, "**And it ...**",
 # explanation - which reads as a template by the third card. The headings
 # are claims too, not labels: "Plays well with what you have" promises
-# something, where "Integration" only named a topic.
+# something, where "Integration" only named a topic. The last card asks
+# instead, and its bold lead is the one-word answer - so the reader who
+# scans only the headings still leaves with the price.
+#
+# THE ORDER IS AN ARGUMENT: it is safe here, it fits what you run, an agent
+# can write it - and only then, to somebody already persuaded, what it costs.
+# The price is the last card because it is the last question, not the first.
 hero:
   # The greeting, because this is the front door and a reader who arrives from
   # a talk or a colleague's link should be met rather than pitched at. The
@@ -93,7 +99,7 @@ features:
     target: _self
 ---
 
-## Ready for the enterprise
+## Ready for Your Enterprise
 
 **Runs inside the security you already have.** One HTTP endpoint, standard SAP
 logon — your [authorizations](/configuration/authorization) and
@@ -112,15 +118,6 @@ It runs where your users already are: a browser tab, a
 Zone](/configuration/btp) or [SAP Mobile Start](/configuration/mobile_start) —
 rendering with the UI5 your system already ships.
 
-## Free. Really.
-
-[MIT licensed](/resources/license), commercial use included — no licence key,
-no subscription, no per-user fee.
-
-**Nobody counts your users, because nothing is counting.** It is a standard UI5
-app served by your own ABAP stack — ten users or ten thousand, the SAP licence
-you have is the one you keep.
-
 ## Made for AI agents
 
 **One class is one file — the whole app, for an agent to write.** It can check
@@ -128,6 +125,15 @@ its own work without an SAP system: the [linter](/advanced/linter) validates the
 view, the [MCP server](/advanced/mcp_server) boots the app headless and returns
 the errors and a screenshot. [The AI guide](/get_started/ai) starts with one
 paragraph you paste ahead of a task.
+
+## And what does it cost?
+
+**Nothing.** [MIT licensed](/resources/license), commercial use included — no
+licence key, no subscription, no per-user fee.
+
+Nobody counts your users, because nothing is counting: it is a standard UI5 app
+served by your own ABAP stack — ten users or ten thousand, the SAP licence you
+have is the one you keep.
 
 ## Try it out now
 


### PR DESCRIPTION
The four cards on the front door are an argument, and the order was not making it. "Free. Really." sat third, between the integration answer and the AI one, where a price nobody has asked for yet reads as the pitch it is trying not to be.

It goes last — bottom right — after the reader has been told it is safe here, that it fits what they already run, and that an agent can write it:

| | left | right |
|---|---|---|
| top | Ready for **Your** Enterprise | Plays well with what you have |
| bottom | Made for AI agents | **And what does it cost?** |

And it asks rather than announces. The heading is the question, and the card's own bold lead is the one-word answer, so somebody who scans only the four headings still leaves with the price:

> **And what does it cost?**
>
> **Nothing.** [MIT licensed](/resources/license), commercial use included — no licence key, no subscription, no per-user fee.
>
> Nobody counts your users, because nothing is counting: it is a standard UI5 app served by your own ABAP stack — ten users or ten thousand, the SAP licence you have is the one you keep.

The claim itself is unchanged, minus one bold: the house rule is one bold claim per card, and the answer to the heading is now the one that earns it — "Nobody counts your users" carries the same sentence as plain prose leading its paragraph.

"Ready for the enterprise" becomes **"Ready for Your Enterprise"**: it is the reader's enterprise the card is about, not the abstract one.

## How this was checked

Measured on the built site (`node scripts/build-site.mjs .site`, served on the shared origin):

* **1440px** — the two rows come back 225/225 and 204/204, so the grid stays square:

  ```
  Ready for Your Enterprise      x=153 y=555 w=548 h=225
  Plays well with what you have  x=725 y=555 w=548 h=225
  Made for AI agents             x=153 y=804 w=548 h=204
  And what does it cost?         x=725 y=804 w=548 h=204
  ```

* **390px** — the four stack in order, `scrollWidth - clientWidth` is negative, so nothing runs off the side.

Nothing keys on a heading slug any more (#267), so a reworded heading cannot take the layout with it — which is exactly the failure this rename would have caused before that.

`npm run check` — all twelve gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_