### PR TITLE
Three cards end with a way out

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,15 @@ description: One ABAP class is one UI5 app - no JavaScript, no OData, no fronten
 # THE ORDER IS AN ARGUMENT: it is safe here, it fits what you run, an agent
 # can write it - and only then, to somebody already persuaded, what it costs.
 # The price is the last card because it is the last question, not the first.
+#
+# THREE CARDS END WITH A WAY OUT, and the link sits on the topic, never on the
+# word "here" - a reader scanning the links has to be able to tell where each
+# one goes. The cost card has none on purpose: its answer is complete on the
+# card, and its one destination (the licence) is already linked in the line
+# above, where "MIT licensed" stands. A second link to the same page inside
+# one card is the "every claim once" rule broken with a hyperlink - which is
+# also why the AI card's "The AI guide" is no longer a link: it and the card's
+# closer pointed at the same page, one line apart.
 hero:
   # The greeting, because this is the front door and a reader who arrives from
   # a talk or a colleague's link should be met rather than pitched at. The
@@ -107,6 +116,9 @@ logon — your [authorizations](/configuration/authorization) and
 tested against Standard ABAP and ABAP Cloud. [Support](/resources/support) is on
 GitHub and Slack.
 
+Learn more about [Enterprise Readiness](/get_started/about#enterprise-ready)
+here.
+
 ## Plays well with what you have
 
 **Complements UI5 freestyle and RAP — it does not replace them.** Your RAP
@@ -118,13 +130,17 @@ It runs where your users already are: a browser tab, a
 Zone](/configuration/btp) or [SAP Mobile Start](/configuration/mobile_start) —
 rendering with the UI5 your system already ships.
 
+Learn more about [Integration](/get_started/about#where-it-fits) here.
+
 ## Made for AI agents
 
 **One class is one file — the whole app, for an agent to write.** It can check
 its own work without an SAP system: the [linter](/advanced/linter) validates the
 view, the [MCP server](/advanced/mcp_server) boots the app headless and returns
-the errors and a screenshot. [The AI guide](/get_started/ai) starts with one
-paragraph you paste ahead of a task.
+the errors and a screenshot. The AI guide starts with one paragraph you paste
+ahead of a task.
+
+Learn more about [Developing with AI](/get_started/ai) here.
 
 ## And what does it cost?
 


### PR DESCRIPTION
Each of the three front-door cards that describes something the site covers in depth now closes with one line pointing there:

| card | closer | goes to |
|---|---|---|
| Ready for Your Enterprise | Learn more about **Enterprise Readiness** here. | `/get_started/about#enterprise-ready` |
| Plays well with what you have | Learn more about **Integration** here. | `/get_started/about#where-it-fits` |
| Made for AI agents | Learn more about **Developing with AI** here. | `/get_started/ai` |

The link sits on the topic, never on the word "here" — a reader scanning the links has to be able to tell where each one goes, and "here" tells them nothing.

**The cost card has none, on purpose.** Its answer is complete on the card, and its one destination is already linked in the line above it, where "MIT licensed" stands. A second link to the same page inside one card is "every claim once" broken with a hyperlink — which is also why `The AI guide` in the AI card is no longer a link: it and that card's new closer pointed at the same page, one line apart. The words stay; the destination is offered once.

## How this was checked

* **1440px** — the two rows come back 259/259 and 204/204, so the grid stays square.
* **390px** — the four still stack in order, `scrollWidth - clientWidth` is negative.
* The link checker reads `37103 internal links (1816 of them naming a section), none of them dead`, and both new anchors (`id="enterprise-ready"`, `id="where-it-fits"`) are in the rendered `about.html`.
* `npm run check` — all twelve gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_