### PR TITLE
The bar goes back to any page that is still behind you, not only the playground

### DIFF
--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -98,16 +98,17 @@ export function lastVisited(site, fallback, scope = fallback) {
   }
 }
 
-/* ── THE PLAYGROUND ITEM GOES BACK when the playground is behind you ────────
+/* ── THE BAR GOES BACK to a page that is still behind you ───────────────────
  *
- * The item is a link, a link makes a NEW document, and a new playground boots
- * the whole ABAP runtime and runs the app from the top - two to three seconds,
- * and the app's own state gone with the document that held it. The one
- * mechanism that hands a running page back alive is the back/forward cache,
- * and it applies to a page the reader has BEEN on. So when the page the item
- * opens is still in this tab's history, the click (scripts/site-js/site.js)
- * traverses to it there instead. This is the half with no DOM in it: which
- * entry that is. The counterpart is src/shell/site-memory.mjs in
+ * An item in the bar is a link, a link makes a NEW document, and a new
+ * playground - the page itself, or the runnable example on the front door -
+ * boots the whole ABAP runtime and runs the app from the top: two to three
+ * seconds, and the app's own state gone with the document that held it. The
+ * one mechanism that hands a running page back alive is the back/forward
+ * cache, and it applies to a page the reader has BEEN on. So when the page an
+ * item opens is still in this tab's history, the click (scripts/site-js/
+ * site.js) traverses to it there instead. This is the half with no DOM in it:
+ * which entry that is. The counterpart is src/shell/site-memory.mjs in
  * abap2UI5/playground, and the sample pages' inline copy - change one, change
  * the others.
  */

--- a/scripts/site-js/site.js
+++ b/scripts/site-js/site.js
@@ -14,7 +14,7 @@
 import { setUpPlayground } from './playground.js';
 import { setUpCodeLines, watchCodeLines } from './code-lines.js';
 import { markDirective, setUpLinkToSelection } from './link-to-selection.js';
-import { entryOf, handOff, lastVisited, rememberHere, rememberScroll, restoreScroll } from './site-memory.js';
+import { entryOf, handOff, lastVisited, rememberHere, rememberScroll, restoreScroll, takeHandoff } from './site-memory.js';
 
 /* The Run button under a runnable ABAP example, and "copy link to selection":
    one delegated listener each, for the whole document. */
@@ -97,39 +97,52 @@ document.addEventListener('click', (e) => {
   if (e.target.closest?.('a[data-site]')) lift();
 }, true);
 
-/* ---- and the Playground item goes BACK when the playground is behind you --
+/* ---- and the bar goes BACK to a page that is still behind you -----------
  *
- * Reported: "the Playground tab - when I go to it the app is always run again,
- * although it had already run before."
+ * Reported twice. First: "the Playground tab - when I go to it the app is
+ * always run again, although it had already run before." Then, once that
+ * item went back: the front door, with the example under Try it out now
+ * running in it, loaded fresh every time as well - and the runnable example
+ * is a whole ABAP runtime in a frame, exactly what the playground is.
  *
- * It is a link, so a press builds a NEW document: the whole ABAP runtime boots
- * and the app starts from the top. Measured against a local copy with no
- * network in the way, that is 2.4 to 2.8 seconds every single time - and the
- * app's own state, a half-filled form or a table scrolled to row 200, is gone
- * with the document that held it. No browser preserves a running page across a
- * forward navigation. Exactly one mechanism preserves it at all, and it is the
- * back/forward cache, which applies to a page the reader has BEEN on.
+ * Every item in the bar is a link, so a press builds a NEW document: the
+ * runtime boots and the app starts from the top. Measured against a local
+ * copy with no network in the way, that is 2.4 to 2.8 seconds every single
+ * time - and the app's own state, a half-filled form or a table scrolled to
+ * row 200, is gone with the document that held it. No browser preserves a
+ * running page across a forward navigation. Exactly one mechanism preserves
+ * it at all, and it is the back/forward cache, which applies to a page the
+ * reader has BEEN on.
  *
- * So when the page the item opens is still in this tab's history, the press
- * goes to it there. Two ways of knowing which entry that is:
+ * So when the page an item opens is still in this tab's history, the press
+ * goes to it there - Home, Documentation, Samples and Playground alike, which
+ * is also why this is one rule and not four. Two ways of knowing which entry:
  *
  *   - The Navigation API: navigation.entries() is the tab's same-origin
  *     history, and entryOf( ) (theme/site-memory.js) finds the nearest entry
- *     that IS the item's page - same path, same query. Any distance, either
- *     direction: a reader who read two chapters since is two steps behind
- *     it, and one who left it with the Back button is one step in front.
+ *     that IS the item's page - same origin, path and query. Any distance,
+ *     either direction: a reader who read two chapters since is two steps
+ *     behind it, and one who left it with the Back button is one step in
+ *     front.
  *   - Without it, the one case that can be known: this document was opened
- *     FROM the playground itself (not from a sample page under it, which is a
- *     different page), and the history has not grown since - an anchor or a
- *     text fragment pushed onto it would make one step back something else.
- *     A tab the playground opened with target=_blank has nothing behind it
- *     at all.
+ *     FROM that page (a sample page lives under the playground's path and is
+ *     a different page, which is why the whole URL is compared), and the
+ *     history has not grown since - an anchor or a text fragment pushed onto
+ *     it would make one step back something else. A tab the playground
+ *     opened with target=_blank has nothing behind it at all.
  *
- * It can only ever land on the link: the item's href is lifted to the last
- * playground URL, and that is the page this looks for. What it adds is the
- * browser's option to hand the page back alive instead of rebuilding it - and
- * where the browser declines, a reload is what the link would have done
- * anyway (the playground says why in its console, main.mjs over there).
+ * It can only ever land on the link: the item's href is what is looked for,
+ * lifted or not. The item for the page the reader is ON - Documentation on
+ * every page of the manual - is the browser's to handle, as it always was.
+ * What this adds is the browser's option to hand the page back alive instead
+ * of rebuilding it - and where the browser declines, a reload is what the
+ * link would have done anyway (the playground says why in its console,
+ * main.mjs over there).
+ *
+ * A page handed back alive is where the reader left it, offset and all, so
+ * the record a data-back link wrote on the way out is spent: it is taken on
+ * pageshow, or the next arrival at that page within the half minute would
+ * inherit it.
  *
  * The fallback is for the one case that would be worse than today: a press
  * that does not navigate would be a dead press. A traversal the browser cannot
@@ -137,8 +150,8 @@ document.addEventListener('click', (e) => {
  * followed after all - and the timer is dropped on pagehide, so a document
  * that WAS cached does not fire it on the way back in and bounce the reader
  * out of the page they returned to. */
-(function playgroundBehindYou() {
-  if (!document.querySelector('a[data-site="playground"]')) return;
+(function barBehindYou() {
+  if (!document.querySelector('.bar-nav a[href]')) return;
   const bare = (u) => u.origin + u.pathname.replace(/index\.html$/, '') + u.search;
   const behind = history.length;
   const cameFromIt = (href) => {
@@ -147,12 +160,17 @@ document.addEventListener('click', (e) => {
       return bare(new URL(document.referrer)) === bare(new URL(href, location.href));
     } catch { return false; }
   };
+  addEventListener('pageshow', (e) => { if (e.persisted) takeHandoff(); });
   document.addEventListener('click', (e) => {
-    const a = e.target.closest?.('a[data-site="playground"]');
+    const a = e.target.closest?.('.bar-nav a[href]');
     if (!a || e.defaultPrevented) return;
     /* A press that means "in a new tab" still means that. */
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    if (a.target && a.target !== '_self') return;
     const href = a.href;
+    let want;
+    try { want = bare(new URL(href, location.href)); } catch { return; }
+    if (want === bare(new URL(location.href))) return;
     const nav = globalThis.navigation;
     let step;
     if (nav?.entries && nav.traverseTo) {

--- a/test/bar-back.test.mjs
+++ b/test/bar-back.test.mjs
@@ -1,23 +1,24 @@
 /*
- * The bar's Playground item, and when it goes back instead.
+ * The bar, and when an item in it goes back instead.
  *
  * Reported as "the Playground tab — when I go to it the app is always run
- * again, although it had already run before". It is a link, so a press builds
- * a new document: the ABAP runtime boots and the app starts from the top.
- * Measured against a local copy with no network in the way, 2.4 to 2.8 seconds
- * every time, and the app's own state gone with the document. No browser keeps
- * a running page across a FORWARD navigation; the back/forward cache is the
- * only mechanism that keeps one at all, and it applies to a page the reader
- * has been on.
+ * again, although it had already run before" - and then again for the front
+ * door, whose Try it out now example is a playground in a frame. An item is a
+ * link, so a press builds a new document: the ABAP runtime boots and the app
+ * starts from the top. Measured against a local copy with no network in the
+ * way, 2.4 to 2.8 seconds every time, and the app's own state gone with the
+ * document. No browser keeps a running page across a FORWARD navigation; the
+ * back/forward cache is the only mechanism that keeps one at all, and it
+ * applies to a page the reader has been on.
  *
- * So when the playground is still in the tab's history, the item goes to it
- * there. Which entry that is comes out of `entryOf` (theme/site-memory.js),
+ * So when the page an item opens is still in the tab's history, the item goes
+ * to it there. Which entry that is comes out of `entryOf` (theme/site-memory.js),
  * over what navigation.entries() answers - the half with no DOM in it, checked
  * here against histories of every shape. The click itself is source read as
- * text, the way test/cross-site.test.mjs reads the Run bar's link: the
- * Navigation API first, the one case a page can know without it (opened from
- * the playground, history not grown since) as the fallback, and a way out if
- * the step goes nowhere.
+ * text, the way test/cross-site.test.mjs reads the Run bar's link: every item
+ * of the bar, the Navigation API first, the one case a page can know without
+ * it (opened from that page, history not grown since) as the fallback, and a
+ * way out if the step goes nowhere.
  *
  * Whether the browser then hands the page back alive is the browser's call and
  * cannot be measured here at all - this sandbox's headless Chromium has the
@@ -104,13 +105,27 @@ test('an entry the API will not describe, and a link that is not a URL, are simp
 /* ---- the click, as written --------------------------------------------- */
 const SRC = readFileSync(join(ROOT, 'scripts/site-js/site.js'), 'utf8');
 const shortcut = SRC.slice(
-  SRC.indexOf('(function playgroundBehindYou()'),
+  SRC.indexOf('(function barBehindYou()'),
   SRC.indexOf('/* Where on the page, not only which page.'),
 );
 
-test('the shortcut exists and is about the Playground item', () => {
+test('the shortcut exists and is about every item of the bar', () => {
   assert.ok(shortcut.length > 200, 'the block should still be there to reason about');
-  assert.match(shortcut, /a\[data-site="playground"\]/);
+  assert.match(shortcut, /closest\?\.\('\.bar-nav a\[href\]'\)/, 'one rule for the four items, not four');
+  assert.doesNotMatch(shortcut, /data-site="playground"/, 'the Playground item is not a special case any more');
+});
+
+test('the item for the page the reader is on is left to the browser', () => {
+  assert.match(shortcut, /if \(want === bare\(new URL\(location\.href\)\)\) return;/,
+    'Documentation on every page of the manual points at this page; stepping back to an older copy of it would be a surprise');
+  assert.match(shortcut, /if \(a\.target && a\.target !== '_self'\) return;/,
+    'a link that opens elsewhere has nothing to go back to');
+});
+
+test('a page handed back alive spends the scroll record written on the way out', () => {
+  assert.match(shortcut, /addEventListener\('pageshow', \(e\) => \{ if \(e\.persisted\) takeHandoff\(\); \}\)/,
+    'a restored page is where the reader left it; the record must not reach the next arrival');
+  assert.match(SRC, /import \{ entryOf, [^}]*takeHandoff \} from '\.\/site-memory\.js'/);
 });
 
 test('it asks the Navigation API first, over the whole same-origin history', () => {
@@ -121,7 +136,7 @@ test('it asks the Navigation API first, over the whole same-origin history', () 
   assert.match(SRC, /import \{ entryOf, /, 'entryOf comes from theme/site-memory.js like the rest of the memory');
 });
 
-test('without it, only a reader who came from the playground itself steps back', () => {
+test('without it, only a reader who came from that page itself steps back', () => {
   assert.match(shortcut, /document\.referrer/, 'where this document was opened from is the whole condition');
   assert.match(shortcut, /bare\(new URL\(document\.referrer\)\) === bare\(new URL\(href, location\.href\)\)/,
     'the whole page - a sample page lives under the same path and is a different page');


### PR DESCRIPTION
Follow-up to #270. Once the Playground item stepped back, the same was reported for the front door: its Try it out now example is a playground in a frame, and Home loaded fresh every time. Both true, and for one reason. An item in the bar is a link, a link makes a new document, and a new playground boots the whole runtime and runs the app from the top.

## What changes

- **One rule for the four items** instead of a special case for one. When the page an item opens is still in this tab's history, the click traverses to it there: `entryOf()`'s nearest same-origin, same-path, same-query entry, either direction, with the referrer-and-history-length case as the fallback. The selector is `.bar-nav a[href]`; the item for the page the reader is on (Documentation on every page of the manual) is left to the browser, and a link that opens elsewhere is left alone.
- **A page handed back alive spends its scroll record.** The back/forward cache restores the page where the reader left it, offset and all, so the record a `data-back` link wrote on the way out is taken on `pageshow`; left there, the next arrival within its half minute would have inherited it.
- The same rule lands in abap2UI5/playground#86 for the catalogue and the sample pages.

## Tests

`test/playground-back.test.mjs` is `test/bar-back.test.mjs` now. It keeps the eleven `entryOf` cases and reads the click for the one selector, the guard for the current page, the spent record, the fallback, the modifier keys and the way out.

Verified locally: `npm test` (170 pass) and `site.js` bundled with esbuild the way `build-site.mjs` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY)_