### PR TITLE
A page built again after a step back says why, in the console

### DIFF
--- a/scripts/site-js/site.js
+++ b/scripts/site-js/site.js
@@ -161,6 +161,18 @@ document.addEventListener('click', (e) => {
     } catch { return false; }
   };
   addEventListener('pageshow', (e) => { if (e.persisted) takeHandoff(); });
+  /* And when THIS page arrived by Back or Forward - a bar item on one of the
+     other three sites stepping back to it, or the browser's own button - and
+     was built again rather than handed back, the one place the browser says
+     why is notRestoredReasons on the arrival. The only console line on this
+     site, for the same reason the playground has one: nothing a reader can do
+     about it, nothing on the page to say it in, and the person who needs it
+     is reading the console anyway. On the front door it is the running
+     example that was lost; on a chapter, only the offset and a Run panel. */
+  const arrival = performance.getEntriesByType?.('navigation')?.[0];
+  if (arrival?.type === 'back_forward' && arrival.notRestoredReasons) {
+    console.info('docs: rebuilt rather than restored from the back/forward cache', arrival.notRestoredReasons);
+  }
   document.addEventListener('click', (e) => {
     const a = e.target.closest?.('.bar-nav a[href]');
     if (!a || e.defaultPrevented) return;

--- a/test/bar-back.test.mjs
+++ b/test/bar-back.test.mjs
@@ -122,6 +122,14 @@ test('the item for the page the reader is on is left to the browser', () => {
     'a link that opens elsewhere has nothing to go back to');
 });
 
+test('a page built again after a step back says why, in the console', () => {
+  assert.match(shortcut, /arrival\?\.type === 'back_forward' && arrival\.notRestoredReasons/,
+    'only an arrival by Back or Forward that the browser did not restore has reasons to print');
+  assert.match(shortcut, /console\.info\('docs: rebuilt rather than restored from the back\/forward cache', arrival\.notRestoredReasons\)/,
+    'the reasons themselves, which is the one place the browser says what blocked the cache');
+  assert.equal((SRC.match(/console\./g) || []).length, 1, 'and it is the only console line on the site');
+});
+
 test('a page handed back alive spends the scroll record written on the way out', () => {
   assert.match(shortcut, /addEventListener\('pageshow', \(e\) => \{ if \(e\.persisted\) takeHandoff\(\); \}\)/,
     'a restored page is where the reader left it; the record must not reach the next arrival');


### PR DESCRIPTION
Follow-up to #273. The bar steps back to a page that is still behind the reader so that the browser can hand it back alive, on the front door with the example under Try it out now still running. Whether it does is the browser's call, and when it declined, nothing on this site said so: the playground prints `notRestoredReasons` on such an arrival (abap2UI5/playground#85), the manual did not.

## What changes

- `scripts/site-js/site.js`: an arrival by Back or Forward that was built rather than restored prints the browser's own `notRestoredReasons` to the console, in the same words as the playground. It is the only console line on the site, for the same reason the playground has one: nothing a reader can do about it, nothing on the page to say it in, and the person who needs it is reading the console anyway.
- `test/bar-back.test.mjs` pins the line, its condition, and that it stays the only console call in `site.js`.

Verified locally: `npm test` (171 pass) and `site.js` bundled with esbuild the way `build-site.mjs` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY)_