### PR TITLE
The sample-page test reads the playground's shape off the file every checkout has

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,6 +87,7 @@ jobs:
           fetch-depth: 1
           sparse-checkout: |
             src/catalogue/catalogue.css
+            src/catalogue/page-entry.mjs
             src/shell/site-memory.mjs
             tools/sample-pages.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,7 @@ jobs:
           fetch-depth: 1
           sparse-checkout: |
             src/catalogue/catalogue.css
+            src/catalogue/page-entry.mjs
             src/shell/site-memory.mjs
             tools/sample-pages.mjs
           sparse-checkout-cone-mode: false

--- a/test/site-memory-keys.test.mjs
+++ b/test/site-memory-keys.test.mjs
@@ -60,14 +60,23 @@ test('the playground spells them the same way', { skip: playground ? false : 'no
  * so the keys are the one file's. Both shapes are accepted here, because the
  * checkout CI clones is the playground's main and the two repositories do not
  * land on the same day. What must hold either way: a sample page reaches the
- * same five names, through the module or through the copy. */
+ * same five names, through the module or through the copy.
+ *
+ * WHICH SHAPE IS READ OFF sample-pages.mjs, the one file every checkout has -
+ * not off whether page-entry.mjs is there. CI clones the playground SPARSELY
+ * (check.yml, deploy.yml: three files), and the day the playground switched
+ * shapes the entry file was simply not in the checkout: this test took that
+ * for the old shape, looked for the inline keys, and failed the deploy of a
+ * commit that had nothing to do with it. Now a page that loads samples/page.mjs
+ * says the shape, and a checkout without the entry file is named as such. */
 test('a sample page writes to the same places', { skip: playground ? false : 'no playground checkout' }, () => {
   const entry = path.join(playground, 'src', 'catalogue', 'page-entry.mjs');
   const pages = fs.readFileSync(path.join(playground, 'tools', 'sample-pages.mjs'), 'utf8');
-  if (fs.existsSync(entry)) {
+  if (pages.includes('samples/page.mjs')) {
+    assert.ok(fs.existsSync(entry),
+      'the sample pages load samples/page.mjs, so the checkout has to carry src/catalogue/page-entry.mjs - the sparse checkout in check.yml and deploy.yml names it');
     assert.match(fs.readFileSync(entry, 'utf8'), /from "\.\.\/shell\/site-memory\.mjs"/,
       'the sample pages import the memory rather than copying it');
-    assert.ok(pages.includes('samples/page.mjs'), 'a per-sample page loads samples/page.mjs');
     return;
   }
   for (const key of ['abap2ui5-playground:last-', 'abap2ui5-playground:scroll', 'abap2ui5-playground:returning'])


### PR DESCRIPTION
## What changes

Deploy run 1558 went red on `main` right after #275, in `test/site-memory-keys.test.mjs`, and the cause is the playground's merge of the same hour rather than anything in #275: the sample pages' memory moved from an inline copy in `tools/sample-pages.mjs` to `samples/page.mjs` (abap2UI5/playground#87). The test accepted both shapes, but told them apart by whether `src/catalogue/page-entry.mjs` was in the checkout - and CI clones the playground sparsely, three files, that not among them. So the new shape read as the old one, the inline keys were looked for in a file that no longer carries them, and the deploy failed.

- The shape is now read off `tools/sample-pages.mjs`, the one file every checkout has: a page that loads `samples/page.mjs` is the new shape, and the entry file is then required and its import checked. A checkout that lacks the file fails saying exactly that.
- `check.yml` and `deploy.yml` name `src/catalogue/page-entry.mjs` in their sparse checkout, so CI reads the import as the test means to.

## Verified

- The failure reproduced locally against a three-file sparse copy of playground `main`; with the fix it passes against the four-file sparse copy, a full checkout, and the playground as it was before its switch.
- `npm test`: 220 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY)_