### PR TITLE
What the developer gets on the manager's front door, and a calculator that keeps its punchline until asked

### DIFF
--- a/docs/.vitepress/theme/cost-calculator.js
+++ b/docs/.vitepress/theme/cost-calculator.js
@@ -2,8 +2,9 @@
  * The cost calculator, once it is in a browser.
  *
  * The page carries everything: sliders with their stops, a readout beside
- * each, choices made with checkboxes and radio buttons, a button, and - hidden until the
- * button is pressed - a sheet whose lines echo the readings, and the total.
+ * each, choices made with checkboxes and radio buttons, a button, and - hidden
+ * until the button is pressed - a sheet whose lines echo the readings, the
+ * total, and the words under it.
  * All of it is written into the HTML with its answer already on it. What
  * this adds is the readout following its slider, the echoes following the
  * readout, every amount rewritten in the currency chosen, and the button.
@@ -57,11 +58,14 @@ export function syncCostCalculator(root = document) {
 function calculate(button) {
   const calc = button.closest(CALCULATOR);
   const inputs = calc?.querySelector('.cost-inputs');
-  const result = calc?.querySelector('[data-result]');
-  if (!inputs || !result) return;
+  /* What the button hands out: the sheet inside the calculator, and the words
+     under it - the formula, and the one line that is not zero - which are
+     markdown outside it and carry the same mark. */
+  const results = calc ? [...calc.ownerDocument.querySelectorAll('[data-result]')] : [];
+  if (!inputs || !results.length) return;
   const controls = inputs.querySelectorAll('input, select');
   if (calc.dataset.state === 'calculated') {
-    result.hidden = true;
+    for (const result of results) result.hidden = true;
     delete inputs.dataset.locked;
     for (const control of controls) control.disabled = false;
     delete calc.dataset.state;
@@ -74,11 +78,11 @@ function calculate(button) {
   button.disabled = true;
   button.textContent = 'Calculating\u2026';
   setTimeout(() => {
-    result.hidden = false;
+    for (const result of results) result.hidden = false;
     calc.dataset.state = 'calculated';
     button.disabled = false;
     button.textContent = button.dataset.again;
-    result.scrollIntoView?.({ block: 'nearest' });
+    results[0].scrollIntoView?.({ block: 'nearest' });
   }, 700);
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,13 +47,13 @@ description: One ABAP class is one UI5 app - no JavaScript, no OData, no fronten
 # behind this, what happens when nobody is, how an app is governed, what it is
 # not for. So the enterprise card says lifecycle (transports, ATC, ABAP Unit),
 # exit path (a handful of classes and one table, nothing to migrate away
-# from), versioned releases with every change listed, support as it is (the community's,
-# partners for training, no vendor SLA - and nothing that ends with a
-# contract) and who runs it in production, by name and linked. The
-# integration card says what comes with UI5 itself, that a system without
-# internet access is fine, and what this is NOT for - offline, real-time
-# collaboration, a visual designer - with the three comparisons linked. An
-# evaluator who finds the limits on page three trusts nothing on page one.
+# from), versioned releases with every change listed, and support as it is
+# (the community's, no vendor SLA - and nothing that ends with a contract).
+# The integration card says what comes with UI5 itself, 1.71 to 2.x, and
+# that a system without internet access is fine. References by name and a
+# list of what this is NOT for were tried here and taken out again by the
+# maintainer: the limits stay on the About page, the references on Who Uses
+# abap2UI5.
 #
 # THIS PAGE IS FOR THE MANAGER. A developer has usually found the project by
 # another path - a talk, a sample, the playground - and the person this page

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,17 @@ description: One ABAP class is one UI5 app - no JavaScript, no OData, no fronten
 # collaboration, a visual designer - with the three comparisons linked. An
 # evaluator who finds the limits on page three trusts nothing on page one.
 #
+# THIS PAGE IS FOR THE MANAGER. A developer has usually found the project by
+# another path - a talk, a sample, the playground - and the person this page
+# has to convince is the one who decides whether it may be used. So nothing
+# here is arranged for a developer's reading order: the cards come before the
+# code. What a developer gets anyway, because it costs the manager nothing,
+# is two sentences in front of the example (what you are looking at, how to
+# play with it), one way out behind it (the tutorial, through to transport
+# and unit tests), the UI5 releases in the integration card, and a Tooling
+# card that names the daily tools - ADT, the ABAP debugger, ABAP Unit -
+# before the extras.
+#
 # THE EXAMPLE IS A REAL APP, not a greeting: the tutorial's finished class - a
 # table of invoices with an edit dialog, a date picker, save and a toast - so
 # that the first thing that runs on this page looks like the thing a reader
@@ -114,7 +125,7 @@ hero:
 features:
   - title: Documentation
     icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" d="M12 6.9C10.4 5.5 8.2 4.8 5.4 4.8H2.4v12.6h3c2.8 0 5 .7 6.6 2.1 1.6-1.4 3.8-2.1 6.6-2.1h3V4.8h-3c-2.8 0-5 .7-6.6 2.1z"/><path fill="none" stroke="currentColor" stroke-width="1.7" d="M12 6.9v12.6"/></svg>
-    details: Tutorial, cookbook and reference — everything from your first app to production.
+    details: A twelve-step tutorial, a cookbook and the client API reference — from your first class to production.
     link: /get_started/about
   - title: Samples
     icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.6" y="4.2" width="18.8" height="15.6" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M2.6 9.1h18.8M8.2 9.1v10.7"/></svg>
@@ -155,9 +166,9 @@ that would otherwise need a frontend project of its own.
 It runs where your users already are: a browser tab, a
 [Fiori launchpad](/configuration/launchpad) tile, [SAP Build Work
 Zone](/configuration/btp) or [SAP Mobile Start](/configuration/mobile_start).
-Because it is UI5 itself, Fiori design, themes, accessibility and translation
-come with it — and rendering with the UI5 your system ships, it works without
-internet access.
+Because it is UI5 itself — 1.71 to 2.x — Fiori design, themes, accessibility
+and translation come with it, and rendering with the UI5 your system ships, it
+works without internet access.
 
 → *More on [Integration](/get_started/about#where-it-fits)*
 
@@ -183,6 +194,12 @@ have is the one you keep.
 → *Run your own numbers through the [Cost Calculator](/resources/cost_calculator)*
 
 ## Try it out now
+
+This is the whole app: one ABAP class on the left, running on the right. Press
+the pencil on a row, change the date, save — every click is one roundtrip into
+the class, which builds the view and hands it back with the data
+([how it works](/get_started/about#how-it-works)). Change a line of the code
+and run it again.
 
 ```abap edit
 CLASS zcl_app_invoices DEFINITION PUBLIC.
@@ -324,6 +341,8 @@ CLASS zcl_app_invoices IMPLEMENTATION.
 ENDCLASS.
 ```
 
+→ *The [Tutorial](/tutorials/walkthrough/) builds this app in twelve steps, through to transport and unit tests*
+
 ## Around the project
 
 <div class="a2ui5-out">
@@ -337,7 +356,7 @@ ENDCLASS.
   </a>
   <a class="a2ui5-out-card is-inside" href="/docs/advanced/mcp_server">
     <span class="a2ui5-out-title">Tooling</span>
-    <span class="a2ui5-out-details">A VS Code extension, an MCP server for AI assistants, and an app template to start from.</span>
+    <span class="a2ui5-out-details">Write it in ADT, debug it in the ABAP debugger, test it with ABAP Unit. On top: a VS Code extension that runs the app on F9, an MCP server for AI assistants, and an app template to start from.</span>
   </a>
 
   <a class="a2ui5-out-card" href="https://github.com/abap2UI5/abap2UI5/" target="_blank" rel="noreferrer">

--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -40,8 +40,12 @@ Every SAP project has a sheet like this one. Set the sliders to your landscape, 
 </div>
 </div>
 
+<div class="cost-after" data-result hidden>
+
 The formula is short: every line is zero, and a sum of zeros is zero. Slide the users to 250,000 and the systems to 50 and calculate again - the sheet does not move, because nothing is counting. abap2UI5 is [MIT licensed](/resources/license), commercial use included, and an app built with it is a standard UI5 app served by the ABAP stack you already run.
 
 ## The one line that is not zero
 
 abap2UI5 is open-source work. The people who build and maintain it do so in their free time, and the zero above is what they give away. If this page just took a budget line off your project, consider giving a little of it back: [sponsor the contributors](/resources/sponsor), and the open-source projects abap2UI5 is built on.
+
+</div>

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -117,6 +117,13 @@ test('the sheet waits for the button', () => {
   assert.match(PAGE, /<div class="cost-result" data-result hidden>/, 'the sheet is hidden until Calculate is pressed');
   assert.ok(PAGE.indexOf('<div class="cost-inputs">') < PAGE.indexOf('data-calculate='), 'the inputs come first');
   assert.ok(PAGE.indexOf('data-calculate=') < PAGE.indexOf('data-result'), 'then the button, then the sheet');
+  /* The words under the calculator wait with it: the formula and the one line
+     that is not zero are markdown inside a wrapper that carries the same mark,
+     with blank lines around the markdown so the renderer still renders it. */
+  const after = PAGE.indexOf('<div class="cost-after" data-result hidden>\n\n');
+  assert.ok(after > PAGE.lastIndexOf('<div class="cost-result"'), 'the words under the sheet wait for the button too');
+  assert.ok(PAGE.trimEnd().endsWith('\n\n</div>'), 'and the wrapper closes after the last of them');
+  assert.ok(PAGE.indexOf('\n## The one line', after) > after, 'the section is markdown inside it, heading and all');
 });
 
 test('the front door\'s cost card leads here, and the page ends at the sponsors', () => {


### PR DESCRIPTION
## What changes

**The front door stays the manager's, and the developer gets what costs the manager nothing.** A developer has usually found the project by another path; the person this page has to convince decides whether it may be used. So nothing is rearranged for a developer's reading order, and only what costs the manager nothing is added: two sentences in front of the example (what you are looking at, how to play with it, the roundtrip in one clause, How It Works linked), one way out behind it (the tutorial, through to transport and unit tests), the UI5 releases 1.71 to 2.x in the integration card, a Documentation tile that names the tutorial, the cookbook and the API reference, and a Tooling card that starts with ADT, the ABAP debugger and ABAP Unit before the extras. The header comment says who the page is for, so the next reading does not rearrange it.

**The words under the calculator wait for the button too.** The formula and the one line that is not zero stood on the page before Calculate was pressed, giving the answer away under a sheet that was still hidden. They sit in a wrapper with the same `data-result` mark now, markdown inside it with blank lines around so the renderer still renders heading and anchor, and the button shows and hides everything with that mark.

**The page's own comment follows the maintainer's cut.** Main took the references by name and the list of what this is not for back out of the front door (7817c22); the comment at the top of the page now describes the page as it is and says where the two live instead.

Rebased onto that main commit; its cuts are kept as they are.

## Verified

- `npm test`: 223 pass.
- The site build against a built playground frame: every internal link and anchor live, the How It Works anchor and the tutorial link included; the VitePress build renders the hidden wrapper with the heading inside it; `check:cross-site` and `check:playground` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY)_