### PR TITLE
What a machine reads on every page, and a calculator that fits a phone

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2761,9 +2761,31 @@
 .cost-calculate:hover { filter: brightness(1.08); }
 .cost-calculate:disabled { cursor: progress; opacity: .7; }
 .cost-inputs[data-locked] .cost-row { opacity: .5; }
+/* ON A PHONE A ROW IS TWO LINES: the label with its readout on the first and
+   the slider the whole width of the second - the shape a phone's own settings
+   give a slider - where the readout used to take a third line of its own. A
+   choice's boxes go under their label rather than beside it: nine systems in
+   the column beside "Your systems" left the label wrapped to a word a line and
+   the boxes to a two-word column. The button is the row's whole width, and
+   the height of a finger. */
 @media (max-width: 620px) {
-  .cost-row { grid-template-columns: 1fr auto; }
-  .cost-row input[type="range"] { grid-column: 1 / -1; }
+  .cost-row { grid-template-columns: minmax(0, 1fr) auto; }
+  .cost-row output { grid-column: 2; grid-row: 1; }
+  .cost-row input[type="range"] { grid-column: 1 / -1; grid-row: 2; }
+  .cost-row .cost-choices { grid-column: 1 / -1; }
+  .cost-calculate { width: 100%; line-height: 44px; }
+}
+/* A thumb rather than a pointer: each box the size of a target and the word
+   beside it a row the height of one, the slider a band a finger can land on,
+   and the currency list a size iOS does not zoom the page in on - a control
+   set under 16px is one it magnifies on focus and leaves magnified. Nothing
+   here moves under a mouse. */
+@media (pointer: coarse) {
+  .cost-row .cost-choices label { min-height: 32px; }
+  .cost-row .cost-choices input[type="radio"],
+  .cost-row .cost-choices input[type="checkbox"] { width: 18px; height: 18px; }
+  .cost-row input[type="range"] { height: 32px; }
+  .cost-row select { font-size: 16px; }
 }
 .cost-sheet { margin: 20px 0 0; padding: 0 16px; border: 1px solid var(--line); border-radius: 8px; background: var(--bg-sunken); }
 .cost-line {

--- a/docs/advanced/downporting.md
+++ b/docs/advanced/downporting.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: abap2UI5 below ABAP 7.50 - the downported branch supports NetWeaver 7.02 and later, generated from main automatically; how it works and why the framework is downportable.
 ---
 # Downporting
 

--- a/docs/advanced/insights/index.md
+++ b/docs/advanced/insights/index.md
@@ -1,3 +1,6 @@
+---
+description: The Insights series - the ideas behind abap2UI5 in pieces one coffee long, from why it exists and how it works to a working day and where it belongs.
+---
 # Technical Insights
 
 The knowledge behind abap2UI5, cut into pieces that each fit one coffee. Every

--- a/docs/advanced/linter.md
+++ b/docs/advanced/linter.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: The abap2UI5 linter reconstructs the UI5 view out of the ABAP that builds it and reports what UI5 does not have, without an SAP system - findings, rules, the pipeline, the library.
 ---
 # abap2UI5 linter
 

--- a/docs/advanced/mcp_server.md
+++ b/docs/advanced/mcp_server.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: The abap2UI5 MCP server - the tools an AI coding agent gets to boot an app headless, read the errors and a screenshot, and search the samples; setup and the intended loop.
 ---
 # MCP Server
 

--- a/docs/advanced/vscode.md
+++ b/docs/advanced/vscode.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: The abap2UI5 VS Code extension - run the app from the editor on F9, check views while you type, write views with the linter's help, in VS Code and vscode.dev.
 ---
 # VS Code Extension
 

--- a/docs/configuration/authorization.md
+++ b/docs/configuration/authorization.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Authorization for abap2UI5 apps at the service level or in the app class, with the authorization objects and checks you already use in ABAP.
 ---
 # Authorization
 

--- a/docs/configuration/btp.md
+++ b/docs/configuration/btp.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Run abap2UI5 apps in SAP Build Work Zone and other BTP services through the connector app, with an on-premise or cloud ABAP backend.
 ---
 # BTP Build Work Zone
 

--- a/docs/configuration/launchpad.md
+++ b/docs/configuration/launchpad.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Embed abap2UI5 apps as tiles in the SAP Fiori Launchpad on S/4HANA on-premise or private cloud - installation, target mapping, launchpad features, KPIs and troubleshooting.
 ---
 # Fiori Launchpad
 

--- a/docs/configuration/mobile_start.md
+++ b/docs/configuration/mobile_start.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: abap2UI5 apps as tiles in SAP Mobile Start on iOS and Android, mirrored from the Fiori Launchpad with no extra development.
 ---
 # Mobile Start
 

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: How abap2UI5 keeps data on the server - one HTTP endpoint, SAP authentication and authorization, the Content-Security-Policy, response headers and CSRF.
 ---
 # Security
 abap2UI5 is a backend-centric framework. All logic and business data stay on the server; the frontend gets only the data it needs to render the view.

--- a/docs/cookbook/event_navigation/life_cycle.md
+++ b/docs/cookbook/event_navigation/life_cycle.md
@@ -3,6 +3,7 @@ outline: [2, 4]
 samples:
   - z2ui5_cl_smp_app_495
   - z2ui5_cl_smp_app_004
+description: The abap2UI5 app life cycle - every request enters main( ), and check_on_init, check_on_navigated and check_on_event tell you which case it is, pitfalls included.
 ---
 # Life Cycle
 

--- a/docs/cookbook/expert_more/statefulness.md
+++ b/docs/cookbook/expert_more/statefulness.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: abap2UI5 apps run stateless by default, one fresh ABAP session per roundtrip; stateful sessions exist for the few cases that need them, with their trade-offs.
 ---
 # Statefulness
 

--- a/docs/cookbook/model/binding.md
+++ b/docs/cookbook/model/binding.md
@@ -6,6 +6,7 @@ samples:
   - z2ui5_cl_smp_app_166
   - z2ui5_cl_smp_app_144
   - z2ui5_cl_smp_app_061
+description: Data binding in abap2UI5 - client->_bind( ) shares ABAP variables with the UI5 view, for displaying and editing data, binding to structures, and the data-type mapping.
 ---
 # Binding
 

--- a/docs/cookbook/model/tables.md
+++ b/docs/cookbook/model/tables.md
@@ -11,6 +11,7 @@ samples:
   - z2ui5_cl_smp_app_160
   - z2ui5_cl_smp_app_143
   - z2ui5_cl_smp_app_459
+description: Tables in abap2UI5 - binding an internal table to a UI5 table, editable cells, nested structures, and the working samples for each.
 ---
 # Tables
 

--- a/docs/cookbook/popup_popover/popup.md
+++ b/docs/cookbook/popup_popover/popup.md
@@ -6,6 +6,7 @@ samples:
   - z2ui5_cl_smp_app_161
   - z2ui5_cl_smp_app_170
   - z2ui5_cl_smp_app_470
+description: Popups in abap2UI5 - a dialog built as a UI5 fragment in ABAP, the flow logic behind opening and closing it, and popups as separate apps.
 ---
 # Popup
 

--- a/docs/cookbook/view/definition.md
+++ b/docs/cookbook/view/definition.md
@@ -4,6 +4,7 @@ samples:
   - z2ui5_cl_smp_app_493
   - z2ui5_cl_smp_app_050
   - z2ui5_cl_smp_app_255
+description: How an abap2UI5 view is defined - a standard UI5 XML view sent from ABAP, built with the view builder control by control, and where to look for controls.
 ---
 # Definition
 

--- a/docs/get_started/ai.md
+++ b/docs/get_started/ai.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Developing abap2UI5 apps with an AI assistant - one paragraph to paste into a prompt, and the linter and MCP server that let an agent check its own work without a system.
 ---
 # Developing with AI
 

--- a/docs/get_started/hello_world.md
+++ b/docs/get_started/hello_world.md
@@ -2,6 +2,7 @@
 outline: [2, 4]
 samples:
   - z2ui5_cl_smp_app_493
+description: Your first abap2UI5 app - one ABAP class with a view, two-way data binding and an event, explained line by line.
 ---
 # Hello World
 

--- a/docs/get_started/next.md
+++ b/docs/get_started/next.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Where to go after your first abap2UI5 app - the sample apps, the tooling, development and configuration topics, add-ons and real-world use.
 ---
 # What's Next?
 

--- a/docs/get_started/quickstart.md
+++ b/docs/get_started/quickstart.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Install abap2UI5 with abapGit and start your first app, or try it first in the browser playground and the live demo with no system at all.
 ---
 # Quickstart
 

--- a/docs/get_started/tooling.md
+++ b/docs/get_started/tooling.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: The optional tooling around abap2UI5 - the app template, checking a view without a system, running the app from the editor, and where the samples live.
 ---
 # Tooling
 

--- a/docs/resources/addons.md
+++ b/docs/resources/addons.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: The optional add-ons around abap2UI5 - popups, HTTP and RFC connectors, a lock manager, table maintenance, launchpad KPIs - and the open-source projects it builds on.
 ---
 # Add-ons
 

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: The abap2UI5 release notes - every release with its changes, newest first.
 ---
 # Release Notes
 

--- a/docs/resources/contribution.md
+++ b/docs/resources/contribution.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: How to contribute to abap2UI5 - code, samples and documentation, turning answers into pages, and where to ask for help.
 ---
 # Contribution
 

--- a/docs/resources/deprecations.md
+++ b/docs/resources/deprecations.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: What in abap2UI5 has a successor - each deprecated call with what to write instead, old and new code side by side.
 ---
 # Deprecations
 

--- a/docs/resources/license.md
+++ b/docs/resources/license.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: abap2UI5 is MIT licensed, free for commercial use; the apps built with it are standard UI5 freestyle apps, licensed like any other UI5 app in your organization.
 ---
 # License
 

--- a/docs/resources/sponsor.md
+++ b/docs/resources/sponsor.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Sponsor abap2UI5 and the open-source projects it is built on; the framework is maintained by volunteers in their free time.
 ---
 # Sponsor
 

--- a/docs/resources/support.md
+++ b/docs/resources/support.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Where to get help with abap2UI5 - community support on GitHub issues and Slack, and the options for commercial support.
 ---
 # Support
 

--- a/docs/resources/who_uses.md
+++ b/docs/resources/who_uses.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 4]
+description: Companies, workshops and integrations that use abap2UI5, with the system release and the use case, and how to add your own.
 ---
 # Who Uses abap2UI5?
 

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -428,6 +428,10 @@ const meta = ({ page, title, description, kind = 'article', isHome = false }) =>
   const url = canonical(page);
   return [
     ['link', { rel: 'canonical', href: url }],
+    /* Not a standard a crawler is obliged to read - robots.txt is, and it can
+       only live at the origin's root, which is not this deployment's to write
+       - but a hint some of them do read, and it costs one line. */
+    ['link', { rel: 'sitemap', type: 'application/xml', href: `${SITE_URL}/sitemap.xml` }],
     /* THE SAME PAGE AS MARKDOWN. `generate-llms.mjs` publishes one per page
        under docs/public and llms.txt tells a reader to "drop the .md for the
        rendered version" - but nothing on the page itself said the twin
@@ -508,12 +512,19 @@ const linkedData = ({ page, title, description, url, isHome }) => {
         applicationSubCategory: 'SAP ABAP UI framework',
         operatingSystem: 'SAP NetWeaver AS ABAP 7.02 and up, S/4HANA, ABAP Cloud',
         softwareVersion: RELEASE,
+        releaseNotes: `${SITE_URL}/resources/changelog.html`,
         programmingLanguage: 'ABAP',
+        runtimePlatform: 'SAP NetWeaver AS ABAP',
+        softwareRequirements: 'SAP NetWeaver AS ABAP 7.02 or later, or ABAP Cloud; SAPUI5 or OpenUI5 1.71 or later',
         codeRepository: 'https://github.com/abap2UI5/abap2UI5',
+        downloadUrl: 'https://github.com/abap2UI5/abap2UI5',
+        softwareHelp: { '@type': 'CreativeWork', name: 'abap2UI5 documentation', url: `${SITE_URL}/` },
         license: `${SITE_URL}/resources/license.html`,
         isAccessibleForFree: true,
         offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-        author: { '@type': 'Organization', name: 'abap2UI5', url: 'https://github.com/abap2UI5' },
+        keywords: 'ABAP, SAPUI5, OpenUI5, SAP Fiori, ABAP Cloud, S/4HANA, abapGit, UI5 apps in ABAP',
+        sameAs: ['https://github.com/abap2UI5/abap2UI5', 'https://www.linkedin.com/company/abap2ui5/'],
+        author: { '@type': 'Organization', name: 'abap2UI5', url: 'https://github.com/abap2UI5', sameAs: ['https://github.com/abap2UI5', 'https://www.linkedin.com/company/abap2ui5/'] },
       },
     ]);
     return `<script type="application/ld+json">${json.replace(/</g, '\\u003c')}</script>`;
@@ -526,8 +537,14 @@ const linkedData = ({ page, title, description, url, isHome }) => {
       headline: title.replace(/ \| abap2UI5$/, ''),
       description,
       url,
+      mainEntityOfPage: url,
       inLanguage: 'en',
+      /* The date the footer prints, in the vocabulary a machine reads: the
+         last commit that touched this page's markdown. */
+      dateModified: lastTouched(page),
+      about: { '@type': 'SoftwareApplication', name: 'abap2UI5', url: `${SITE_URL}/` },
       isPartOf: { '@type': 'WebSite', name: 'abap2UI5', url: `${SITE_URL}/` },
+      author: { '@type': 'Organization', name: 'abap2UI5', url: 'https://github.com/abap2UI5' },
       publisher: { '@type': 'Organization', name: 'abap2UI5', url: 'https://github.com/abap2UI5' },
     },
     {

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -49,6 +49,7 @@ import {
   sidebarPages, markdownFiles, mdSuffix, linkOf, fileOf,
   stripFrontmatter, describe, title,
 } from './lib/pages.mjs';
+import { declaredRelease } from './lib/release.mjs';
 
 const PUBLIC = path.join(DOCS, 'public');
 
@@ -126,6 +127,26 @@ const index = [
   'markdown so a machine can read the same thing. Every link below is the raw',
   'source of a page; drop the `.md` for the rendered version.',
   '',
+  /* The answers a question needs no page for, in one place: what a model is
+   * asked first - is it free, what does it run on, how is it installed - and
+   * what it would otherwise have to assemble from six pages, with the risk of
+   * assembling it wrong. Every line is a fact a page states; the release
+   * number is the one the bar prints, held by check:version. */
+  'The facts, for a question that needs no page:',
+  '',
+  `- Latest release: ${declaredRelease(ROOT)} - every release lists its changes in the [release notes](${SITE}/resources/changelog.md)`,
+  '- License: MIT, commercial use included - no license key, no per-user fee, no subscription, no BTP required',
+  '- Runs on: SAP NetWeaver AS ABAP 7.02 and later, S/4HANA on-premise and private cloud, BTP ABAP Environment and',
+  '  S/4HANA Public Cloud (ABAP Cloud, released APIs only); the frontend is SAPUI5 or OpenUI5, 1.71 to 2.x, from a CDN',
+  '  or the UI5 the system ships - a system without internet access is fine',
+  '- Install: one abapGit pull of https://github.com/abap2UI5/abap2UI5 (the `702` branch below 7.50), then one HTTP service',
+  '- An app: one ABAP class implementing `z2ui5_if_app`; `main( )` runs on every roundtrip, the view is UI5 XML built in',
+  '  ABAP, data is bound both ways, and the app is stateless like any other UI5 app',
+  '- Not for: offline apps or real-time collaboration; there is no visual designer',
+  '- Support: the community, on GitHub issues and Slack; no vendor and no SLA',
+  '- Tooling: a linter (`@abap2ui5/linter` on npm), an MCP server, a VS Code extension, and a browser playground',
+  '  at https://abap2ui5.github.io/playground/ that runs an app with no SAP system',
+  '',
   '- [llms-full.txt](' + SITE + '/llms-full.txt): the whole documentation as one',
   '  document, if you would rather fetch it once than page by page',
   '',
@@ -143,6 +164,9 @@ const index = [
      interface offer?", and the answer to both is published - 771 sample
      classes with an index of their own, and the interface generated from the
      source - and neither was named here. Both are one fetch. */
+  '- [the playground](https://abap2ui5.github.io/playground/llms.txt): how to open a class in the',
+  '  browser by URL, how to embed a running example in a page of your own, and',
+  '  where the samples are as data',
   '- [the sample catalogue](https://abap2ui5.github.io/playground/samples/llms.txt): 771',
   '  complete apps from three repositories, each with a page of its own and the',
   '  class in full. That file describes `apps.json`, the whole index as data:',

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -133,6 +133,14 @@
   content: ""; width: 11px; height: 9px; background: currentColor;
   clip-path: polygon(0 0, 100% 0, 100% 1.5px, 0 1.5px, 0 3.75px, 100% 3.75px, 100% 5.25px, 0 5.25px, 0 7.5px, 100% 7.5px, 100% 9px, 0 9px);
 }
+/* 25px of button under a thumb, and it is the one that opens the whole menu
+   on a phone: the height of a target there, the words still centred in it.
+   The crumbs beside it are 12px of text; padding gives each one a row to land
+   on. Neither moves under a mouse. */
+@media (pointer: coarse) {
+  .side-button { min-height: 36px; }
+  .crumbs a { display: inline-block; padding: 4px 0; }
+}
 
 /* From 1680 up the margin holds it, so it stands there instead: no button, no
    scrim, no drawer - the same nav, placed. */
@@ -1123,9 +1131,31 @@ html { scrollbar-gutter: stable; }
 .cost-calculate:hover { filter: brightness(1.08); }
 .cost-calculate:disabled { cursor: progress; opacity: .7; }
 .cost-inputs[data-locked] .cost-row { opacity: .5; }
+/* ON A PHONE A ROW IS TWO LINES: the label with its readout on the first and
+   the slider the whole width of the second - the shape a phone's own settings
+   give a slider - where the readout used to take a third line of its own. A
+   choice's boxes go under their label rather than beside it: nine systems in
+   the column beside "Your systems" left the label wrapped to a word a line and
+   the boxes to a two-word column. The button is the row's whole width, and
+   the height of a finger. */
 @media (max-width: 620px) {
-  .cost-row { grid-template-columns: 1fr auto; }
-  .cost-row input[type="range"] { grid-column: 1 / -1; }
+  .cost-row { grid-template-columns: minmax(0, 1fr) auto; }
+  .cost-row output { grid-column: 2; grid-row: 1; }
+  .cost-row input[type="range"] { grid-column: 1 / -1; grid-row: 2; }
+  .cost-row .cost-choices { grid-column: 1 / -1; }
+  .cost-calculate { width: 100%; line-height: 44px; }
+}
+/* A thumb rather than a pointer: each box the size of a target and the word
+   beside it a row the height of one, the slider a band a finger can land on,
+   and the currency list a size iOS does not zoom the page in on - a control
+   set under 16px is one it magnifies on focus and leaves magnified. Nothing
+   here moves under a mouse. */
+@media (pointer: coarse) {
+  .cost-row .cost-choices label { min-height: 32px; }
+  .cost-row .cost-choices input[type="radio"],
+  .cost-row .cost-choices input[type="checkbox"] { width: 18px; height: 18px; }
+  .cost-row input[type="range"] { height: 32px; }
+  .cost-row select { font-size: 16px; }
 }
 .cost-sheet { margin: 20px 0 0; padding: 0 16px; border: 1px solid var(--line); border-radius: 8px; background: var(--bg-sunken); }
 .cost-line {

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -132,3 +132,34 @@ test('the front door\'s cost card leads here, and the page ends at the sponsors'
   assert.match(last, /\]\(\/resources\/sponsor\)/, 'the last section is the one that asks');
   assert.match(last, /open-source/i);
 });
+
+/* The stylesheet is written twice - scripts/site-css/docs.css for the site the
+   build renders, docs/.vitepress/theme/style.css for VitePress's second
+   opinion - and the calculator's rules are the same text in both, from the
+   grid a row is down to the two lines it becomes on a phone. One edited
+   without the other is a page that is right in one build and wrong in the
+   other. */
+test('the two stylesheets carry one calculator, its phone rules included', () => {
+  const block = (file) => {
+    const css = readFileSync(join(ROOT, file), 'utf8');
+    const from = css.indexOf('.cost { margin: 20px 0; }');
+    const to = css.indexOf('.cost-total { grid-template-columns: 1fr; } }', from);
+    assert.ok(from > 0 && to > from, `${file} carries the calculator`);
+    return css.slice(from, to);
+  };
+  const site = block('scripts/site-css/docs.css');
+  assert.equal(block('docs/.vitepress/theme/style.css'), site, 'the theme carries the same calculator');
+  /* On a phone a row is the label with its readout, then the slider across the
+     whole width; a choice's boxes go under their label; the button is the
+     width of the row and the height of a finger. */
+  const phone = site.slice(site.indexOf('@media (max-width: 620px) {'));
+  assert.match(phone, /\.cost-row output \{ grid-column: 2; grid-row: 1; \}/);
+  assert.match(phone, /\.cost-row input\[type="range"\] \{ grid-column: 1 \/ -1; grid-row: 2; \}/);
+  assert.match(phone, /\.cost-row \.cost-choices \{ grid-column: 1 \/ -1; \}/);
+  assert.match(phone, /\.cost-calculate \{ width: 100%; line-height: 44px; \}/);
+  /* Under a thumb the boxes are the size of a target, and the currency list is
+     the one size iOS does not zoom the page in on. */
+  const thumb = site.slice(site.indexOf('@media (pointer: coarse) {'));
+  assert.match(thumb, /input\[type="checkbox"\] \{ width: 18px; height: 18px; \}/);
+  assert.match(thumb, /\.cost-row select \{ font-size: 16px; \}/);
+});


### PR DESCRIPTION
Two commits: what an AI or a search engine reads off the manual, and what the manual looks like on an iPhone.

## What a machine reads

- The home page's `SoftwareApplication` now names its release notes, runtime platform (ABAP 7.02 up, UI5 1.71 to 2.x), software requirements, download (abapGit), help, keywords and `sameAs` links.
- Every chapter carries a `TechArticle` with `dateModified` from the page's last touch, author, what it is about and `mainEntityOfPage`, plus a `BreadcrumbList` — and a `<link rel="sitemap">` hint in the head.
- `llms.txt` opens with a facts block (declared release, license, systems, where the code and the samples are) and points at the playground's own `llms.txt`.
- 29 pages had no `description` — quickstart, hello world, tooling, security, launchpad, BTP, binding, popups, tables, the resources — and a search result or an AI summary showed their first paragraph instead. Each has one now.

Not possible from here: `robots.txt` and a sitemap announcement have to live at the origin root (`abap2ui5.github.io`), which is the organization's own repository.

## On a phone

- The cost calculator: a slider's row is the label with its readout on one line and the slider across the whole width under it, where the readout took a third line; a choice's boxes go under their label instead of beside it, where nine systems left "Your systems" wrapped to a word a line; the button is the row's whole width and 44px tall. Under a thumb the boxes are 18px, each word a 32px row, and the currency list 16px so iOS does not zoom the page in on it.
- The Chapters button is 36px under a thumb, and each crumb a row to land on. Nothing moves under a mouse.
- Both stylesheets (`scripts/site-css/docs.css`, `docs/.vitepress/theme/style.css`) carry the same calculator, and `test/cost-calculator.test.mjs` now says so, phone rules named.

The bar's own touch targets come from the playground's stylesheet, which this site borrows at build time (abap2UI5/playground#88).

## Checked

`npm test` (224), the site build (167 pages, no dead links), the VitePress build, and iPhone 15 Pro renders of the home, a chapter, the calculator before and after Calculate, the chapter drawer and the bar's menu — no horizontal overflow at 393, 375, 360 or 320px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGnV9PvxLHHPz8zKqUkMY)_