### PR TITLE
The cost of a screen reads in one pass again

### DIFF
--- a/docs/advanced/insights/02-the-cost-of-a-screen.md
+++ b/docs/advanced/insights/02-the-cost-of-a-screen.md
@@ -1,14 +1,16 @@
 # #2 The Cost of a Screen
 
-An ABAP team needs a screen. A maintenance view
-for a customizing table nobody wants to explain in SM30 again. A cockpit
-showing what last night's job actually did. An approval step for one
-department. Sometimes theses are tasked used by four people, twice a year. Sometimes these program are only used in a go live or migration phase and will neveer started again after that.
+An ABAP team needs a screen. A maintenance view for a customizing table nobody
+wants to explain in SM30 again. A cockpit showing what last night's job
+actually did. An approval step for one department. Some of these are used by
+four people, twice a year. Some run during a go-live or a migration and are
+never started again after that.
 
-The logic behind such a screen might be thirty lines. And if the user interface in front of
-it is not, and — this is the part that hurts — it does not scale down with the
-logic: a data model, a service, a binding, an annotation model, a frontend
-artifact, a deployment. And all of these objects will now exist forever if you don't delete it.f 
+The logic behind such a screen might be thirty lines. The user interface in
+front of it is not, and — this is the part that hurts — it does not scale down
+with the logic: a data model, a service, a binding, an annotation model, a
+frontend artifact, a deployment. Every one of those objects then exists
+forever, unless somebody remembers to delete it.
 
 None of that is waste. It is what makes a real application dependable. It is
 simply a *fixed* cost, and a fixed cost is brutal to a small thing.
@@ -114,7 +116,10 @@ on a phone if that is where you open it. Replace `model_init( )` with the
 `SELECT` that reads your job log and it is finished. Nothing published, nothing
 to deprecate, nothing anybody has to un-build in three years.
 
-abap2UI5 is not a replacement your RAP or UI5 apps, it can be a nice addidtion to your existing UI soultion. Especially fpr small programs or when you need a UI for a single time task.
+abap2UI5 is not a replacement for your RAP or UI5 apps. It is a nice addition
+to the UI solutions you already run — especially for small programs, and for
+the screen somebody needs exactly once. What you pay for that is the layout:
+you write the view by hand, and nothing generates it from annotations.
 
 Give abap2UI5 a try!
 


### PR DESCRIPTION
## What changed

The last edit to `02-the-cost-of-a-screen.md` added what it wanted to say and
left the sentences half-turned:

- an `if` with no second half — *"And if the user interface in front of it is
  not, and — this is the part that hurts — …"*
- *"Sometimes theses are tasked used by four people, twice a year"*
- four typos: `neveer`, `it.f`, `addidtion`, `soultion`, plus `fpr`
- two paragraphs on one long line each, where the rest of the file — and every
  other page — wraps at the same column

Same content, straightened. What the edit wanted stays: the screen four people
open twice a year, the program that runs during a go-live and is never started
again, *"might be thirty lines"*, and a closing that calls abap2UI5 an addition
to what a team already runs rather than a replacement for it.

One half-sentence is added back — *what you pay for that is the layout: you
write the view by hand, and nothing generates it from annotations.* Every other
article in the series names its price, and this is the article about price. The
longer Fiori Elements comparison that the edit cut stays cut.

## Gates

Green: `test` (229), `docs:build`, `check:examples`, `check:conventions`,
`check:playground`.

`npm run build` and `check:version` need network this environment does not
have (the playground's published assets, the release API); both are unrelated
to a prose change and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_