### PR TITLE
A refresh starts the site over, and a heading folds what it opened

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,7 +362,10 @@ list**: a colour scheme is a choice about every page there will ever be, not a
 place, and nothing here clears by prefix. The keys being shared means a refresh
 here also drops what the catalogue and the playground wrote about themselves,
 which is the point — afterwards all four items in the bar open their section's
-front page. Their copy of the module does not reset on its own reloads yet.
+front page. Their copy of the module does the same on its own reloads
+(`forgetOnReload( )` in `src/shell/site-memory.mjs` over there, called from
+`keepSiteLinksCurrent( )` and `rememberHere( )`; the search box forgets its own
+key in `setUpSearch( )`).
 
 **The playground is remembered too** (`:last-playground`), and it did not use
 to be. The argument against was that its URL carries the code in the editor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ person reads the page. Do not put "as an AI, …" prose back into `docs/`.
 | `scripts/site-css/docs.css` | The manual's own layer over the catalogue's stylesheet — the chapter menu, the outline, prev/next, the Run panel, the skip link. Joined with the two borrowed files and minified into one `site.css` at build time |
 | `scripts/site-js/site.js` | The entry point for everything a page does beyond its markup. Bundled with the four modules it imports (below) into one `site.js` by esbuild — six requests three deep became one |
 | `docs/.vitepress/theme/style.css` | Everything this site looks like. Its palette is the playground's, copied — see *One site in three places* below |
-| `docs/.vitepress/theme/site-memory.js` | Where the reader was, on each site, so the bar comes back to it; pinned by `test/site-memory.test.mjs` |
+| `docs/.vitepress/theme/site-memory.js` | Where the reader was, on each site, so the bar comes back to it — and `forgetOnReload( )`, which drops all of it on a refresh; pinned by `test/site-memory.test.mjs` and `test/reload-reset.test.mjs` |
 | `docs/.vitepress/theme/link-to-selection.js` | **Copy link to selection** — the button under a selection inside the article, and the fallback for a browser too old for `:~:`. `theme/text-fragment.js` is the half with no DOM in it (what to quote, how to spell it), pinned by `test/text-fragment.test.mjs` |
 | `docs/.vitepress/theme/TheBar.vue` | The bar, as one element this repository owns: the brand, `SiteNav.vue` (the four sections), `SearchBox.vue`, the two marks, `SiteMenu.vue` (the menu behind the last button, and the version number `check:version` reads). It used to be the theme's bar with our parts in its slots and 85 override lines arguing its own parts out of the way; the theme now keeps two things, the hamburger and the screen it opens on a phone |
 | `docs/.vitepress/theme/SiteNav.vue` | The four sections, in the bar and again in the phone screen the theme's hamburger opens. Every item that leaves this deployment carries a `target` (`check:cross-site`), and three of the four are lifted to where the reader last was (`site-memory.js`) |
@@ -61,7 +61,7 @@ in it are decidable, and all thirteen are decided before a merge:
 
 | | |
 |---|---|
-| `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate; the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow; the text fragment behind *Copy link to selection* — what it quotes, and how it escapes it; and the crumb trail above every title, walked against the real sidebar so a restructured section cannot leave the trail passing against a fiction; and **the sidebar against the pages** (`test/sidebar-titles.test.mjs`): every entry's label is its page's own H1 (a search result shows the H1, the menu the label, and fourteen pages had two names a reader could not connect), every section's link is either its own page or the first page in its list (Configuration opened Setup while Installation stood first), and every page under `docs/` has an entry |
+| `test` | the sample-catalogue parser in `scripts/lib/`, against a row of every shape the three sample repositories generate; the cross-site position memory, specifically which stored values `theme/site-memory.js` may follow and what a refresh forgets (`test/reload-reset.test.mjs`); the text fragment behind *Copy link to selection* — what it quotes, and how it escapes it; and the crumb trail above every title, walked against the real sidebar so a restructured section cannot leave the trail passing against a fiction; and **the sidebar against the pages** (`test/sidebar-titles.test.mjs`): every entry's label is its page's own H1 (a search result shows the H1, the menu the label, and fourteen pages had two names a reader could not connect), every section's link is either its own page or the first page in its list (Configuration opened Setup while Installation stood first), and every page under `docs/` has an entry |
 | `check:version` | the release number in the bar's menu (`VERSION` in `theme/SiteMenu.vue` — it was a nav dropdown's label in `config.mjs` until the bar was rebuilt, and in `SiteBar.vue` until the bar was split), the deprecations page and the changelog, against the newest release tag of the framework — this one goes stale without anybody touching this repository |
 | `docs:build` | a page that does not build is a page nobody can read |
 | `check:examples` | the ABAP in the fenced blocks, against the real framework: does it compile, and does the view it builds name controls and properties that exist on the UI5 floor this documentation targets. **It ran no abaplint rules at all until 2026-09-04** — the generated config had no `rules` block, so abaplint walked 139 files, ran nothing, and printed `0 issue(s) found` for years. Ten examples with an unbalanced parenthesis were sitting behind that. The three compile rules it runs now (`parser_error`, `check_syntax`, `unknown_types`) are the sample repositories' own; the reasoning for stopping there, measured against the full 188-rule set, is in the file |
@@ -346,6 +346,23 @@ not it is also treated as a page.
 | where you were | `theme/site-memory.js`. Every page writes its own path down; the Samples item is lifted to whatever the catalogue last wrote. A stored value is **checked, not followed** — resolved against this origin and kept only if it is still inside the section the markup declares: the href it carries, or a wider `scope` the caller names for a link written deeper than what it restores (the other three bars point Documentation at the first page of the manual and still come back to wherever the reader was in it). A poisoned or stale key costs a restored position and nothing else. The cases are `test/site-memory.test.mjs` |
 | where **on** the page you were | `theme/site-memory.js` again, keys `:scroll` (a small map of path → offset, the twelve most recent) and `:returning`. Restored **on arrival by the bar and nowhere else**: a bar item writes one record saying where it is sending the reader, and the page that *is* that, arriving within half a minute and with no hash of its own, honours it. Restoring on every load would fight the browser's own back-and-forward restoration and would drop a reader who followed an ordinary link into the middle of a page with nothing to explain it. A stored offset is checked the same way a stored path is — `scrollTo` takes whatever it is given. `test/scroll-memory.test.mjs` |
 | the last thing you searched for | `theme/search-engine.js`, key `:search`. A hit opens another page, often another deployment, and the box that opens there was empty; the query is written down as a hit is opened and the next box starts with it, selected, so the first keystroke replaces it. Checked (a string, short, and less than half an hour old) rather than used. `test/search.test.mjs` |
+
+**A refresh starts over.** Every one of those is a memory of a JOURNEY — state
+one page hands the next because a click here makes a new document, which is why
+the chapter menu's shape (`:docs-sections`, `scripts/site-js/site.js`), the
+offset, the four bar items and the search box all survive a navigation. Reload
+is the one press on the site that has never meant *go somewhere*, and it is
+what a reader presses when a page looks wrong: handing them back the same
+half-open menus, the same offset and a bar still pointing at yesterday's sample
+is the site remembering its way back into whatever they were trying to leave.
+So `forgetOnReload( )` empties all seven keys on a `reload` navigation and on
+no other, first thing, before anything reads them — the page that follows is a
+first visit, and starts writing a new trail at once. **The theme is not in the
+list**: a colour scheme is a choice about every page there will ever be, not a
+place, and nothing here clears by prefix. The keys being shared means a refresh
+here also drops what the catalogue and the playground wrote about themselves,
+which is the point — afterwards all four items in the bar open their section's
+front page. Their copy of the module does not reset on its own reloads yet.
 
 **The playground is remembered too** (`:last-playground`), and it did not use
 to be. The argument against was that its URL carries the code in the editor

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -24,7 +24,7 @@ import { setUpCostCalculator } from './cost-calculator.js'
 import TheBar from './TheBar.vue'
 import SiteNav from './SiteNav.vue'
 import Crumbs from './Crumbs.vue'
-import { rememberHere, rememberScroll, restoreScroll } from './site-memory.js'
+import { forgetOnReload, rememberHere, rememberScroll, restoreScroll } from './site-memory.js'
 
 /** @type {import('vitepress').Theme} */
 export default {
@@ -122,6 +122,15 @@ export default {
     // whether this arrival is the one the bar named, and holds the offset
     // against the router's own scroll-to-top and a page that is still growing.
     if (!import.meta.env.SSR) {
+      // A REFRESH STARTS OVER, before any of the below reads the memory: all
+      // of it is state one page hands the next so a journey across pages reads
+      // as one, and reload is the reader saying the journey is over
+      // (site-memory.js). Only the search box is named - the chapter menu this
+      // resets on the published site is `scripts/site-js/site.js`'s, and the
+      // one here is the default theme's, which persists nothing. The key is
+      // search-engine.js's QUERY_KEY, spelled rather than imported so this
+      // does not pull the matching engine in.
+      forgetOnReload(['abap2ui5-playground:search'])
       rememberUnlessHome()
       setUpCodeLines()
       restoreScroll()

--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -338,3 +338,78 @@ export function restoreScroll() {
   };
   requestAnimationFrame(put);
 }
+
+/* ── A REFRESH STARTS OVER ──────────────────────────────────────────────────
+ *
+ * Reported as: "it now remembers everywhere on the documentation where I was -
+ * but when I refresh the page everything should be initial again, the menus
+ * folded, when I move between Documentation, Samples and Home."
+ *
+ * Which is what pressing reload has always meant, and every memory above is
+ * the other case. They exist because a click makes a NEW DOCUMENT: the shape
+ * of the chapter menu, how far down the page you were, which page of the other
+ * section you left - all of it is state a page hands the next one so that a
+ * journey ACROSS pages reads as one. None of it is a preference; all of it is
+ * "where I am right now", written down because the browser drops it at the
+ * door.
+ *
+ * A refresh is the reader saying: not this, start again. It is the one press
+ * on the site that has never meant "go somewhere" - and it is what everyone
+ * reaches for when a page looks wrong. Handing them back the same half-open
+ * menus, the same offset and a bar still pointing at yesterday's sample is the
+ * one answer that cannot help: the site remembers its way back into whatever
+ * they were trying to leave. So the trail is dropped, and the next document
+ * starts writing a new one.
+ *
+ * WHAT IS DROPPED IS THE TRAIL, NOT THE READER'S SETTINGS. The theme
+ * (`:theme`) is a choice about every page there will ever be, and a refresh
+ * that turned the site white again would be a bug of exactly the kind this is
+ * fixing. It is not in the list, and nothing here clears by prefix.
+ *
+ * The keys are shared with the two deployments beside this one, so a refresh
+ * here also drops what the catalogue and the playground wrote about
+ * themselves - which is the point: after it, all four items in the bar open
+ * their section's front page again. Their own copy of this module does not
+ * reset on ITS reloads yet; when it does, this comment and that one are the
+ * pair to keep in step.
+ */
+
+/** The places this file remembers a reader in, all five of them. */
+const REMEMBERED = [KEY.docs, KEY.samples, KEY.playground, SCROLL_KEY, HANDOFF_KEY];
+
+/** How this document was arrived at: "navigate", "reload", "back_forward",
+ *  "prerender" - or "" where the browser will not say. */
+export function arrivedBy() {
+  try {
+    const entry = performance.getEntriesByType("navigation")[0];
+    if (entry && typeof entry.type === "string") return entry.type;
+    /* What a browser too old for that entry still has. 1 is TYPE_RELOAD. */
+    return performance.navigation?.type === 1 ? "reload" : "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Forget the way back here - and only on a reload, which is the whole of it.
+ *
+ * `also` is what the CALLER remembers under its own keys: the chapter menu and
+ * the search box belong to one deployment each, so this file does not spell
+ * them (`site.js` does). `how` is here to be passed in by the tests, which
+ * have no navigation entry to read.
+ *
+ * Answers whether this was the arrival it acts on - a refused storage has
+ * nothing to forget and is not a different answer.
+ */
+export function forgetOnReload(also = [], how = arrivedBy()) {
+  if (how !== "reload") return false;
+  if (typeof localStorage === "undefined") return false;
+  for (const key of [...REMEMBERED, ...also]) {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      /* A refused storage has nothing to forget. */
+    }
+  }
+  return true;
+}

--- a/docs/.vitepress/theme/site-memory.js
+++ b/docs/.vitepress/theme/site-memory.js
@@ -369,9 +369,11 @@ export function restoreScroll() {
  * The keys are shared with the two deployments beside this one, so a refresh
  * here also drops what the catalogue and the playground wrote about
  * themselves - which is the point: after it, all four items in the bar open
- * their section's front page again. Their own copy of this module does not
- * reset on ITS reloads yet; when it does, this comment and that one are the
- * pair to keep in step.
+ * their section's front page again. Their own copy of this module does the
+ * same on ITS reloads - forgetOnReload( ) in src/shell/site-memory.mjs over
+ * there, called from keepSiteLinksCurrent( ) and from rememberHere( ) and
+ * acting once per document, because the three documents call those two in
+ * either order. Change one, change the other.
  */
 
 /** The places this file remembers a reader in, all five of them. */

--- a/scripts/site-js/site.js
+++ b/scripts/site-js/site.js
@@ -15,7 +15,34 @@ import { setUpPlayground } from './playground.js';
 import { setUpCodeLines, watchCodeLines } from './code-lines.js';
 import { markDirective, setUpLinkToSelection } from './link-to-selection.js';
 import { setUpCostCalculator } from './cost-calculator.js';
-import { entryOf, handOff, lastVisited, rememberHere, rememberScroll, restoreScroll, takeHandoff } from './site-memory.js';
+import { entryOf, forgetOnReload, handOff, lastVisited, rememberHere, rememberScroll, restoreScroll, takeHandoff } from './site-memory.js';
+
+/* ---- a refresh starts over ---------------------------------------------
+ *
+ * "It now remembers everywhere on the documentation where I was - but when I
+ * refresh the page everything should be initial again, the menus folded, when
+ * I move between Documentation, Samples and Home."
+ *
+ * Everything this site writes down is a memory of a JOURNEY between its pages,
+ * kept because every page is a fresh document (site-memory.js says the rest).
+ * Reload is the one press that has never meant "go somewhere", and it is what
+ * a reader reaches for when a page looks wrong - so what it gets back is a
+ * first visit: the chapter menu as the build folds it, no offset, and four bar
+ * items pointing at their section's front page.
+ *
+ * FIRST, BEFORE ANYTHING READS ANY OF IT. The menu below is put back from
+ * storage as this file runs, the bar is lifted from it a few lines down, and
+ * the search box - the catalogue's own module, bundled after this one - opens
+ * with the last query. All of them read a store this has already emptied.
+ *
+ * The two keys here are the ones this deployment owns; the five the memory
+ * itself keeps are its own business. The theme is in neither list: a colour
+ * scheme is a choice about every page there will ever be, not a place. */
+const SECTIONS_KEY = 'abap2ui5-playground:docs-sections';
+/* Spelled here and in the search module the bar carries (theme/search-engine.js
+   is this repository's copy of it, QUERY_KEY). */
+const SEARCH_KEY = 'abap2ui5-playground:search';
+forgetOnReload([SECTIONS_KEY, SEARCH_KEY]);
 
 /* The Run button under a runnable ABAP example, and "copy link to selection":
    one delegated listener each, for the whole document. */
@@ -289,7 +316,7 @@ document.addEventListener('click', (e) => {
   /* A second name, because every value under the first one was written by the
      navigation bug above and none of it is the reader's. A store that cannot
      be trusted is worse than an empty one. */
-  const KEY = 'abap2ui5-playground:docs-sections';
+  const KEY = SECTIONS_KEY;
   /* A section is a checkbox followed by its group (build-site.mjs): the box
      is what opens it, the group carries the key it is remembered by. */
   const groups = [...document.querySelectorAll('.sidebar .side-group[data-key]')];

--- a/test/reload-reset.test.mjs
+++ b/test/reload-reset.test.mjs
@@ -1,0 +1,132 @@
+/*
+ * A refresh starts over.
+ *
+ * Reported as: "it now remembers everywhere on the documentation where I was —
+ * but when I refresh the page everything should be initial again, the menus
+ * folded, when I move between Documentation, Samples and Home."
+ *
+ * Every memory this site keeps — the chapter menu's shape, how far down the
+ * page you were, which page of the other section you left, the last thing you
+ * searched for — exists because a click makes a NEW DOCUMENT: it is state one
+ * page hands the next so that a journey across pages reads as one. Reload is
+ * the reader saying the journey is over, and it is what everyone presses when
+ * a page looks wrong; a site that hands back the same half-open menus and the
+ * same offset is remembering its way back into the thing they were leaving.
+ *
+ * Two things this must NOT do, and both are cases below: reset on an ordinary
+ * navigation (which would delete the memory on the way to using it), and take
+ * the theme with it (a colour scheme is a choice about every page there will
+ * ever be, not a place).
+ *
+ * No browser runs in this suite, so the second half checks the wiring the same
+ * way the chapter menu's own file does: against the source that runs it.
+ *
+ *   npm test
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const { arrivedBy, forgetOnReload } = await import('../docs/.vitepress/theme/site-memory.js');
+
+const SECTIONS = 'abap2ui5-playground:docs-sections';
+const SEARCH = 'abap2ui5-playground:search';
+const THEME = 'abap2ui5-playground:theme';
+
+/** Everything a reader can have on this origin, written down. */
+const full = () => ({
+  'abap2ui5-playground:last-docs': '/docs/cookbook/model/trees',
+  'abap2ui5-playground:last-samples': '/playground/samples/?q=table',
+  'abap2ui5-playground:last-playground': '/playground/#code',
+  'abap2ui5-playground:scroll': '{"/docs/cookbook/model/trees":1840}',
+  'abap2ui5-playground:returning': '{"to":"/docs/","at":0}',
+  [SECTIONS]: '{"Cookbook":true,"Cookbook / Model":true}',
+  [SEARCH]: '{"q":"table","at":0}',
+  [THEME]: 'dark',
+});
+
+/** The store the module reads, as a stub, for one call. */
+function withStore(store, run) {
+  const before = globalThis.localStorage;
+  globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+  };
+  try {
+    return run();
+  } finally {
+    globalThis.localStorage = before;
+  }
+}
+
+test('a reload forgets every place the reader was', () => {
+  const store = full();
+  const forgot = withStore(store, () => forgetOnReload([SECTIONS, SEARCH], 'reload'));
+  assert.equal(forgot, true);
+  assert.deepEqual(Object.keys(store), [THEME],
+    'the menus, the offsets, the four bar items and the search box all start again');
+});
+
+test('...and the theme is not a place', () => {
+  const store = full();
+  withStore(store, () => forgetOnReload([SECTIONS, SEARCH], 'reload'));
+  assert.equal(store[THEME], 'dark',
+    'a refresh that turned the site white again would be the bug this fixes');
+});
+
+test('an ordinary navigation keeps all of it — that is the whole feature', () => {
+  for (const how of ['navigate', 'back_forward', 'prerender', '']) {
+    const store = full();
+    const forgot = withStore(store, () => forgetOnReload([SECTIONS, SEARCH], how));
+    assert.equal(forgot, false, `${how || 'an unknown arrival'} is not a refresh`);
+    assert.deepEqual(store, full(), `${how || 'an unknown arrival'} left the memory alone`);
+  }
+});
+
+test('a browser that will not say how you arrived is not a refresh', () => {
+  /* Node has no navigation entry, which is the same shape as a browser too old
+     for one: arrivedBy answers "" and nothing is forgotten. */
+  assert.equal(arrivedBy(), '');
+  const store = full();
+  withStore(store, () => forgetOnReload([SECTIONS, SEARCH]));
+  assert.deepEqual(store, full());
+});
+
+test('a refused storage costs nothing', () => {
+  const before = globalThis.localStorage;
+  globalThis.localStorage = { removeItem: () => { throw new Error('denied'); } };
+  try {
+    assert.equal(forgetOnReload([SECTIONS], 'reload'), true);
+  } finally {
+    globalThis.localStorage = before;
+  }
+});
+
+const SITE = readFileSync(join(ROOT, 'scripts/site-js/site.js'), 'utf8');
+
+test('the page forgets BEFORE anything reads the memory', () => {
+  const at = (needle) => {
+    const i = SITE.indexOf(needle);
+    assert.notEqual(i, -1, `${needle} is no longer in site.js`);
+    return i;
+  };
+  const reset = at('forgetOnReload([');
+  for (const reader of ['restoreScroll()', 'rememberHere(', 'function lift()', '(function tree()']) {
+    assert.ok(reset < at(reader), `${reader} would read a store the reset had not emptied yet`);
+  }
+});
+
+test('the two keys the page owns are the two keys the page uses', () => {
+  assert.match(SITE, /const SECTIONS_KEY = 'abap2ui5-playground:docs-sections';/);
+  assert.match(SITE, /const SEARCH_KEY = 'abap2ui5-playground:search';/);
+  assert.match(SITE, /forgetOnReload\(\[SECTIONS_KEY, SEARCH_KEY\]\)/);
+  /* The chapter menu reads the same constant it is reset by - it was spelled
+     twice in this file, which is one place for the two to drift apart. */
+  assert.match(SITE, /const KEY = SECTIONS_KEY;/);
+  assert.equal((SITE.match(/abap2ui5-playground:docs-sections/g) || []).length, 1);
+});


### PR DESCRIPTION
Two reports about the chapter menu, one after the other.

## 1. A refresh starts the site over

> *"es wird sich jetzt überall auf der Doku-Seite gemerkt wo man stand, aber wenn ich die Seite refresh sollte alles wieder initial sein, also die Menüs eingeklappt, wenn ich zwischen den Kategorien Documentation, Samples und Home hin und her springe."*

Everything this site writes down — the chapter menu's shape, how far down the page you were, which page of the other section you left, the last thing you searched for — is a memory of a **journey**: state one page hands the next because a click here makes a new document. That is why it survives a navigation at all.

Reload is the one press that has never meant *go somewhere*, and it is what a reader presses when a page looks wrong. Handing them back the same half-open menus, the same offset and a bar still pointing at yesterday's sample is the site remembering its way back into whatever they were trying to leave.

`forgetOnReload( )` (`docs/.vitepress/theme/site-memory.js`) empties seven keys on a `reload` navigation and on no other — the three `:last-docs` / `:last-samples` / `:last-playground`, `:scroll`, `:returning`, the chapter menu (`:docs-sections`) and the search box (`:search`). It is called first thing in `scripts/site-js/site.js`, before the menu is put back, before the bar is lifted, before `restoreScroll( )` and before the bundled search module reads anything. The VitePress build (the second opinion, and `docs:dev`) does the same in `theme/index.js`.

After a refresh the menus are folded — bar the section holding the page, which the build opens, because a menu that hid where you are would be worse — and Documentation, Samples, Playground and Home open their section's front page again. The page then writes itself down again at once: a refresh drops the trail, it does not pretend the reader is nowhere.

**The theme is deliberately not in the list.** A colour scheme is a choice about every page there will ever be, not a place, and nothing here clears by prefix.

Two keys of this deployment's own are passed by the caller, so `theme/site-memory.js` still spells exactly the five names the playground's copy spells (`test/site-memory-keys.test.mjs` pins that pair).

## 2. A section's own words fold it when you are already there

> *"wenn ich unter Documentation auf eine Überschrift im Menü klicke, dann klappt sich das Menü auf, wenn ich aber nochmal auf diese Überschrift klicke, dann klappt es sich nicht ein."*

Both true, and the reason is that the words are a **link**. Most sections point at a page of their own, so the first press went to that page — where the section holding it is opened by the build and again by the walk in `site.js`, whatever is stored. The second press went to that same page a second time: a fresh document, the same section, opened again. Only the caret folded it, which is 24 pixels next to twelve characters that look like they should.

So when the link names the page the reader is **on**, it has nothing to open and folds the list instead. Anywhere else it stays what it says it is, and a press that means *in a new tab* still means that. The box is flipped through a `change` event rather than by hand: assigning `checked` fires nothing, and the one listener that writes the menu down listens for `change`, so a fold that was not remembered would come back on the next page as though it had not been asked for.

## Verification

`test/reload-reset.test.mjs` — 7 cases: what a reload forgets, that the theme survives, that `navigate` / `back_forward` / `prerender` / an unknown arrival forget nothing, that a refused storage costs nothing, and that the page resets *before* anything reads the store. Three more in `test/sidebar-memory.test.mjs` for the heading. `npm test` 239/239.

Measured in Chromium against **the real published build** (`npm run build` against a built playground checkout, then the pages served):

| | navigation | refresh |
|---|---|---|
| a section the reader unfolded | open | folded |
| the section holding the page | open | open |
| the theme | `dark` | `dark` |

and, pressing *Cookbook* twice:

| | before | after |
|---|---|---|
| first press, from another page | opens the section | opens the section |
| second press, now on that page | still open | **folded**, URL unchanged |
| the same-URL press | a navigation (`navigate`, not `reload` — it does not trip §1) | no navigation at all |

`docs:build` and `check:cross-site` green.

The other half of §1 is the playground's four bars: abap2UI5/playground#90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mtBw41t7mBg7AdBfaSRGp