### PR TITLE
The calculator's last line is a panel, and it asks for an evening rather than money

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2804,20 +2804,4 @@
 .cost-total > div { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--fg-dim); }
 .cost-total output { font-size: 28px; line-height: 1.15; font-weight: 600; color: var(--accent); font-variant-numeric: tabular-nums; }
 .cost-total > div:first-child output { font-size: 40px; }
-/* What the zeros get you. The sheet answers the question the page asks in one
-   character, ten times over, which is a thin thing to hand somebody who just
-   worked through nine sliders - so the same reveal carries a short list of
-   what comes with the number. Plain lines, two columns where there is room:
-   it is a note under the total, not a second headline. */
-.cost-perks { margin: 20px 0 0; font-size: 13px; line-height: 1.6; color: var(--fg-dim); }
-.cost-perks-head { margin: 0 0 8px; font-weight: 600; color: var(--fg); }
-/* Named down to the element, because both themes give a list in an article a
-   marker and an indent of its own. */
-.cost-perks ul.cost-perks-list {
-  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 24px;
-  margin: 0; padding: 0; list-style: none;
-}
-.cost-perks ul.cost-perks-list li { margin: 0; }
-.cost-perks ul.cost-perks-list li strong { color: var(--fg); font-weight: 600; }
-@media (max-width: 620px) { .cost-perks ul.cost-perks-list { grid-template-columns: 1fr; } }
 @media (max-width: 620px) { .cost-total { grid-template-columns: 1fr; } }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2804,4 +2804,28 @@
 .cost-total > div { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--fg-dim); }
 .cost-total output { font-size: 28px; line-height: 1.15; font-weight: 600; color: var(--accent); font-variant-numeric: tabular-nums; }
 .cost-total > div:first-child output { font-size: 40px; }
+/* The one line the sheet cannot total. The answer above it is ten zeros, so
+   the way to say that somebody still paid for them is a panel of its own -
+   the accent border the total carries, on the quieter background, so it reads
+   as the other half of the answer rather than as a footnote or a plea. The
+   four ways are a list without markers, two columns where there is room, each
+   led by what it is: three of them cost an evening and one costs money, and
+   they are in that order on purpose. */
+.cost-give {
+  margin: 28px 0 0; padding: 4px 24px 20px; border: 1px solid var(--accent);
+  border-radius: 8px; background: var(--bg-sunken);
+}
+.cost-give h2 { margin: 16px 0 10px; padding: 0; border: 0; }
+.cost-give p { font-size: 14px; }
+.cost-give > :last-child { margin-bottom: 0; }
+/* Named down to the element, because both themes give a list in an article a
+   marker and an indent of its own. */
+.cost-give ul {
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px 24px;
+  margin: 16px 0; padding: 0; list-style: none;
+  font-size: 13px; line-height: 1.6; color: var(--fg-dim);
+}
+.cost-give ul li { margin: 0; padding: 0; }
+.cost-give ul li strong { display: block; color: var(--fg); font-weight: 600; }
+@media (max-width: 620px) { .cost-give ul { grid-template-columns: 1fr; } }
 @media (max-width: 620px) { .cost-total { grid-template-columns: 1fr; } }

--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -37,8 +37,6 @@ Set the sliders to your landscape, tick your systems and your support, pick a cu
 <div><span class="cost-total-what">Per year</span><output data-total>€0</output></div>
 <div><span class="cost-total-what">Per user, per month</span><output data-total>€0</output></div>
 </div>
-</ul>
-</div>
 </div>
 </div>
 
@@ -48,8 +46,8 @@ The formula is short: every line is zero, and a sum of zeros is zero. Put the us
 
 ## Free to use is not the same as free to make
 
-Keep in mind, those zeros were written in somebody's evenings - the release you will pull next month, the answer under your issue, the 7.02 downport nobody asked for. That part of the bill is real; it is just not addressed to you.
+Keep in mind that those zeros were written in somebody's evenings - the release you will pull next month, the answer under your issue, the 7.02 downport nobody asked for. That part of the bill is real; it is just not addressed to you.
 
-So if this page took a line out of a budget, put a little of it back: [sponsor the contributors](/resources/sponsor), and the open-source projects abap2UI5 stands on. Reporting a bug, or answering somebody else's question on github or in [Slack](https://communityinviter.com/apps/abapgit/abap), counts too.
+So if this page took a line out of a budget, put a little of it back: [sponsor the contributors](/resources/sponsor), and the open-source projects abap2UI5 stands on. Reporting a bug, or answering somebody else's question on GitHub or in [Slack](https://communityinviter.com/apps/abapgit/abap), counts too.
 
 </div>

--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -44,10 +44,21 @@ Set the sliders to your landscape, tick your systems and your support, pick a cu
 
 The formula is short: every line is zero, and a sum of zeros is zero. Put the users at 250,000, tick every system on the list, ask for ten years of it and press Calculate again - the sheet will not move, because nothing is counting. abap2UI5 is [MIT licensed](/resources/license), commercial use included, and what you build with it is a standard UI5 app served by the ABAP stack you already run.
 
+<div class="cost-give">
+
 ## Free to use is not the same as free to make
 
 Keep in mind that those zeros were written in somebody's evenings - the release you will pull next month, the answer under your issue, the 7.02 downport nobody asked for. That part of the bill is real; it is just not addressed to you.
 
-So if this page took a line out of a budget, put a little of it back: [sponsor the contributors](/resources/sponsor), and the open-source projects abap2UI5 stands on. Reporting a bug, or answering somebody else's question on GitHub or in [Slack](https://communityinviter.com/apps/abapgit/abap), counts too.
+And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back:
+
+- **Sponsor an evening.** [The contributors](/resources/sponsor), and the open-source projects abap2UI5 stands on. This is the one line that takes money, and the smallest amount is a real one.
+- **Answer somebody.** A question in [Slack](https://communityinviter.com/apps/abapgit/abap) or under a [GitHub issue](https://github.com/abap2UI5/abap2UI5/issues) can save the next person an afternoon of searching.
+- **Send what you built.** A bug report with a reproducer, a sample worth copying, a pull request - the feature you needed and wrote yourself is a feature everybody gets.
+- **Say that it exists.** A blog post, a talk, a screenshot of your app in the launchpad, a word in the SAP Community. There is no marketing department; there is you.
+
+Pick whichever is easiest this week. None of it comes with an invoice, and all of it counts.
+
+</div>
 
 </div>

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -1187,6 +1187,30 @@ html { scrollbar-gutter: stable; }
 .cost-total > div { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--fg-dim); }
 .cost-total output { font-size: 28px; line-height: 1.15; font-weight: 600; color: var(--accent); font-variant-numeric: tabular-nums; }
 .cost-total > div:first-child output { font-size: 40px; }
+/* The one line the sheet cannot total. The answer above it is ten zeros, so
+   the way to say that somebody still paid for them is a panel of its own -
+   the accent border the total carries, on the quieter background, so it reads
+   as the other half of the answer rather than as a footnote or a plea. The
+   four ways are a list without markers, two columns where there is room, each
+   led by what it is: three of them cost an evening and one costs money, and
+   they are in that order on purpose. */
+.cost-give {
+  margin: 28px 0 0; padding: 4px 24px 20px; border: 1px solid var(--accent);
+  border-radius: 8px; background: var(--bg-sunken);
+}
+.cost-give h2 { margin: 16px 0 10px; padding: 0; border: 0; }
+.cost-give p { font-size: 14px; }
+.cost-give > :last-child { margin-bottom: 0; }
+/* Named down to the element, because both themes give a list in an article a
+   marker and an indent of its own. */
+.cost-give ul {
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px 24px;
+  margin: 16px 0; padding: 0; list-style: none;
+  font-size: 13px; line-height: 1.6; color: var(--fg-dim);
+}
+.cost-give ul li { margin: 0; padding: 0; }
+.cost-give ul li strong { display: block; color: var(--fg); font-weight: 600; }
+@media (max-width: 620px) { .cost-give ul { grid-template-columns: 1fr; } }
 @media (max-width: 620px) { .cost-total { grid-template-columns: 1fr; } }
 
 /* ---- the front door's example folds on a phone --------------------------

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -1187,22 +1187,6 @@ html { scrollbar-gutter: stable; }
 .cost-total > div { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--fg-dim); }
 .cost-total output { font-size: 28px; line-height: 1.15; font-weight: 600; color: var(--accent); font-variant-numeric: tabular-nums; }
 .cost-total > div:first-child output { font-size: 40px; }
-/* What the zeros get you. The sheet answers the question the page asks in one
-   character, ten times over, which is a thin thing to hand somebody who just
-   worked through nine sliders - so the same reveal carries a short list of
-   what comes with the number. Plain lines, two columns where there is room:
-   it is a note under the total, not a second headline. */
-.cost-perks { margin: 20px 0 0; font-size: 13px; line-height: 1.6; color: var(--fg-dim); }
-.cost-perks-head { margin: 0 0 8px; font-weight: 600; color: var(--fg); }
-/* Named down to the element, because both themes give a list in an article a
-   marker and an indent of its own. */
-.cost-perks ul.cost-perks-list {
-  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 24px;
-  margin: 0; padding: 0; list-style: none;
-}
-.cost-perks ul.cost-perks-list li { margin: 0; }
-.cost-perks ul.cost-perks-list li strong { color: var(--fg); font-weight: 600; }
-@media (max-width: 620px) { .cost-perks ul.cost-perks-list { grid-template-columns: 1fr; } }
 @media (max-width: 620px) { .cost-total { grid-template-columns: 1fr; } }
 
 /* ---- the front door's example folds on a phone --------------------------

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -146,11 +146,22 @@ test('the links wait for the sheet, and lead out of it only there', () => {
   assert.doesNotMatch(sheet, /cost-perks|<\/ul>/, 'and nothing is left of the list that used to close the sheet');
 });
 
-test('the front door\'s cost card leads here, and the page ends at the sponsors', () => {
+/* The page answers in zeros, so the section that says somebody still paid for
+   them is a panel rather than a paragraph after the sheet - and what it asks
+   for is mostly not money: four ways, three of which cost an evening. The
+   ways are pinned because the ONE that takes money is the one a page like
+   this drifts towards over time, and the other three are the point. */
+test('the front door\'s cost card leads here, and the page ends on the four ways', () => {
   assert.match(HOME, /\]\(\/resources\/cost_calculator\)/, 'the cost card links the calculator');
   const last = PAGE.slice(PAGE.lastIndexOf('\n## '));
+  assert.ok(PAGE.indexOf('<div class="cost-give">') < PAGE.lastIndexOf('\n## '), 'the section stands in a panel of its own');
   assert.match(last, /\]\(\/resources\/sponsor\)/, 'the last section is the one that asks');
   assert.match(last, /open-source/i);
+  const ways = (last.match(/^- \*\*/gm) || []);
+  assert.equal(ways.length, 4, 'four ways, each led by what it is');
+  assert.equal((last.match(/\]\(https?:/g) || []).length, 2, 'two of them lead somewhere to do it: Slack and the issue tracker');
+  assert.match(last, /github\.com\/abap2UI5\/abap2UI5\/issues/);
+  assert.match(last, /communityinviter\.com/);
 });
 
 /* The stylesheet is written twice - scripts/site-css/docs.css for the site the

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -123,26 +123,27 @@ test('the sheet waits for the button', () => {
   const after = PAGE.indexOf('<div class="cost-after" data-result hidden>\n\n');
   assert.ok(after > PAGE.lastIndexOf('<div class="cost-result"'), 'the words under the sheet wait for the button too');
   assert.ok(PAGE.trimEnd().endsWith('\n\n</div>'), 'and the wrapper closes after the last of them');
-  assert.ok(PAGE.indexOf('\n## The line that is not zero', after) > after, 'the section is markdown inside it, heading and all');
+  assert.ok(PAGE.indexOf('\n## Free to use is not the same as free to make', after) > after, 'the section is markdown inside it, heading and all');
 });
 
-/* Two things the sheet carries that the inputs deliberately do not. The links
-   to the issue tracker and to Slack: they sat in the support row, which is a
-   way out of the page in the middle of filling it in, and they belong on the
-   Support line of the answer instead. And what the zeros get you - the sheet
-   is ten times the same character, and on its own that is a thin reward for
-   working through nine sliders. */
-test('the links wait for the sheet, and the sheet ends on what the zeros get you', () => {
+/* What the sheet carries that the inputs deliberately do not: the links to the
+   issue tracker and to Slack. They sat in the support row, which is a way out
+   of the page in the middle of filling it in, and they belong on the Support
+   line of the answer instead.
+
+   There was a list under the total here too - what the zeros get you - on the
+   grounds that ten identical characters are a thin reward for nine sliders.
+   It was taken out again: the sentences under the sheet say the same thing in
+   the page's own voice, and the list said it twice. Its rules went out of both
+   stylesheets with it. */
+test('the links wait for the sheet, and lead out of it only there', () => {
   const inputs = PAGE.slice(PAGE.indexOf('<div class="cost-inputs">'), PAGE.indexOf('data-calculate='));
   assert.doesNotMatch(inputs, /<a /, 'nothing leads out of the page while it is being filled in');
   const sheet = PAGE.slice(PAGE.indexOf('<div class="cost-result"'), PAGE.indexOf('<div class="cost-after"'));
   assert.match(sheet, /Support<small>[^<]*<span data-echo="cost-support">/, 'the sheet has a support line');
   assert.match(sheet, /github\.com\/abap2UI5\/abap2UI5\/issues/, 'and the issue tracker is on it');
   assert.match(sheet, /communityinviter\.com/, 'and Slack');
-  assert.ok(sheet.indexOf('<div class="cost-total">') < sheet.indexOf('<div class="cost-perks">'), 'the features come after the total');
-  const perks = sheet.slice(sheet.indexOf('<div class="cost-perks">'));
-  assert.ok((perks.match(/<li>/g) || []).length >= 3, 'a handful of them');
-  assert.match(perks, /<li><strong>[^<]+<\/strong> /, 'each one led by what it is');
+  assert.doesNotMatch(sheet, /cost-perks|<\/ul>/, 'and nothing is left of the list that used to close the sheet');
 });
 
 test('the front door\'s cost card leads here, and the page ends at the sponsors', () => {


### PR DESCRIPTION
Two commits: the page is straightened first, then the section that asks gets a
shape of its own.

## The straightening

The list under the total was taken out by hand and left its closing tags
standing — a `</ul>` with no list, and one `</div>` more than the sheet opens,
so the wrapper the words under the calculator sit in was closed a level too
early.

Two pins named what the page no longer carries and had been red on `main`
since that edit: the heading, now *Free to use is not the same as free to
make*, and the four features under the total. The first follows the page; the
second is replaced by its opposite — nothing of that list is left in the sheet
— and the comment above it says why the list went rather than pretending it
was never there. Its rules go out of **both** stylesheets, which is the pair
`test/cost-calculator` holds to the same text.

Also from the same edit: *on github* is GitHub, and the sentence the heading
took its words from starts on its own two feet again.

## The panel

The page answers nine sliders with ten zeros. What it had to say after that —
that somebody still paid for them — was a paragraph like any other under the
sheet, in the same weight as the formula above it, and it read as a footnote.

It is a panel now: the accent border the total carries, on the quieter
background, so it lands as the other half of the answer. What it asks for is
four things rather than one, in this order:

- **Sponsor an evening.** The contributors, and the open-source projects
  abap2UI5 stands on — the one line that takes money.
- **Answer somebody.** A question in Slack or under a GitHub issue.
- **Send what you built.** A reproducer, a sample worth copying, a pull
  request.
- **Say that it exists.** A blog post, a talk, a screenshot of your app in the
  launchpad.

Three of the four cost an evening and one costs money, which is the point:
contribution is the currency, and the page says so without complaining about
it or asking twice. It closes on *pick whichever is easiest this week*.

The rules go into both stylesheets, two columns where there is room and one on
a phone, with the heading in the page's own measure rather than larger. The
four ways are pinned: a page like this drifts towards the line that takes
money, and the other three are why the panel exists.

Checked in a browser against the built site, light and dark and at 390px.

## Gates

Green: `test` (229), `docs:build`, `check:cross-site`, `check:design`,
`check:images`.

`npm run build` and `check:version` need network this environment does not
have (the playground's published assets, the release API); both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_