### PR TITLE
Three words on the calculator, and the first of the four ways says it takes money

### DIFF
--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -42,7 +42,7 @@ Set the sliders to your landscape, tick your systems and your support, pick a cu
 
 <div class="cost-after" data-result hidden>
 
-The formula is short: every line is zero, and a sum of zeros is zero, no matter what you cloicked before ;) . abap2UI5 is [MIT licensed](/resources/license), commercial use included, and what you build with it is a standard UI5 app served by the ABAP stack you already run.
+The formula is short: every line is zero, and a sum of zeros is zero - no matter what you clicked before. ;) abap2UI5 is [MIT licensed](/resources/license), commercial use included, and what you build with it is a standard UI5 app served by the ABAP stack you already run.
 
 <div class="cost-give">
 
@@ -52,7 +52,7 @@ Keep in mind that those zeros were written in somebody's evenings - the release 
 
 And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back:
 
-- **Sponsor some money.** [The contributors](/resources/sponsor), and the open-source projects abap2UI5 stands on. This is the one line that takes money, and the smallest amount is a real one.
+- **Sponsor the work.** [The contributors](/resources/sponsor), and the open-source projects abap2UI5 stands on. This is the one line that takes money, and the smallest amount is a real one.
 - **Answer somebody.** A question in [Slack](https://communityinviter.com/apps/abapgit/abap) or under a [GitHub issue](https://github.com/abap2UI5/abap2UI5/issues) can save the next person an afternoon of searching.
 - **Send what you built.** A bug report with a reproducer, a sample worth copying, a pull request - the feature you needed and wrote yourself is a feature everybody gets.
 - **Say that it exists.** A blog post, a talk, a screenshot of your app in the launchpad, a word in the SAP Community. There is no marketing department; there is you.


### PR DESCRIPTION
## What changed

The hand edit was checked against every gate first — `test` (236),
`docs:build`, `check:cross-site` and `check:api-names` all pass on it, and no
pin was broken. What was left is language:

- **`cloicked`** is *clicked*.
- The smiley carried a space in front of its full stop and ran straight into
  the sentence after it (*…before ;) abap2UI5 is MIT licensed*). It now ends a
  sentence of its own.
- ***Sponsor some money*** → ***Sponsor the work***. English does not sponsor
  money, and the point the edit was making — that this line, out of the four,
  is the one that costs money — is carried by the sentence right behind it:
  *This is the one line that takes money, and the smallest amount is a real
  one.*

The short version of the formula stays short. The old proof of the joke —
250,000 users, every system ticked, ten years, press Calculate again — went
out with the edit, and the line lands without it.

## Gates

Green: `test` (236), `docs:build`, `check:cross-site`, `check:api-names`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_