### PR TITLE
The phone does not follow the Fiori design guidelines; the app does

### DIFF
--- a/docs/advanced/insights/02-the-cost-of-a-screen.md
+++ b/docs/advanced/insights/02-the-cost-of-a-screen.md
@@ -112,16 +112,16 @@ ENDCLASS.
 ```
 
 Activate it, call the ICF endpoint with `?app_start=zcl_job_monitor`, and it is
-on screen. About as much work as an ALV — except this one also starts on your
-phone following the Fiori design guidelines.
+on screen. About as much work as an ALV — except this one follows the Fiori
+design guidelines, and starts on your phone.
 
-Replace `model_init( )` with the `SELECT` that reads your job log, and it
-is finished. Nothing published, nothing to deprecate, nothing anybody has to
+Replace `model_init( )` with the `SELECT` that reads your job log, and it is
+finished. Nothing published, nothing to deprecate, nothing anybody has to
 un-build in three years.
 
-abap2UI5 is not a replacement for your RAP or UI5 apps. It is an addition
-to the UI solutions you already run — especially for small programs, and for
-the screen somebody needs exactly once.
+abap2UI5 is not a replacement for your RAP or UI5 apps. It is an addition to
+the UI solutions you already run — especially for small programs, and for the
+screen somebody needs exactly once.
 
 And it runs on the UI5 and the ABAP your system already has. Install it with
 abapGit and give it a try!


### PR DESCRIPTION
## What changed

The trim to `02-the-cost-of-a-screen.md` left one sentence attached to the
wrong subject:

> except this one also starts on your **phone following the Fiori design
> guidelines**

which reads as a phone that follows them. The two claims are two clauses of
their own now — the app follows the guidelines, and it starts on your phone.

The two paragraphs the trim shortened are rewrapped to the column the file
wraps in. That is the whole of the rest.

Everything the trim took out stays out: the launchpad tile, *nice*, *today*.

## Gates

Green: `test` (236), `docs:build`, `check:conventions`, `check:playground`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_