### PR TITLE
One box for the answer, and ten ways to pay it back that are all the same size

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2826,6 +2826,18 @@
   font-size: 13px; line-height: 1.6; color: var(--fg-dim);
 }
 .cost-give ul li { margin: 0; padding: 0; }
-.cost-give ul li strong { display: block; color: var(--fg); font-weight: 600; }
+/* The lead of a way is a line of its own - and only the lead: a strong later
+   in the sentence (the tag a post carries) is a word inside it. */
+.cost-give ul li strong:first-child { display: block; }
+.cost-give ul li strong { color: var(--fg); font-weight: 600; }
 @media (max-width: 620px) { .cost-give ul { grid-template-columns: 1fr; } }
+/* The note is the sheet's last line rather than a paragraph under it: the
+   three figures answer the question, and the sentence that says why they are
+   all the same character belongs inside the same border. It spans the grid,
+   sits on a hairline under the figures, and is the size of a caption - a note
+   on the total, not a fourth number. */
+.cost-total-note {
+  grid-column: 1 / -1; margin: 4px 0 0; padding-top: 14px;
+  border-top: 1px solid var(--line); font-size: 13px; line-height: 1.6; color: var(--fg-dim);
+}
 @media (max-width: 620px) { .cost-total { grid-template-columns: 1fr; } }

--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -49,15 +49,20 @@ Set the sliders to your landscape, tick your systems and your support, pick a cu
 
 Keep in mind that those zeros were written in somebody's evenings - the release you will pull next month, the answer under your issue, the 7.02 downport nobody asked for. That part of the bill is real; it is just not addressed to you.
 
-And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back:
+And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back - nine that cost an evening, and one that costs money:
 
-- **Sponsor the work.** [The contributors](/resources/sponsor), and the open-source projects abap2UI5 stands on. This is the one line that takes money, and the smallest amount is a real one.
-- **Answer somebody.** A question in [Slack](https://communityinviter.com/apps/abapgit/abap) or under a [GitHub issue](https://github.com/abap2UI5/abap2UI5/issues) can save the next person an afternoon of searching.
-- **Send what you built.** A bug report with a reproducer, a sample worth copying, a pull request - the feature you needed and wrote yourself is a feature everybody gets.
-- **Say that it exists.** A blog post, a talk, a screenshot of your app in the launchpad. On [LinkedIn](https://www.linkedin.com/company/abap2ui5) you can mention the project's page and tag the post **#abap2UI5**, and a post in the [SAP Community](https://community.sap.com/) reaches the people who have the same problem you had last month. Everything written about abap2UI5 is collected on the [references page](/resources/references). There is no marketing department; there is you.
-- **Put your company on the list.** [Who Uses abap2UI5?](/resources/who_uses) collects the customer projects, integrations and workshops that run on it. Adding yours is one row in a table, and it is what tells the next team asking *is anybody actually using this?* that the answer is yes.
+- **Star the repository.** One click on [GitHub](https://github.com/abap2UI5/abap2UI5), and the next visitor sees a project rather than an experiment.
+- **Answer somebody.** One reply in [Slack](https://communityinviter.com/apps/abapgit/abap) can save the next person an afternoon of searching for it.
+- **Report what broke.** An [issue](https://github.com/abap2UI5/abap2UI5/issues) with a class that reproduces the problem is half of the fix already.
+- **Send a screen you built.** A class in [samples](https://github.com/abap2UI5/samples) is what the next developer copies instead of inventing it.
+- **Fix a line in these docs.** Every page carries an *Edit this page* link into [the repository](https://github.com/abap2UI5/docs), and typos count.
+- **Pick up something small.** The [contribution list](/resources/contribution) starts at *a missing property on a control* - no project required.
+- **Post about it.** Mention [the page](https://www.linkedin.com/company/abap2ui5) on LinkedIn, tag it **#abap2UI5**, and it lands in the [references](/resources/references).
+- **Write it up.** One article in the [SAP Community](https://community.sap.com/) reaches everybody who has the problem you just solved.
+- **Add your company.** One row in [Who Uses abap2UI5?](/resources/who_uses) is what answers *is anybody actually running this?*
+- **Sponsor the work.** [The contributors](/resources/sponsor), and the open-source projects it stands on - the smallest amount is a real one.
 
-Pick whichever is easiest this week. None of it comes with an invoice, and all of it counts.
+Pick the one that is easiest this week. None of it comes with an invoice, and all of it counts.
 
 </div>
 

--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -36,13 +36,12 @@ Set the sliders to your landscape, tick your systems and your support, pick a cu
 <div><span class="cost-total-what">Total, over <span data-echo="cost-term">3 years</span></span><output data-total>€0</output></div>
 <div><span class="cost-total-what">Per year</span><output data-total>€0</output></div>
 <div><span class="cost-total-what">Per user, per month</span><output data-total>€0</output></div>
+<p class="cost-total-note">The formula is short: every line is zero, and a sum of zeros is zero - no matter what you clicked before. 😉 abap2UI5 is <a href="/docs/resources/license">MIT licensed</a>, commercial use included, and what you build with it is a standard UI5 app served by the ABAP stack you already run.</p>
 </div>
 </div>
 </div>
 
 <div class="cost-after" data-result hidden>
-
-The formula is short: every line is zero, and a sum of zeros is zero - no matter what you clicked before. ;) abap2UI5 is [MIT licensed](/resources/license), commercial use included, and what you build with it is a standard UI5 app served by the ABAP stack you already run.
 
 <div class="cost-give">
 
@@ -55,7 +54,8 @@ And it is payable in a currency you already have. If this page took a line out o
 - **Sponsor the work.** [The contributors](/resources/sponsor), and the open-source projects abap2UI5 stands on. This is the one line that takes money, and the smallest amount is a real one.
 - **Answer somebody.** A question in [Slack](https://communityinviter.com/apps/abapgit/abap) or under a [GitHub issue](https://github.com/abap2UI5/abap2UI5/issues) can save the next person an afternoon of searching.
 - **Send what you built.** A bug report with a reproducer, a sample worth copying, a pull request - the feature you needed and wrote yourself is a feature everybody gets.
-- **Say that it exists.** A blog post, a talk, a screenshot of your app in the launchpad, a word in the SAP Community. There is no marketing department; there is you.
+- **Say that it exists.** A blog post, a talk, a screenshot of your app in the launchpad. On [LinkedIn](https://www.linkedin.com/company/abap2ui5) you can mention the project's page and tag the post **#abap2UI5**, and a post in the [SAP Community](https://community.sap.com/) reaches the people who have the same problem you had last month. Everything written about abap2UI5 is collected on the [references page](/resources/references). There is no marketing department; there is you.
+- **Put your company on the list.** [Who Uses abap2UI5?](/resources/who_uses) collects the customer projects, integrations and workshops that run on it. Adding yours is one row in a table, and it is what tells the next team asking *is anybody actually using this?* that the answer is yes.
 
 Pick whichever is easiest this week. None of it comes with an invoice, and all of it counts.
 

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -1209,8 +1209,20 @@ html { scrollbar-gutter: stable; }
   font-size: 13px; line-height: 1.6; color: var(--fg-dim);
 }
 .cost-give ul li { margin: 0; padding: 0; }
-.cost-give ul li strong { display: block; color: var(--fg); font-weight: 600; }
+/* The lead of a way is a line of its own - and only the lead: a strong later
+   in the sentence (the tag a post carries) is a word inside it. */
+.cost-give ul li strong:first-child { display: block; }
+.cost-give ul li strong { color: var(--fg); font-weight: 600; }
 @media (max-width: 620px) { .cost-give ul { grid-template-columns: 1fr; } }
+/* The note is the sheet's last line rather than a paragraph under it: the
+   three figures answer the question, and the sentence that says why they are
+   all the same character belongs inside the same border. It spans the grid,
+   sits on a hairline under the figures, and is the size of a caption - a note
+   on the total, not a fourth number. */
+.cost-total-note {
+  grid-column: 1 / -1; margin: 4px 0 0; padding-top: 14px;
+  border-top: 1px solid var(--line); font-size: 13px; line-height: 1.6; color: var(--fg-dim);
+}
 @media (max-width: 620px) { .cost-total { grid-template-columns: 1fr; } }
 
 /* ---- the front door's example folds on a phone --------------------------

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -158,10 +158,16 @@ test('the front door\'s cost card leads here, and the page ends on the four ways
   assert.match(last, /\]\(\/resources\/sponsor\)/, 'the last section is the one that asks');
   assert.match(last, /open-source/i);
   const ways = (last.match(/^- \*\*/gm) || []);
-  assert.equal(ways.length, 4, 'four ways, each led by what it is');
-  assert.equal((last.match(/\]\(https?:/g) || []).length, 2, 'two of them lead somewhere to do it: Slack and the issue tracker');
-  assert.match(last, /github\.com\/abap2UI5\/abap2UI5\/issues/);
-  assert.match(last, /communityinviter\.com/);
+  assert.equal(ways.length, 5, 'five ways, each led by what it is');
+  /* Every way says where to do it, and the four places are not
+     interchangeable: two to answer somebody in, two to say it out loud. */
+  assert.match(last, /communityinviter\.com/, 'Slack');
+  assert.match(last, /github\.com\/abap2UI5\/abap2UI5\/issues/, 'the issue tracker');
+  assert.match(last, /linkedin\.com\/company\/abap2ui5/, 'the project page a post can mention');
+  assert.match(last, /community\.sap\.com/, 'the SAP Community');
+  assert.match(last, /#abap2UI5/, 'and the tag that collects those posts');
+  assert.match(last, /\]\(\/resources\/references\)/, 'where what is written about it lands');
+  assert.match(last, /\]\(\/resources\/who_uses\)/, 'and the list a company can put itself on');
 });
 
 /* The stylesheet is written twice - scripts/site-css/docs.css for the site the

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -158,9 +158,13 @@ test('the front door\'s cost card leads here, and the page ends on the four ways
   assert.match(last, /\]\(\/resources\/sponsor\)/, 'the last section is the one that asks');
   assert.match(last, /open-source/i);
   const ways = (last.match(/^- \*\*/gm) || []);
-  assert.equal(ways.length, 5, 'five ways, each led by what it is');
+  assert.equal(ways.length, 10, 'ten ways, each led by what it is and each one thing to do');
+  for (const way of last.split('\n').filter((l) => l.startsWith('- **'))) {
+    assert.match(way, /\]\(/, `${way.slice(0, 28)}… says where to do it`);
+  }
   /* Every way says where to do it, and the four places are not
-     interchangeable: two to answer somebody in, two to say it out loud. */
+     interchangeable: two to answer somebody in, two to say it out loud. And
+     every way carries a link, because a way without one is a wish. */
   assert.match(last, /communityinviter\.com/, 'Slack');
   assert.match(last, /github\.com\/abap2UI5\/abap2UI5\/issues/, 'the issue tracker');
   assert.match(last, /linkedin\.com\/company\/abap2ui5/, 'the project page a post can mention');


### PR DESCRIPTION
Two commits on the cost calculator.

## The sheet closes on its own note

The formula sentence was a paragraph under the answer, in the same weight as
the sliders above it. It is the sheet's last line now — inside the same
border, across the grid, on a hairline under the three figures, at the size of
a caption. One box: three numbers, and the reason they are all the same
character.

## Ten ways, each one thing to do, each with a link

The four ways were four different sizes of ask — one a click, one *write a
blog post*, one money — and the long ones had grown three sentences and four
links while the short ones had one. A reader picking something to do compares
them, so they are the same size now: ten, between 94 and 114 characters, each
led by its verb, each carrying the link that starts it.

Splitting the big ones made the room:

- *Send what you built* was a bug report, a sample and a pull request in one
  line → **Report what broke** (an issue with a class that reproduces it),
  **Send a screen you built** (a class in samples), **Pick up something small**
  (the contribution list, which starts at *a missing property on a control*).
- *Say that it exists* was a blog post, a talk, LinkedIn and the SAP Community
  → **Post about it** (the page to mention, **#abap2UI5** as the tag, the
  references it lands in) and **Write it up** (one article, for the people who
  have the problem you just solved).

Two are new and cost nothing: **Star the repository**, and **Fix a line in
these docs** — every page carries an *Edit this page* link, and typos count.
One more was asked for and is in: **Add your company** to
[Who Uses abap2UI5?](https://abap2ui5.github.io/docs/resources/who_uses).

The order runs from a click to money, which is also what they cost. Nine of
them cost an evening, and the intro says so.

Also fixed on the way: `.cost-give ul li strong` made **every** strong a block,
so **#abap2UI5** sat on a line of its own mid-sentence. Only the lead is a
block now.

Rules go into both stylesheets, as the pair `test/cost-calculator` requires.
The pin follows: ten ways, and every one of them has to name where to do it —
a way without a link is a wish.

Checked in a browser against the built site, light and dark and at 390px.

## Gates

Green: `test` (236), `docs:build`, `check:cross-site`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_