### PR TITLE
Two more ways: a link that needs no system, and the control nobody has ported

### DIFF
--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -49,14 +49,16 @@ Set the sliders to your landscape, tick your systems and your support, pick a cu
 
 Keep in mind that those zeros were written in somebody's evenings - the release you will pull next month, the answer under your issue, the 7.02 downport nobody asked for. That part of the bill is real; it is just not addressed to you.
 
-And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back - nine that cost an evening, and one that costs money:
+And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back - eleven that cost an evening, and one that costs money:
 
 - **Star the repository.** One click on [GitHub](https://github.com/abap2UI5/abap2UI5), and the next visitor sees a project rather than an experiment.
 - **Answer somebody.** One reply in [Slack](https://communityinviter.com/apps/abapgit/abap) can save the next person an afternoon of searching for it.
+- **Show it to somebody.** The [playground](https://abap2ui5.github.io/playground/) runs a class in a browser - no system, no install, one link.
 - **Report what broke.** An [issue](https://github.com/abap2UI5/abap2UI5/issues) with a class that reproduces the problem is half of the fix already.
 - **Send a screen you built.** A class in [samples](https://github.com/abap2UI5/samples) is what the next developer copies instead of inventing it.
+- **Add a control.** [samples-controls](https://github.com/abap2UI5/samples-controls) is one app per UI5 control, and some of them are still missing.
+- **Pick up something small.** The [contribution list](/resources/contribution) starts at *one property on the view builder* - no project required.
 - **Fix a line in these docs.** Every page carries an *Edit this page* link into [the repository](https://github.com/abap2UI5/docs), and typos count.
-- **Pick up something small.** The [contribution list](/resources/contribution) starts at *a missing property on a control* - no project required.
 - **Post about it.** Mention [the page](https://www.linkedin.com/company/abap2ui5) on LinkedIn, tag it **#abap2UI5**, and it lands in the [references](/resources/references).
 - **Write it up.** One article in the [SAP Community](https://community.sap.com/) reaches everybody who has the problem you just solved.
 - **Add your company.** One row in [Who Uses abap2UI5?](/resources/who_uses) is what answers *is anybody actually running this?*

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -158,7 +158,7 @@ test('the front door\'s cost card leads here, and the page ends on the four ways
   assert.match(last, /\]\(\/resources\/sponsor\)/, 'the last section is the one that asks');
   assert.match(last, /open-source/i);
   const ways = (last.match(/^- \*\*/gm) || []);
-  assert.equal(ways.length, 10, 'ten ways, each led by what it is and each one thing to do');
+  assert.equal(ways.length, 12, 'twelve ways, each led by what it is and each one thing to do');
   for (const way of last.split('\n').filter((l) => l.startsWith('- **'))) {
     assert.match(way, /\]\(/, `${way.slice(0, 28)}… says where to do it`);
   }


### PR DESCRIPTION
## What changed

Two ways join the panel on the cost calculator, in the same shape as the ten
already there — one verb, one link, one thing to do.

- **Show it to somebody.** *The [playground](https://abap2ui5.github.io/playground/)
  runs a class in a browser - no system, no install, one link.* It sits with
  the ways that spread the word rather than the ways that write code, because
  that is what sending it is: the cheapest way there is to explain what this
  project does, with no appointment and nothing to install at the other end.
- **Add a control.** *[samples-controls](https://github.com/abap2UI5/samples-controls)
  is one app per UI5 control, and some of them are still missing.* The code way
  that names a gap rather than a wish — the controls nobody has ported yet are
  visible from the outside.

So the two do not describe the same afternoon, the contribution line beside it
now starts at *one property on the view builder* rather than *a missing
property on a control*.

Twelve now, six rows of two, still between 94 and 114 characters each and
still one link apiece. The intro counts again: eleven cost an evening, one
costs money. The pin follows.

The playground link is the first cross-site link on this page, and
`check:cross-site` counts it — 353 links out of 182 pages, all of them opting
out of the router.

Checked in a browser against the built site, light and dark and at 390px.

## Gates

Green: `test` (236), `docs:build`, `check:cross-site`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_