### PR TITLE
Eleven articles stop being islands, where one of them stands on another

### DIFF
--- a/docs/advanced/insights/06-the-frontend-knows-nothing.md
+++ b/docs/advanced/insights/06-the-frontend-knows-nothing.md
@@ -10,8 +10,9 @@ whether it is currently showing a table, a form or a wizard, and it has no idea
 which action follows the next click. Open the network tab and you can watch it
 find out.
 
-Everything it needs arrives per request. Everything it decides is decided on
-the server.
+Everything it needs arrives per request — the two strings of
+[#5](/advanced/insights/05-ui5-over-the-wire). Everything it decides is decided
+on the server.
 
 The pattern has a name: a **Hypermedia-Driven Application**. Between the
 multi-page app, where every interaction fetches a whole document, and the

--- a/docs/advanced/insights/07-one-handler-for-every-app.md
+++ b/docs/advanced/insights/07-one-handler-for-every-app.md
@@ -23,7 +23,8 @@ Gateway. The stack fits on a screenshot.
 The reason it can be generic is that nothing about the data is agreed in
 advance. In an OData conversation the metadata comes first and fixes the shape;
 data follows within that shape for the rest of the session. Here the model
-travels **with** every response, so each response may carry a different one.
+travels **with** every response — [#5](/advanced/insights/05-ui5-over-the-wire) —
+so each response may carry a different one.
 There is no contract to violate because there is no contract to register.
 
 ## How Much Handler That Is

--- a/docs/advanced/insights/08-only-the-changed-part.md
+++ b/docs/advanced/insights/08-only-the-changed-part.md
@@ -1,6 +1,7 @@
 # #8 Only the Changed Part
 
-If the backend sends the view on every request, does the screen rebuild itself
+If the backend sends the view on every request —
+[#5](/advanced/insights/05-ui5-over-the-wire) — does the screen rebuild itself
 on every click?
 
 It would, and the user would notice within about two seconds. A rebuilt view is

--- a/docs/advanced/insights/11-no-build-no-deploy-no-cache.md
+++ b/docs/advanced/insights/11-no-build-no-deploy-no-cache.md
@@ -30,8 +30,9 @@ standard transport system moves it to production like any other ABAP object.
 There is no state in which the backend is live and the frontend is not — which
 is the state most Fiori incidents are actually about.
 
-**No cache to invalidate.** The UI is built on every request, so there is no
-build output that can be stale. Nobody runs a cache transaction, nobody asks a
+**No cache to invalidate.** The UI is built on every request
+([#5](/advanced/insights/05-ui5-over-the-wire)), so there is no build output
+that can be stale. Nobody runs a cache transaction, nobody asks a
 colleague to hard-refresh, and a change that does not appear is a change that
 was not activated.
 

--- a/docs/advanced/insights/13-four-verbs-every-control.md
+++ b/docs/advanced/insights/13-four-verbs-every-control.md
@@ -25,7 +25,8 @@ attribute, `end` goes back up. Four methods, and you now know the entire API.
 
 Nothing in there names a control, which is exactly why every control is
 reachable — including the ones released last month and the ones nobody has
-wrapped. The builder cannot be behind UI5, because it never knew what UI5
+wrapped. The vocabulary stays UI5's own, which is
+[#4](/advanced/insights/04-no-annotation-in-between). The builder cannot be behind UI5, because it never knew what UI5
 contains.
 
 The trade is honest: the completion list is gone. What replaced it is not

--- a/docs/advanced/insights/24-abap-unit-for-a-screen.md
+++ b/docs/advanced/insights/24-abap-unit-for-a-screen.md
@@ -9,8 +9,8 @@ include. That is the whole story here, and the reason it stays that short is a
 decision in the app rather than in the framework: **the logic does not touch
 `client`.**
 
-`main( )` dispatches. The methods it dispatches to read data, decide, and
-change attributes. Only `view_display( )` and the message calls need the
+`main( )` dispatches — [#16](/advanced/insights/16-one-click-one-request). The
+methods it dispatches to read data, decide, and change attributes. Only `view_display( )` and the message calls need the
 client, so a test calls the other methods directly and looks at the attributes
 afterwards:
 

--- a/docs/advanced/insights/30-on-stack-or-side-by-side.md
+++ b/docs/advanced/insights/30-on-stack-or-side-by-side.md
@@ -15,8 +15,10 @@ maintenance slots, its change freeze in December.
 
 **Side-by-side** means the app runs on the SAP BTP ABAP Environment and calls
 the S/4 system remotely — released OData, RFC or SOAP services. Everything on
-the BTP side is Level A by construction, and it works against S/4HANA Public
-Cloud, where on-stack custom code is not an option at all.
+the BTP side is Level A by construction — the levels are
+[#29](/advanced/insights/29-when-the-api-is-not-released) — and it works
+against S/4HANA Public Cloud, where on-stack custom code is not an option at
+all.
 
 ![The apps run on the SAP BTP ABAP Environment and call released remote APIs of S/4HANA](/advanced/use_cases/side_by_side_level_a.svg){ width=90% }
 

--- a/docs/advanced/insights/31-one-app-many-systems.md
+++ b/docs/advanced/insights/31-one-app-many-systems.md
@@ -1,7 +1,8 @@
 # #31 One App, Many Systems
 
-A side-by-side app already runs outside the system it serves. Which invites a
-question worth asking out loud: how many systems can it serve?
+A side-by-side app ([#30](/advanced/insights/30-on-stack-or-side-by-side))
+already runs outside the system it serves. Which invites a question worth
+asking out loud: how many systems can it serve?
 
 More than one. The app lives on the SAP BTP ABAP Environment and reaches each
 S/4 system through its released APIs, so the connection is configuration rather

--- a/docs/advanced/insights/33-rap-or-abap2ui5.md
+++ b/docs/advanced/insights/33-rap-or-abap2ui5.md
@@ -27,8 +27,9 @@ choosing the harder road for no prize.
 **Reach for abap2UI5 when the screen is the deliverable.** One consumer, one
 purpose, and often a short life: an operations tool, a correction screen, a
 form somebody needs by Thursday, a dashboard for one team. Also whenever the
-shape is not known until runtime — a table whose columns come from RTTI — or
-when the screen needs a control the annotation vocabulary does not reach. And
+shape is not known until runtime — a table whose columns come from RTTI,
+[#1](/advanced/insights/01-somewhere-on-the-way-to-ui5) — or when the screen
+needs a control the annotation vocabulary does not reach. And
 on an older release, where RAP is not available at all.
 
 **The two are not exclusive, and this is the part worth remembering.** An

--- a/docs/advanced/insights/34-freestyle-or-abap2ui5.md
+++ b/docs/advanced/insights/34-freestyle-or-abap2ui5.md
@@ -41,8 +41,9 @@ release to coordinate — for a screen whose logic never left the server in the
 first place.
 
 The practical tiebreaker is usually iteration speed against client richness.
-Change a class, activate, refresh — no build, no cache, no deployment — is
-worth a great deal for internal applications, and worth exactly nothing for an
+Change a class, activate, refresh — no build, no cache, no deployment,
+[#11](/advanced/insights/11-no-build-no-deploy-no-cache) — is worth a great
+deal for internal applications, and worth exactly nothing for an
 app that has to work on a tablet in a warehouse with no signal.
 
 What is left after the edges is still most business software: forms, tables,

--- a/docs/advanced/insights/36-written-for-agents.md
+++ b/docs/advanced/insights/36-written-for-agents.md
@@ -11,8 +11,9 @@ system. An agent writing a freestyle app has to hold an ABAP backend and a
 JavaScript frontend in its head at once and keep the contract between them
 true.
 
-An agent writing an abap2UI5 app writes one file, in one language, and the
-thing it writes is the thing that runs.
+An agent writing an abap2UI5 app writes one file, in one language — the shape
+of [#14](/advanced/insights/14-a-classrun-for-the-browser) — and the thing it
+writes is the thing that runs.
 
 Three things around the framework turn that from a nice property into a working
 setup.


### PR DESCRIPTION
## What this is

A read of all 36 Insights articles against each other, after the hand edits of
the last days.

**What holds:** headings, index rows and sidebar entries agree for all 36,
every article signs off, and every name the prose uses is live in the
framework rather than in the frozen package — `z2ui5_t_01`, the exit's
`check_hide_error_details`, `draft_exp_time_in_hours` and `custom_js`, the
client's `popup_destroy`, `set_title_launchpad` and `check_launchpad_active`.

**What the read found** is the shape of the series rather than a fault in it:
seventeen of the 36 had no link in and no link out, four of them carrying an
argument another article rests on. Where the dependency is real, it now has a
link:

| | |
|---|---|
| #6, #7, #8, #11 → #5 | the two strings they all assume |
| #13 → #4 | the vocabulary that is UI5's own |
| #24 → #16 | the dispatch a test calls into |
| #30 → #29 | the levels it uses as a unit |
| #31 → #30 | the side-by-side app it starts from |
| #33 → #1 | the runtime-typed table it names |
| #34 → #11 | the loop its tiebreaker is about |
| #36 → #14 | one class, one method, one file |

Six are still islands — #12, #15, #17, #26, #27, #32 — and stay that way: none
of them leans on another article to make its point, and a link that is
decoration is a link a reader learns to skip.

## Gates

Green: `test` (236), `docs:build`, `check:examples`, `check:conventions`,
`check:playground`, `check:api-names`, `check:cross-site`, `check:samples`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_