### PR TITLE
The calculator counts its own ways again, #1 is a coffee, and #2 ends on a claim

### DIFF
--- a/docs/advanced/insights/01-somewhere-on-the-way-to-ui5.md
+++ b/docs/advanced/insights/01-somewhere-on-the-way-to-ui5.md
@@ -14,58 +14,51 @@ cl_salv_table=>factory( IMPORTING r_salv_table = DATA(lo_alv)
 lo_alv->display( ).
 ```
 
-Two statements, any internal table, no type known at design time. RTTS reads
-the structure at runtime, the field catalog follows from it, DDIC labels come
-along for free.
+Two statements, any internal table, no type known at design time: RTTS reads
+the structure at runtime, the field catalog follows, DDIC labels come along for
+free.
 
-Data browsers, table maintenance, migration cockpits, generic reports — a whole
-category of tooling was built that way, and the generality was the requirement,
-not a trick. Then the screens moved to the browser, and that trick quietly
-stopped working.
+Data browsers, table maintenance, migration cockpits, generic reports — a
+whole category of tooling was built that way, and the generality was the
+requirement, not a trick. Then the screens moved to the browser.
 
 ## Model Definition at Design Time — OData
 
-When you build a UI5 app today, the path from backend to frontend goes through
-a typed OData service. That holds for freestyle UI5, for Fiori Elements, and
-for a fully backend-driven RAP application with a consumption view. The shape
-of the model is decided when the code is written and baked into the contract.
+Build a UI5 app today and the path from backend to frontend goes through a
+typed OData service — in freestyle UI5, in Fiori Elements, in a RAP
+application with a consumption view. The shape of the model is decided when
+the code is written, and baked into the contract.
 
-And that is powerful! The point of OData is that a client can trust the API and
-discover everything it needs from the metadata document — it does not have to
-know SAP at all. Whenever you do not know the client, or the client does not
-know your backend, that contract is exactly what you want.
+And that is powerful: a client can trust the API and discover everything it
+needs from the metadata document, without knowing SAP at all. Whenever you do
+not know the client, that is exactly what you want.
 
-But it does mean the entity type has to exist before the data does. Which is
+It does mean the entity type has to exist before the data does — which is
 awkward when the entity type *is* the question.
 
 ## Model Definition at Runtime — RTTS
 
-Because some use cases do not know the model at design time either. Think of
-SE16 or SE16N again: the whole point is to display any table.
+SE16 is exactly that case: the whole point is to display any table, so the
+contract buys nothing. Backend and frontend are tightly coupled, one team
+builds both, and anything resting on design-time metadata is aimed at a
+different problem.
 
-There the contract buys nothing. Backend and frontend are tightly coupled, one
-team builds both, and the client knows the system intimately — anything resting
-on design-time metadata is aimed at a different problem.
-
-The model is assembled at runtime, and in ABAP that has always been RTTS, a
-service nearly every ABAP developer already knows without necessarily knowing
-the acronym (the reading half is RTTI):
+The model is assembled at runtime instead, and in ABAP that has always been
+RTTS — a service nearly every ABAP developer already uses without necessarily
+knowing the acronym (the reading half is RTTI):
 
 ![Design time: the entity type is declared before any data exists. Runtime: RTTS reads the shape from the data that is there.](/insights/01-runtime-model.svg)
 
 *Design time: the entity type is declared before any data exists. Runtime: RTTS reads the shape from the data that is there.*
 
-So the structure is available. The question is how it gets into a UI5 app.
-
-Luckily, UI5 apps do not actually require OData — a `JSONModel` can be filled
+So the structure is there — and reaching a UI5 app with it is easier than it
+looks, because UI5 does not require OData at all. A `JSONModel` can be filled
 from any plain HTTP endpoint, so nothing stops a request from carrying a
 different model shape every time.
 
-And that is one of the use cases abap2UI5 is built for.
-
 ## Data Binding at Runtime with abap2UI5
 
-In abap2UI5, views are just strings the application builds, and the model is
+In abap2UI5 the view is a string the application builds, and the model is
 bound from ABAP data — including data whose type only exists at runtime. A view
 that draws any table looks like this:
 
@@ -103,34 +96,24 @@ METHOD render_any.
 ENDMETHOD.
 ```
 
-Read it once more and notice what is missing: no entity type, no CDS view, no
-service binding — and not a single field name anywhere in the view. The columns
-are whatever the table happens to have, and the binding paths are the component
-names RTTI just handed back. Go one step further and `comp-type` will tell you
-whether a component is a DDIC type, which is where the real labels come from —
-the field catalog, rebuilt from the same source it always came from.
+Notice what is missing: no entity type, no CDS view, no service binding — and
+not a single field name anywhere in the view. The columns are whatever the
+table happens to have, and the binding paths are the component names RTTI
+handed back. `comp-type` says whether a component is a DDIC type, which is
+where the real labels live — the field catalog, rebuilt from its own source.
 
 Full source:
 [`Z2UI5_CL_SMP_APP_497`](https://github.com/abap2UI5/samples/blob/main/src/01/z2ui5_cl_smp_app_497.clas.abap),
 one of the abap2UI5 samples, so it is compiled and linted on every commit.
 
 A table nobody described, drawn from whatever the data turned out to be.
-Doesn't that look a bit like `cl_salv_table` in a UI5 view? 😉
+Doesn't that look a bit like `cl_salv_table` in a UI5 view? 😉 How far it goes
+is the [se16n addon](https://github.com/abap2UI5-addons/se16n), a full
+SE16-flavored app built on exactly this.
 
-If you want to see how far this goes, there is a full SE16-flavored app built
-on it — the [se16n addon](https://github.com/abap2UI5-addons/se16n).
-
-## Nothing Here Is Exotic
-
-That is the part worth dwelling on, because "generic UI" usually sounds like a
-warning. Both halves stay inside the conventions you already work in, which is
-what makes this cheap to adopt and cheap to hand over.
-
-The frontend is a freestyle UI5 app using `sap.m` controls, XML views, a
-`JSONModel` and two-way binding — nothing proprietary, and nothing you have not
-written before. The backend is a global ABAP class: one interface, in a
-package, traveling in a transport, compiling on ABAP Standard and ABAP Cloud
-alike.
+Nothing in either half is exotic, which is what makes it cheap to hand over:
+the frontend is a freestyle UI5 app with `sap.m` controls and a `JSONModel`,
+and the backend is a global ABAP class in a package, traveling in a transport.
 
 ## What It Costs
 
@@ -140,23 +123,17 @@ locally defined structure gets technical names instead of labels.
 
 So this is not an upgrade over a typed service. One answers what a foreign
 system can depend on for the next five years; the other, what an internal tool
-should show a user right now, given a structure it was handed a millisecond
-ago. Different questions, and it is worth being clear about which one you have.
+should show right now, given a structure it was handed a millisecond ago.
 
 ## Conclusion
 
 RTTS never went away. `cl_abap_structdescr` is still there, and it is released
 in ABAP Cloud too. Only the screen in front of it went missing.
 
-abap2UI5 gives runtime-typed ABAP a UI5 face again by binding ABAP data
-directly, so data typed at runtime stops being a special case. It is just data
-— the way it was in the old SALV and field-catalog days.
+abap2UI5 gives runtime-typed ABAP a UI5 face again by binding the data
+directly, so a structure that exists only at runtime stops being a special
+case. It is just data — the way it was in the old SALV and field-catalog days.
 
-abap2UI5 is open source, runs on-premise and in the cloud, and sits beside what
-you already operate. Put an abap2UI5 app into the launchpad and no user can
-tell it from the RAP and freestyle UI5 tiles next to it.
-
-So next time you reach for RTTS and need a UI, give abap2UI5 a try. It may be
-a good complement to the UI5 solutions you already run.
+So next time you reach for RTTS and need a screen, give abap2UI5 a try.
 
 Happy ABAPing! 🦖🦕🦣

--- a/docs/advanced/insights/02-the-cost-of-a-screen.md
+++ b/docs/advanced/insights/02-the-cost-of-a-screen.md
@@ -125,4 +125,6 @@ screen somebody needs exactly once.
 
 Install it with abapGit and give it a try!
 
+A screen that costs one class is a screen that gets built.
+
 Happy ABAPing! 🦖🦕🦣

--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -49,15 +49,15 @@ Set the sliders to your landscape, tick your systems and your support, pick a cu
 
 Keep in mind that those zeros were written in somebody's evenings - the release you will pull next month, the answer under your issue, the 7.02 downport nobody asked for. That part of the bill is real; it is just not addressed to you.
 
-And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back - eleven that cost an evening, and one that costs money:
+And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back - eight that cost an evening, and one that costs money:
 
 - **Star the repository.** One click on [GitHub](https://github.com/abap2UI5/abap2UI5), and the next visitor sees a project rather than an experiment.
-- **Answer somebody.** One reply on an [issue](https://github.com/abap2UI5/abap2UI5/issues) or in [Slack](https://communityinviter.com/apps/abapgit/abap) can save the next person an afternoon of searching for it.
+- **Answer somebody.** One reply under an [issue](https://github.com/abap2UI5/abap2UI5/issues) or in [Slack](https://communityinviter.com/apps/abapgit/abap) saves the next person an afternoon of searching.
 - **Show it to somebody.** The [playground](https://abap2ui5.github.io/playground/) runs a class in a browser - no system, no install, one link.
 - **Report what broke.** An [issue](https://github.com/abap2UI5/abap2UI5/issues) with a class that reproduces the problem is half of the fix already.
 - **Fix a line in these docs.** Every page carries an *Edit this page* link into [the repository](https://github.com/abap2UI5/docs), and typos count.
-- **Post about it.** Mention [the page](https://www.linkedin.com/company/abap2ui5) on LinkedIn, tag it **#abap2UI5**, and it lands in the [references](/resources/references).
-- **Write it up.** One article in the [SAP Community](https://community.sap.com/) or on [LinkedIn](https://www.linkedin.com/company/abap2ui5) reaches everybody who has the problem you just solved.
+- **Post about it.** A short post that mentions [the page](https://www.linkedin.com/company/abap2ui5) and carries **#abap2UI5** lands in the [references](/resources/references).
+- **Write it up.** A full article, in the [SAP Community](https://community.sap.com/) or on [LinkedIn](https://www.linkedin.com/company/abap2ui5), reaches everybody who had your problem.
 - **Add your company.** One row in [Who Uses abap2UI5?](/resources/who_uses) is what answers *is anybody actually running this?*
 - **Sponsor the work.** [The contributors](/resources/sponsor), and the open-source projects it stands on - the smallest amount is a real one.
 

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -158,7 +158,7 @@ test('the front door\'s cost card leads here, and the page ends on the four ways
   assert.match(last, /\]\(\/resources\/sponsor\)/, 'the last section is the one that asks');
   assert.match(last, /open-source/i);
   const ways = (last.match(/^- \*\*/gm) || []);
-  assert.equal(ways.length, 12, 'twelve ways, each led by what it is and each one thing to do');
+  assert.equal(ways.length, 9, 'nine ways, each led by what it is and each one thing to do');
   for (const way of last.split('\n').filter((l) => l.startsWith('- **'))) {
     assert.match(way, /\]\(/, `${way.slice(0, 28)}… says where to do it`);
   }
@@ -172,6 +172,14 @@ test('the front door\'s cost card leads here, and the page ends on the four ways
   assert.match(last, /#abap2UI5/, 'and the tag that collects those posts');
   assert.match(last, /\]\(\/resources\/references\)/, 'where what is written about it lands');
   assert.match(last, /\]\(\/resources\/who_uses\)/, 'and the list a company can put itself on');
+  /* The intro counts the ways, so it goes stale the moment one is added or
+     taken out - which is exactly how it went stale. All but one cost an
+     evening; that one is the money. */
+  const said = last.match(/- (\w+) that cost an evening, and one that costs money/);
+  const words = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven',
+                 'eight', 'nine', 'ten', 'eleven', 'twelve'];
+  assert.ok(said, 'the intro says how many ways there are');
+  assert.equal(said[1], words[ways.length - 1], `${ways.length} ways, so the intro says ${words[ways.length - 1]} plus the one that costs money`);
 });
 
 /* The stylesheet is written twice - scripts/site-css/docs.css for the site the


### PR DESCRIPTION
## main is red, and this is why

`npm test` has been failing on `main` since the calculator was edited by hand:
three ways were taken out — the sample, the control, the contribution list —
and the pin from #292 still expected twelve. **9 !== 12.** Every run since has
failed on it, `main` included, which is what the deploy runs before it
publishes.

The pin follows the page: nine.

Two things drifted with those three ways:

- The intro still counted *eleven that cost an evening* for a list of nine. It
  says **eight** now — and the count is pinned against the number of ways,
  because a number written in prose beside a list it does not own is exactly
  the thing that goes stale unwatched. It just did.
- LinkedIn was named in two ways after the edit. That reads as meant rather
  than as a duplicate now: a **post** that mentions the page and carries the
  tag, an **article** in the SAP Community or on LinkedIn.

## Article #1 is a coffee again

1,025 words of prose against a series median of 402 — the heaviest article in
the series standing at the front door, on a page that promises one coffee.

826 now, and nothing it claimed is gone. What went is the second telling:
*Nothing Here Is Exotic* said what #3, #5 and #27 each say in full and is one
sentence now; the OData and RTTS sections make their point once; and the
conclusion stops before the paragraph that sells the launchpad, which is #26's
subject.

## Article #2 ends on a claim

Every other article in the series closes on one line between the last
paragraph and the sign-off. #2 now has one too:

> A screen that costs one class is a screen that gets built.

The invitation the last edit put there stays where it is, above it.

## Gates

Green: `test` (236), `docs:build`, `check:cross-site`, `check:examples`,
`check:conventions`, `check:playground`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_