### PR TITLE
#2 points back to #1, and its teaser is rewritten around the ALV it replaces

### DIFF
--- a/blog/teaser-posts.md
+++ b/blog/teaser-posts.md
@@ -34,29 +34,28 @@ attached article preview, so the post carries no inline URL. 744 characters.
 ## The Cost of a Screen
 
 Plain text — LinkedIn renders no markdown. The article link comes from the
-attached article preview, so the post carries no inline URL. 1257 characters.
+attached article preview, so the post carries no inline URL. 1143 characters,
+and the first paragraph is 135 of them: what stands above LinkedIn's fold.
 
 > Small applications in ABAP are still built the way they always were: a
-> selection screen, a SELECT, an ALV grid. And honestly - why not. It takes an
-> afternoon.
+> selection screen, a SELECT, an ALV grid. And honestly - why not.
 >
-> A maintenance view for a customizing table nobody wants to explain in SM30
-> again. A cockpit showing what last night's job did. An approval step for one
-> department, four people, twice a year. A correction screen somebody needs
-> exactly once, during a go-live.
+> It takes an afternoon. A cockpit showing what last night's job did. An
+> approval step for one department, four people, twice a year. A correction
+> screen somebody needs exactly once, during a go-live.
 >
-> Building any of those in UI5 is a different afternoon: a data model, a
-> service, a binding, an annotation model, a frontend project, a deployment -
-> and every one of those objects then exists forever. So the ALV stays.
+> Building any of those in UI5 is different: a data model, a service, a
+> binding, an annotation model, a frontend project, a deployment - and every
+> one of those objects then exists forever. So the ALV stays.
 >
 > New article 🎉 The same job monitor as a complete abap2UI5 app: one ABAP
 > class, activate, call the endpoint. About as much work as the ALV, except
 > this one follows the Fiori design guidelines and starts on your phone too.
 >
 > abap2UI5 is open source, MIT licensed, and it runs on the UI5 and the ABAP
-> your system already has: one abapGit pull, nothing to license, nothing to
-> deploy beside it. A perfect complement to the RAP and freestyle UI5 apps you
-> already run - for the screens nobody would start a project for.
+> your system already has: one abapGit pull, nothing to deploy beside it. A
+> perfect complement to the RAP and freestyle UI5 apps you already run — for
+> the screens nobody would start a project for.
 >
 > Which of your ALV grids would you hand to a user as a Fiori app, if it cost
 > you one class?

--- a/blog/teaser-posts.md
+++ b/blog/teaser-posts.md
@@ -34,19 +34,24 @@ attached article preview, so the post carries no inline URL. 744 characters.
 ## The Cost of a Screen
 
 Plain text — LinkedIn renders no markdown. The article link comes from the
-attached article preview, so the post carries no inline URL. 1143 characters,
-and the first paragraph is 135 of them: what stands above LinkedIn's fold.
+attached article preview, so the post carries no inline URL. 1141 characters,
+and the first line is 111 of them: what stands above LinkedIn's fold, so it
+says the whole thing on its own.
 
 > Small applications in ABAP are still built the way they always were: a
-> selection screen, a SELECT, an ALV grid. And honestly - why not.
+> selection screen, a SELECT, an ALV grid.
 >
-> It takes an afternoon. A cockpit showing what last night's job did. An
-> approval step for one department, four people, twice a year. A correction
-> screen somebody needs exactly once, during a go-live.
+> And honestly - why not.
+>
+> It just takes a few hours to build a cockpit showing what last night's job
+> did. An approval step for one department, four people, twice a year. A
+> correction screen somebody needs exactly once, during a go-live.
 >
 > Building any of those in UI5 is different: a data model, a service, a
-> binding, an annotation model, a frontend project, a deployment - and every
-> one of those objects then exists forever. So the ALV stays.
+> binding, an annotation model, sometimes also a frontend project and a
+> deployment.
+>
+> So the ALV stays.
 >
 > New article 🎉 The same job monitor as a complete abap2UI5 app: one ABAP
 > class, activate, call the endpoint. About as much work as the ALV, except
@@ -60,7 +65,7 @@ and the first paragraph is 135 of them: what stands above LinkedIn's fold.
 > Which of your ALV grids would you hand to a user as a Fiori app, if it cost
 > you one class?
 >
-> #ABAP #SAP #UI5
+> #ABAP #SAP #UI5 #abapGit #abap2UI5
 
 ## abap2UI5 in Your Favorite Programming Model
 

--- a/blog/teaser-posts.md
+++ b/blog/teaser-posts.md
@@ -34,11 +34,11 @@ attached article preview, so the post carries no inline URL. 744 characters.
 ## The Cost of a Screen
 
 Plain text — LinkedIn renders no markdown. The article link comes from the
-attached article preview, so the post carries no inline URL. 1024 characters.
+attached article preview, so the post carries no inline URL. 1257 characters.
 
-> Small applications in ABAP are still built the way they have always been
-> built: a selection screen, a SELECT, an ALV grid. And honestly - why not. It
-> takes an afternoon.
+> Small applications in ABAP are still built the way they always were: a
+> selection screen, a SELECT, an ALV grid. And honestly - why not. It takes an
+> afternoon.
 >
 > A maintenance view for a customizing table nobody wants to explain in SM30
 > again. A cockpit showing what last night's job did. An approval step for one
@@ -47,12 +47,16 @@ attached article preview, so the post carries no inline URL. 1024 characters.
 >
 > Building any of those in UI5 is a different afternoon: a data model, a
 > service, a binding, an annotation model, a frontend project, a deployment -
-> and every one of those objects then exists forever. So the ALV stays, and
-> everyone agrees to stop thinking about it.
+> and every one of those objects then exists forever. So the ALV stays.
 >
 > New article 🎉 The same job monitor as a complete abap2UI5 app: one ABAP
 > class, activate, call the endpoint. About as much work as the ALV, except
 > this one follows the Fiori design guidelines and starts on your phone too.
+>
+> abap2UI5 is open source, MIT licensed, and it runs on the UI5 and the ABAP
+> your system already has: one abapGit pull, nothing to license, nothing to
+> deploy beside it. A perfect complement to the RAP and freestyle UI5 apps you
+> already run - for the screens nobody would start a project for.
 >
 > Which of your ALV grids would you hand to a user as a Fiori app, if it cost
 > you one class?

--- a/blog/teaser-posts.md
+++ b/blog/teaser-posts.md
@@ -34,27 +34,28 @@ attached article preview, so the post carries no inline URL. 744 characters.
 ## The Cost of a Screen
 
 Plain text — LinkedIn renders no markdown. The article link comes from the
-attached article preview, so the post carries no inline URL. 1006 characters.
+attached article preview, so the post carries no inline URL. 1024 characters.
 
+> Small applications in ABAP are still built the way they have always been
+> built: a selection screen, a SELECT, an ALV grid. And honestly - why not. It
+> takes an afternoon.
+>
 > A maintenance view for a customizing table nobody wants to explain in SM30
 > again. A cockpit showing what last night's job did. An approval step for one
-> department. Some of these run during a go-live and are never started again.
+> department, four people, twice a year. A correction screen somebody needs
+> exactly once, during a go-live.
 >
-> The logic behind such a screen might be thirty lines. The user interface in
-> front of it is not, and it does not scale down with the logic: a data model, a
-> service, a binding, an annotation model, a frontend artifact, a deployment -
-> and every one of those objects then exists forever.
+> Building any of those in UI5 is a different afternoon: a data model, a
+> service, a binding, an annotation model, a frontend project, a deployment -
+> and every one of those objects then exists forever. So the ALV stays, and
+> everyone agrees to stop thinking about it.
 >
-> So the screen does not get built. Or it becomes a selection screen and an ALV
-> grid, and everyone agrees to stop thinking about it. Every system has a Z
-> package full of them.
+> New article 🎉 The same job monitor as a complete abap2UI5 app: one ABAP
+> class, activate, call the endpoint. About as much work as the ALV, except
+> this one follows the Fiori design guidelines and starts on your phone too.
 >
-> New article 🎉 The job monitor instead, as a complete abap2UI5 app - one class,
-> nothing else. About as much work as an ALV, except this one follows the Fiori
-> design guidelines and starts on your phone too.
->
-> Which screen in your system stayed an ALV grid because a proper UI was never
-> worth the effort?
+> Which of your ALV grids would you hand to a user as a Fiori app, if it cost
+> you one class?
 >
 > #ABAP #SAP #UI5
 

--- a/blog/teaser-posts.md
+++ b/blog/teaser-posts.md
@@ -33,22 +33,25 @@ attached article preview, so the post carries no inline URL. 744 characters.
 
 ## The Cost of a Screen
 
-Plain text — LinkedIn renders no markdown.
+Plain text — LinkedIn renders no markdown. The article link comes from the
+attached article preview, so the post carries no inline URL. 1006 characters.
 
-> A maintenance view for a customizing table. A cockpit showing what last
-> night's job did. An approval step for one department.
+> A maintenance view for a customizing table nobody wants to explain in SM30
+> again. A cockpit showing what last night's job did. An approval step for one
+> department. Some of these run during a go-live and are never started again.
 >
-> The logic behind each is about thirty lines. The cost of putting a UI in front
-> of thirty lines is not thirty lines, and it does not scale down: a data model,
-> a service, a binding, a frontend artifact, a deployment — and an object that
-> has to be transported, survive upgrades, and one day be deprecated by someone
-> who never met the department that asked for it.
+> The logic behind such a screen might be thirty lines. The user interface in
+> front of it is not, and it does not scale down with the logic: a data model, a
+> service, a binding, an annotation model, a frontend artifact, a deployment -
+> and every one of those objects then exists forever.
 >
-> So the screen never gets built. Every system has a Z package full of the ones
-> that became a selection screen and an ALV grid instead.
+> So the screen does not get built. Or it becomes a selection screen and an ALV
+> grid, and everyone agrees to stop thinking about it. Every system has a Z
+> package full of them.
 >
-> New article 🎉 with a job monitor as a complete abap2UI5 app — and an honest
-> note on where this is the wrong trade.
+> New article 🎉 The job monitor instead, as a complete abap2UI5 app - one class,
+> nothing else. About as much work as an ALV, except this one follows the Fiori
+> design guidelines and starts on your phone too.
 >
 > Which screen in your system stayed an ALV grid because a proper UI was never
 > worth the effort?

--- a/docs/advanced/insights/02-the-cost-of-a-screen.md
+++ b/docs/advanced/insights/02-the-cost-of-a-screen.md
@@ -128,3 +128,7 @@ Install it with abapGit and give it a try!
 A screen that costs one class is a screen that gets built.
 
 Happy ABAPing! 🦖🦕🦣
+
+*The article before this one:
+[#1 Somewhere on the Way to UI5, We Lost RTTS](/advanced/insights/01-somewhere-on-the-way-to-ui5)
+— a table whose structure is only known at runtime, drawn in UI5.*


### PR DESCRIPTION
## The link under #2

A reader who arrives on *The Cost of a Screen* from a link rather than from
the series page has no way back to the article before it — the sidebar is one
click away on a desk and behind a hamburger on a phone, and neither is where
somebody looks when they have just finished reading.

So the last line of the page names the previous article, with the one-line
description the series index gives it, in the shape #29 already uses for a
trailing note: italic, under the sign-off, out of the way of the argument.

## The teaser for #2

The post in `blog/teaser-posts.md` was written for the article as it stood
several edits ago. It promised *an honest note on where this is the wrong
trade* — the paragraph that has since been taken out twice — and said nothing
about what the article now leads with: that the job monitor is a UI5 app, that
it costs about what an ALV costs, and that it starts on a phone.

It is rewritten around the reader's situation rather than the article's
argument: small applications in ABAP are still a selection screen, a SELECT
and an ALV grid; three screens built exactly that way; what the same screen
costs in UI5; then the article. It ends on what abap2UI5 costs to try — open
source, MIT, running on the UI5 and the ABAP the system already has, one
abapGit pull — which is the objection a reader has at exactly that point.

The wording is the author's, through four rounds. One word is not: *it just
takes some hours* is *a few hours*, which is what the phrase is in English.

1,141 characters, and the first line is 111 — what LinkedIn shows above the
fold, saying the whole thing on its own. The note above the post records that,
because it is the kind of thing a later edit undoes without knowing.

## Gates

Green: `test` (236), `docs:build`, `check:cross-site`, `check:conventions`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_