### PR TITLE
The post spreads the word without saying abap2UI5 twice in one line

### DIFF
--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -52,12 +52,12 @@ Keep in mind that those zeros were written in somebody's evenings - the release 
 And it is payable in a currency you already have. If this page took a line out of a budget, here is what puts a little of it back - eight that cost an evening, and one that costs money:
 
 - **Star the repository.** One click on [GitHub](https://github.com/abap2UI5/abap2UI5), and the next visitor sees a project rather than an experiment.
-- **Answer somebody.** One reply under an [issue](https://github.com/abap2UI5/abap2UI5/issues) or in [Slack](https://communityinviter.com/apps/abapgit/abap) saves the next person an afternoon of searching.
+- **Answer somebody.** One reply under an [issue](https://github.com/abap2UI5/abap2UI5/issues) or in [Slack](https://communityinviter.com/apps/abapgit/abap) saves somebody else an afternoon of searching.
 - **Show it to somebody.** The [playground](https://abap2ui5.github.io/playground/) runs a class in a browser - no system, no install, one link.
 - **Report what broke.** An [issue](https://github.com/abap2UI5/abap2UI5/issues) with a class that reproduces the problem is half of the fix already.
 - **Fix a line in these docs.** Every page carries an *Edit this page* link into [the repository](https://github.com/abap2UI5/docs), and typos count.
-- **Post about it.** A short post that mentions [the page](https://www.linkedin.com/company/abap2ui5) and carries **#abap2UI5** helps to spread the word about abap2UI5. 
-- **Write it up.** A full article, in the [SAP Community](https://community.sap.com/) or on [LinkedIn](https://www.linkedin.com/company/abap2ui5), reaches everybody who had your problem and lands in the [references](/resources/references).
+- **Post about it.** A short post that mentions [the page](https://www.linkedin.com/company/abap2ui5) and carries **#abap2UI5** is how the word gets around.
+- **Write it up.** A full article in the [SAP Community](https://community.sap.com/) or on [LinkedIn](https://www.linkedin.com/company/abap2ui5) reaches the next person, and lands in the [references](/resources/references).
 - **Add your company.** One row in [Who Uses abap2UI5?](/resources/who_uses) is what answers *is anybody actually running this?*
 - **Sponsor the work.** [The contributors](/resources/sponsor), and the open-source projects it stands on - the smallest amount is a real one.
 


### PR DESCRIPTION
## What changed

The hand edit moved the references link from the short post to the article,
which is where it belongs: a post is a mention, an article is the thing the
page collects. That stays. This is the language around it.

| before | after |
|---|---|
| *carries **#abap2UI5** helps to spread the word about abap2UI5.* (plus a trailing space) | *carries **#abap2UI5** is how the word gets around.* — the name stood twice in eleven words |
| *Write it up* had grown to **133** characters, against a list that sits between 96 and 117 | the same claim in **117** |
| *the next person* stood in two of the nine ways | *Answer somebody* now saves **somebody else** an afternoon; the article is what reaches the next person |

The list is back to one band: 96–117 characters, every way with exactly one
place to do it.

## Gates

Green: `test` (236 — the pin holds, `references` is still in the section, just
on another line), `docs:build`, `check:cross-site`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_