### PR TITLE
Seven ways: the playground and the typo go

### DIFF
--- a/docs/resources/cost_calculator.md
+++ b/docs/resources/cost_calculator.md
@@ -53,9 +53,7 @@ And it is payable in a currency you already have. If this page took a line out o
 
 - **Star the repository.** One click on [GitHub](https://github.com/abap2UI5/abap2UI5), and the next visitor sees a project rather than an experiment.
 - **Answer somebody.** One reply under an [issue](https://github.com/abap2UI5/abap2UI5/issues) or in [Slack](https://communityinviter.com/apps/abapgit/abap) saves somebody else an afternoon of searching.
-- **Show it to somebody.** The [playground](https://abap2ui5.github.io/playground/) runs a class in a browser - no system, no install, one link.
 - **Report what broke.** An [issue](https://github.com/abap2UI5/abap2UI5/issues) with a class that reproduces the problem is half of the fix already.
-- **Fix a line in these docs.** Every page carries an *Edit this page* link into [the repository](https://github.com/abap2UI5/docs), and typos count.
 - **Post about it.** A short post that mentions [the page](https://www.linkedin.com/company/abap2ui5) and carries **#abap2UI5** is how the word gets around.
 - **Write it up.** A full article in the [SAP Community](https://community.sap.com/) or on [LinkedIn](https://www.linkedin.com/company/abap2ui5) reaches the next person, and lands in the [references](/resources/references).
 - **Add your company.** One row in [Who Uses abap2UI5?](/resources/who_uses) is what answers *is anybody actually running this?*

--- a/test/cost-calculator.test.mjs
+++ b/test/cost-calculator.test.mjs
@@ -158,7 +158,7 @@ test('the front door\'s cost card leads here, and the page ends on the four ways
   assert.match(last, /\]\(\/resources\/sponsor\)/, 'the last section is the one that asks');
   assert.match(last, /open-source/i);
   const ways = (last.match(/^- \*\*/gm) || []);
-  assert.equal(ways.length, 9, 'nine ways, each led by what it is and each one thing to do');
+  assert.equal(ways.length, 7, 'seven ways, each led by what it is and each one thing to do');
   for (const way of last.split('\n').filter((l) => l.startsWith('- **'))) {
     assert.match(way, /\]\(/, `${way.slice(0, 28)}… says where to do it`);
   }


### PR DESCRIPTION
## What changed

*Show it to somebody* (the playground) and *Fix a line in these docs* are out
of the panel on the cost calculator, and the pin follows: **seven**.

Both were the two ways that asked least, which is also why they read as filler
beside the rest — a reader deciding what to do does not need a list that
includes *send a link*. What is left is seven things that each leave something
behind: a star, an answer, a bug report, a post, an article, a row in the
list, money.

The intro needed no fixing this time: the count came out of it in #298, and
the pin holds a number only while the intro states one.

The playground link was this page's only cross-site link, so
`check:cross-site` counts one less: 352 out of 182 pages, all of them still
opting out of the router.

## Gates

Green: `test` (236), `docs:build`, `check:cross-site`.

`npm run build` and `check:version` need network this environment does not
have; both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU

---
_Generated by [Claude Code](https://claude.ai/code/session_015A6sou8jBMhJFLpfANTreU)_