### PR TITLE
Three typos on the front door, and the bold claim on a line of its own in every card

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -199,8 +199,8 @@ you ship. Support is the community's, on GitHub and Slack.
 
 **Complements UI5 freestyle and RAP — it does not replace them, and lives
 right next to your existing UI5 solutions.** It runs in a
-browser tab, a Fiori launchpad tile or Build
-Work Zone and without internet access.
+browser tab, a Fiori launchpad tile or SAP Build Work Zone, and without
+internet access.
 
 → *More on [Integration](/get_started/about#where-it-fits)*
 
@@ -208,7 +208,7 @@ Work Zone and without internet access.
 
 **One class is one file — the whole app, for an agent to write.** The
 abap2UI5 linter and the MCP server let it
-check its own work without an SAP system. 
+check its own work without an SAP system.
 
 → *More on [Developing with AI](/get_started/ai)*
 
@@ -216,7 +216,8 @@ check its own work without an SAP system.
 
 **Nothing.** MIT licensed, commercial use included — no
 license key, no subscription, no per-user fee, and no BTP required. Ten users
-or ten thousand, it runs on your ABAP Stack with the UI5 version you already have, the SAP license you have is the one you keep.
+or ten thousand, it runs on your ABAP stack with the UI5 version you already
+have, and the SAP license you have is the one you keep.
 
 → *Run your own numbers through the [Cost Calculator](/resources/cost_calculator)*
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -188,8 +188,9 @@ features:
 
 ## Ready for your enterprise
 
-**Runs inside the security you already have.** One HTTP endpoint, standard SAP
-logon, your own authorizations — and an app is
+**Runs inside the security you already have.**
+
+One HTTP endpoint, standard SAP logon, your own authorizations — and an app is
 an ABAP class, so transports, ATC and ABAP Unit apply as to everything else
 you ship. Support is the community's, on GitHub and Slack.
 
@@ -198,24 +199,27 @@ you ship. Support is the community's, on GitHub and Slack.
 ## Plays well with what you have
 
 **Complements UI5 freestyle and RAP — it does not replace them, and lives
-right next to your existing UI5 solutions.** It runs in a
-browser tab, a Fiori launchpad tile or SAP Build Work Zone, and without
+right next to your existing UI5 solutions.**
+
+It runs in a browser tab, a Fiori launchpad tile or SAP Build Work Zone, and without
 internet access.
 
 → *More on [Integration](/get_started/about#where-it-fits)*
 
 ## Made for AI agents
 
-**One class is one file — the whole app, for an agent to write.** The
-abap2UI5 linter and the MCP server let it
+**One class is one file — the whole app, for an agent to write.**
+
+The abap2UI5 linter and the MCP server let it
 check its own work without an SAP system.
 
 → *More on [Developing with AI](/get_started/ai)*
 
 ## And what does it cost?
 
-**Nothing.** MIT licensed, commercial use included — no
-license key, no subscription, no per-user fee, and no BTP required. Ten users
+**Nothing.**
+
+MIT licensed, commercial use included — no license key, no subscription, no per-user fee, and no BTP required. Ten users
 or ten thousand, it runs on your ABAP stack with the UI5 version you already
 have, and the SAP license you have is the one you keep.
 


### PR DESCRIPTION
Follow-up to the maintainer's edit of the home page (`docs/index.md` only).

- "Build Work Zone" is "SAP Build Work Zone" again, and the clause gets its comma: "a Fiori launchpad tile or SAP Build Work Zone, and without internet access".
- "ABAP Stack" is "ABAP stack", as the line under the example spells it, and the cost card's last sentence joins its two clauses with "and" rather than a comma.
- A trailing space after "without an SAP system." goes.
- In every card the bold claim is a paragraph of its own, with the explanation starting on the next line, then the "→ More on …" line.

**Verified locally**: `npm test` and `npm run build` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5)_