### PR TITLE
The front door without hairlines, with two plain buttons and cards of plain text

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1287,8 +1287,6 @@
   flex-wrap: wrap;
   gap: 8px 28px;
   margin: 32px 0 0;
-  padding-top: 20px;
-  border-top: 1px solid var(--vp-c-divider);
   font-size: 14px;
   line-height: 22px;
   font-weight: 500;

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,16 +30,16 @@ description: One ABAP class is one UI5 app - no JavaScript, no OData, no fronten
 # tagline now, and nowhere else. abapGit is the same story: the tagline and the
 # second button say it, so no card says it again.
 #
-# AND EVERY CARD IS ONE BOLD CLAIM AND ONE PLAIN SENTENCE. They used to be
+# AND EVERY CARD IS ONE SHORT PARAGRAPH OF PLAIN TEXT. They used to be
 # two or three paragraphs each - the enterprise card alone ran to 120 words -
 # and four panels of prose under three tiles read as a page that starts
 # over. What a card says now is the claim, one sentence that backs it, and
 # the link to the page that argues it in full: the About page carries the
 # lifecycle, the exit path and the support model, and carried them before.
-# The headings are claims too, not labels: "Plays well with what you have"
+# Nothing in the paragraph is bold: the heading carries the claim, the text
+# reads as one run. The headings are claims too, not labels: "Plays well with what you have"
 # promises something, where "Integration" only named a topic. The last card
-# asks instead, and its bold lead is the one-word answer - so the reader who
-# scans only the headings still leaves with the price.
+# asks instead, and its first word is the one-word answer.
 #
 # THE ORDER IS AN ARGUMENT: it is safe here, and it fits what you run - then
 # an agent can write it, and it costs nothing. The price is the last card
@@ -159,7 +159,7 @@ hero:
   # gives it a `target` of its own, which is also what keeps this site's
   # router off a neighbouring deployment (scripts/lib/cross-site.mjs).
   actions:
-    - theme: brand
+    - theme: alt
       text: Try it in the browser
       link: https://abap2ui5.github.io/playground/
     - theme: alt
@@ -188,9 +188,7 @@ features:
 
 ## Ready for your enterprise
 
-**Runs inside the security you already have.**
-
-One HTTP endpoint, standard SAP logon, your own authorizations — and an app is
+Runs inside the security you already have. One HTTP endpoint, standard SAP logon, your own authorizations — and an app is
 an ABAP class, so transports, ATC and ABAP Unit apply as to everything else
 you ship. Support is the community's, on GitHub and Slack.
 
@@ -198,28 +196,22 @@ you ship. Support is the community's, on GitHub and Slack.
 
 ## Plays well with what you have
 
-**Complements UI5 freestyle and RAP — it does not replace them, and lives
-right next to your existing UI5 solutions.**
-
-It runs in a browser tab, a Fiori launchpad tile or SAP Build Work Zone, and without
+Complements UI5 freestyle and RAP — it does not replace them, and lives
+right next to your existing UI5 solutions. It runs in a browser tab, a Fiori launchpad tile or SAP Build Work Zone, and without
 internet access.
 
 → *More on [Integration](/get_started/about#where-it-fits)*
 
 ## Made for AI agents
 
-**One class is one file — the whole app, for an agent to write.**
-
-The abap2UI5 linter and the MCP server let it
+One class is one file — the whole app, for an agent to write. The abap2UI5 linter and the MCP server let it
 check its own work without an SAP system.
 
 → *More on [Developing with AI](/get_started/ai)*
 
 ## And what does it cost?
 
-**Nothing.**
-
-MIT licensed, commercial use included — no license key, no subscription, no per-user fee, and no BTP required. Ten users
+Nothing. MIT licensed, commercial use included — no license key, no subscription, no per-user fee, and no BTP required. Ten users
 or ten thousand, it runs on your ABAP stack with the UI5 version you already
 have, and the SAP license you have is the one you keep.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,9 +211,10 @@ check its own work without an SAP system.
 
 ## And what does it cost?
 
-Nothing. MIT licensed, commercial use included — no license key, no subscription, no per-user fee, and no BTP required. Ten users
-or ten thousand, it runs on your ABAP stack with the UI5 version you already
-have, and the SAP license you have is the one you keep.
+Nothing. MIT licensed, commercial use included — no license key, no
+subscription, no per-user fee, and no BTP required. It runs on your ABAP stack
+with the UI5 version you already have, and the SAP license you have is the one
+you keep.
 
 → *Run your own numbers through the [Cost Calculator](/resources/cost_calculator)*
 

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -793,6 +793,15 @@ html { scroll-padding-top: 62px; }
    column, neither is worth looking at. */
 .home .band[data-demo] .a2ui5-play,
 .home .band[data-demo] > p { max-width: none; }
+/* Its heading is the one the page turns on - the cards make the case, this
+   is the proof - so it is set like a section title rather than like a
+   chapter's H2: larger, and without the hairline every other H2 carries. A
+   rule over it drew a line between the argument and the proof, and the row
+   gap above the band is already the separation. */
+.home .band[data-demo] > h2 {
+  margin: 8px 0 16px; padding-top: 0; border-top: 0;
+  font-size: 22px; line-height: 1.3; letter-spacing: -.02em;
+}
 
 @media (max-width: 860px) {
   /* One column again: two 300px columns of prose are worse than a long page. */
@@ -839,12 +848,11 @@ html { scroll-padding-top: 62px; }
  * whole screen after the example on a page that had already made its case.
  * Two of the five were pages of the manual, one click away in the bar; what
  * is left is what lives OUTSIDE this site, and three links are a line, not
- * a section. A hairline over it, so it reads as the page's last line rather
- * than as part of the example. */
+ * a section. No hairline over it: the tiles above are boxes of their own,
+ * and a rule under a row of boxes is a second edge on the same edge. */
 .vp-doc .a2ui5-links {
   display: flex; flex-wrap: wrap; gap: 8px 28px;
-  margin: 32px 0 0; padding-top: 20px;
-  border-top: 1px solid var(--line);
+  margin: 32px 0 0;
   font-size: 14px; line-height: 22px; font-weight: 500;
 }
 .vp-doc .a2ui5-links a {


### PR DESCRIPTION
Home page only.

- The rule over "Try it out now" and the rule over the line of links (GitHub, LinkedIn, Sponsor) are gone; the example's heading is set as a title, 22px, since it is the heading the page turns on.
- Both hero buttons are drawn the same, outlined: "Try it in the browser" no longer filled in the accent.
- The four cards carry no bold lead and no line break after it; each is one paragraph of plain text, the heading carrying the claim.
- The cost card drops "Ten users or ten thousand": "It runs on your ABAP stack with the UI5 version you already have, and the SAP license you have is the one you keep."

**Verified locally**: `npm test`, `npm run build` and `check:design` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5)_