### PR TITLE
The cost card: with the already installed UI5 version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -213,7 +213,7 @@ check its own work without an SAP system.
 
 Nothing. MIT licensed, commercial use included — no license key, no
 subscription, no per-user fee, and no BTP required. It runs on your ABAP stack
-with the UI5 version you already have, and the SAP license you have is the one
+with the already installed UI5 version, and the SAP license you have is the one
 you keep.
 
 → *Run your own numbers through the [Cost Calculator](/resources/cost_calculator)*


### PR DESCRIPTION
One sentence on the home page, the commit that missed #302 by a second: the cost card now reads "It runs on your ABAP stack with the already installed UI5 version, and the SAP license you have is the one you keep."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5)_