### PR TITLE
The AI card fills its box, the tutorial line stands alone, the links sit lower, the button says Learn more...

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -348,7 +348,7 @@ CLASS zcl_app_invoices IMPLEMENTATION.
 ENDCLASS.
 ```
 
-→ *The [Tutorial](/tutorials/walkthrough/) builds this app in twelve steps, through to transport and unit tests. It runs with the UI5 and the ABAP stack you already have.*
+→ *The [Tutorial](/tutorials/walkthrough/) builds this app in twelve steps, through to transport and unit tests.*
 
 <p class="a2ui5-links">
   <a href="https://github.com/abap2UI5/abap2UI5/" target="_blank" rel="noreferrer"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>GitHub</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -149,8 +149,8 @@ hero:
     height: 200px
   # Two buttons, in the order a stranger needs them: try it without installing
   # anything, then read the one page that says what it is - "In a Nutshell",
-  # named on the button as the page is named in the sidebar, so the reader
-  # lands where the label said. The second used to be "Install with
+  # behind a button that says "Learn more...", which is what the reader
+  # wants rather than what the page is called. The second used to be "Install with
   # abapGit" - the third mention of abapGit in the first screen, and a step
   # the manager this page addresses is not taking; installing is the first
   # tile below. The playground is first on purpose — it is the one claim on
@@ -163,7 +163,7 @@ hero:
       text: Try it in the browser
       link: https://abap2ui5.github.io/playground/
     - theme: alt
-      text: In a Nutshell
+      text: Learn more...
       link: /get_started/about
 
 # Three things to do next, each on the page for it. The bar names the

--- a/docs/index.md
+++ b/docs/index.md
@@ -204,8 +204,12 @@ internet access.
 
 ## Made for AI agents
 
-One class is one file — the whole app, for an agent to write. The abap2UI5 linter and the MCP server let it
-check its own work without an SAP system.
+One class is one file — the whole app, for an agent to write, with no
+frontend project to keep in step. The AI guide starts with one paragraph to
+paste at the top of a prompt, and the abap2UI5 linter and the MCP server let
+the agent check its own work without an SAP system: the linter validates the
+view, the MCP server boots the app headless and returns the errors and a
+screenshot.
 
 → *More on [Developing with AI](/get_started/ai)*
 

--- a/scripts/site-css/docs.css
+++ b/scripts/site-css/docs.css
@@ -852,9 +852,12 @@ html { scroll-padding-top: 62px; }
  * and a rule under a row of boxes is a second edge on the same edge. */
 .vp-doc .a2ui5-links {
   display: flex; flex-wrap: wrap; gap: 8px 28px;
-  margin: 32px 0 0;
+  /* Well clear of the tiles above, and close to the rule under it: the row
+     belongs to the page's foot, not to the tiles. */
+  margin: 56px 0 0;
   font-size: 14px; line-height: 22px; font-weight: 500;
 }
+.home .doc-foot { margin-top: 20px; }
 .vp-doc .a2ui5-links a {
   display: inline-flex; align-items: center; gap: 8px;
   color: var(--fg); text-decoration: none;


### PR DESCRIPTION
Home page only.

- "Made for AI agents" says what the two tools do (the linter validates the view, the MCP server boots the app headless and returns the errors and a screenshot) and names the AI guide's paste-in paragraph, so the card is as tall as the other three.
- The line under the example is the tutorial alone: "→ The Tutorial builds this app in twelve steps, through to transport and unit tests."
- The line of links (GitHub, LinkedIn, Sponsor) sits further under the tiles and closer to the rule beneath it (`docs.css`).
- The hero's second button says "Learn more..." and still opens In a Nutshell.

**Verified locally**: `npm test`, `npm run build` and `check:design` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5)_