### PR TITLE
The integration card names abap2UI5, so it stands on its own

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -196,8 +196,8 @@ transports, ATC and ABAP Unit apply as they do to everything else you ship.
 
 ## Plays well with what you have
 
-It complements your UI5 and RAP apps — it does not replace them, and lives
-right next to your existing solutions. It runs in a browser tab, a Fiori
+abap2UI5 complements your UI5 and RAP apps — it does not replace them, and
+lives right next to your existing solutions. It runs in a browser tab, a Fiori
 launchpad tile or SAP Build Work Zone.
 
 → *More on [Integration](/get_started/about#where-it-fits)*


### PR DESCRIPTION
One sentence on the home page: the integration card opened with "It complements…", and the "It" pointed back to the card before it. The cards are read in any order, so it now says "abap2UI5 complements your UI5 and RAP apps".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4f9fYX4L19mWDDARS7Qw5)_